### PR TITLE
General Revision 03-06-2024

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -4,6 +4,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix qudt: <http://qudt.org/vocab/unit/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @base <http://data.europa.eu/949/> .
@@ -12,14 +13,21 @@
                               owl:imports <http://www.opengis.net/ont/geosparql#> ;
                               <http://creativecommons.org/ns#license> <https://creativecommons.org/licenses/by/4.0/> ;
                               <http://purl.org/dc/terms/contributor> "Designated RINF Topical Working Groups"@en ;
-                              <http://purl.org/dc/terms/creator> [ <http://xmlns.com/foaf/0.1/name> "Dragos Patru" ;
+                              <http://purl.org/dc/terms/creator> [ foaf:name "Dragos Patru" ;
                                                                    <http://www.w3.org/ns/org#memberOf> <http://publications.europa.eu/resource/authority/corporate-body/ERA>
                                                                  ] ,
-                                                                 [ <http://xmlns.com/foaf/0.1/name> "Ghislain Atemezing" ;
+                                                                 [ foaf:name "Ghislain Atemezing" ;
                                                                    rdfs:seeAlso <https://orcid.org/0000-0003-1562-6922> ;
                                                                    <http://www.w3.org/ns/org#memberOf> <http://publications.europa.eu/resource/authority/corporate-body/ERA>
                                                                  ] ;
                               <http://purl.org/dc/terms/description> """
+Revision 03-06-2024:
+- added properties for the primary and subsidiary locations
+- reuse the organisation ontology to address the ERA stakeholder organisations (bodies) and their roles
+- deprecated classes related to organisation
+- error corrections
+- added several definitions
+
 Revision 24-05-2024:
 - remove of the owl:FunctionalProperty from every object or data property;
 - addition of new classes for the purpose of the Topical Wrokgroup micro-level;							  
@@ -37,10 +45,10 @@ Revision 18-04-2024:
 - linked with existing (updated) or new SKOS Concepts, related to the TWG RINF CCS
 					  
 							  """@en ;
-                              <http://purl.org/dc/terms/issued> "2020-07-29"^^xsd:date ;
-                              <http://purl.org/dc/terms/modified> "2023-03-29"^^xsd:date ,
-                                                                  "2024-04-18"^^xsd:date ,
-                                                                  "2024-05-24"^^xsd:date ;
+                              <http://purl.org/dc/terms/issued> "2024-04-18"^^xsd:date ;
+                              <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ,
+                                                                  "2024-05-24"^^xsd:date ,
+                                                                  "2024-06-03"^^xsd:date ;
                               <http://purl.org/dc/terms/publisher> "European Union Agency for Railways" ;
                               <http://purl.org/dc/terms/title> "ERA Ontology"@en ;
                               rdfs:comment """This is the human and machine readable Ontology governed by the European Union Agency for Railways (https://www.era.europa.eu/). It represents the concepts and relationships linked to the sectorial legal framework and the use cases under the AgencyÂ´s remit, as described in the Commission Implementing Regulation (EU) [to be updated after publication] on the common specifications for the register of railway infrastructure [to be updated after publication].
@@ -69,12 +77,20 @@ era:XMLName rdf:type owl:AnnotationProperty ;
             rdfs:label "XML name"@en .
 
 
+###  http://data.europa.eu/949/annexD2Index
+era:annexD2Index rdf:type owl:AnnotationProperty .
+
+
 ###  http://data.europa.eu/949/appendixD2Index
 era:appendixD2Index rdf:type owl:AnnotationProperty ;
                     rdfs:comment "The index of a vocabulary term in Appendix D2 Elements the infrastructure manager has to provide to the railway undertaking for the Route Book from the document Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision 2012/757/EU."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Appendix D2 index"@en ;
                     <http://www.w3.org/2004/02/skos/core#definition> "The index of a vocabulary term in Appendix D2 Elements the infrastructure manager has to provide to the railway undertaking for the Route Book from the document Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision 2012/757/EU."@en .
+
+
+###  http://data.europa.eu/949/appendixD2index
+era:appendixD2index rdf:type owl:AnnotationProperty .
 
 
 ###  http://data.europa.eu/949/appendixD3Index
@@ -84,6 +100,10 @@ era:appendixD3Index rdf:type owl:AnnotationProperty ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Appendix D3 index"@en ;
                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/appendixD3index
+era:appendixD3index rdf:type owl:AnnotationProperty .
 
 
 ###  http://data.europa.eu/949/canonicalURI
@@ -156,10 +176,6 @@ https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj#:~:text=Commission%20Implemen
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Parameter is used in Route Compatibility Check (RCC) calculations"@en ;
                           rdfs:range xsd:boolean .
-
-
-###  http://data.europa.eu/949/XMLName:
-era:XMLName: rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/elements/1.1/contributor
@@ -251,7 +267,7 @@ above the local reference ellipsoid).""" ;
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#location
 <http://www.w3.org/2003/01/geo/wgs84_pos#location> rdf:type owl:AnnotationProperty ;
-                                                   rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/based_near> ;
+                                                   rdfs:subPropertyOf foaf:based_near ;
                                                    rdfs:range <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> .
 
 
@@ -291,7 +307,7 @@ above the local reference ellipsoid).""" ;
 
 
 ###  http://xmlns.com/foaf/0.1/based_near
-<http://xmlns.com/foaf/0.1/based_near> rdf:type owl:AnnotationProperty .
+foaf:based_near rdf:type owl:AnnotationProperty .
 
 
 #################################################################
@@ -367,7 +383,7 @@ era:additionalBrakingInformationDocument rdf:type owl:ObjectProperty ;
 ###  http://data.europa.eu/949/allocationCompany
 era:allocationCompany rdf:type owl:ObjectProperty ;
                       rdfs:domain era:SubsidiaryLocation ;
-                      rdfs:range <http://www.w3.org/ns/org#Organization> ;
+                      rdfs:range era:Body ;
                       rdfs:label "allocation company"@en ,
                                  "the organisation in charge to allocate the code for the subsidiary location"@en .
 
@@ -480,8 +496,8 @@ era:borderPointOf rdf:type owl:ObjectProperty ;
 era:cantDeficiencyBasicSSP rdf:type owl:ObjectProperty ;
                            rdfs:domain era:CCSSubsystem ;
                            rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
+                           era:appendixD3Index "1.3" ;
                            era:inSkosConceptScheme <http://data.europa.eu/949/concepts/cant-deficiencies/CantDeficiencies> ;
-		   	   era:appendixD3Index "1.3" ;
                            era:rinfIndex "1.1.1.3.2.14" ,
                                          "1.2.1.1.1.14" ;
                            era:XMLName: "CPE_SSPUsesCantDef" ;
@@ -527,8 +543,8 @@ era:certificate rdf:type owl:ObjectProperty ;
                 rdfs:domain era:VehicleType ;
                 rdfs:range era:Certificate ;
                 <http://purl.org/dc/terms/created> "2022-06-15"^^xsd:date ;
-                <http://purl.org/dc/terms/modified> "2022-11-15"^^xsd:date ;
-                <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
+                <http://purl.org/dc/terms/modified> "2022-11-15"^^xsd:date ,
+                                                    "2024-04-18"^^xsd:date ;
                 rdfs:comment """For this Vehicle Type, the type or design examination certificate described in the relevant verification module as issued by 
 Notified Bodies, supporting the EC Declaration(s) of Verification for the subsystems in scope of the type's authorisation by an authorizing entity."""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -676,7 +692,7 @@ era:definesSubset rdf:type owl:ObjectProperty ;
                   rdfs:range era:SubsetWithCommonCharacteristics ;
                   <http://purl.org/dc/terms/created> "2022-11-04"^^xsd:date ;
                   <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
-                  rdfs:comment "TODO: review. For the purposes of the register of infrastructure, each infrastructure manager may describe its railway network optionally via common characteristic subsets."@en ;
+                  rdfs:comment "(deprecated) not in use anymore. For the purposes of the register of infrastructure, each infrastructure manager may describe its railway network optionally via common characteristic subsets."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Defines subset"@en ;
                   owl:deprecated "true"^^xsd:boolean ;
@@ -840,7 +856,7 @@ and frequency)."""@en ;
                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
-###  http://data.europa.eu/949/errorCorrectionsOnboard		
+###  http://data.europa.eu/949/errorCorrectionsOnboard
 era:errorCorrectionsOnboard rdf:type owl:ObjectProperty ;
                             rdfs:domain era:CCSSubsystem ;
                             rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
@@ -883,12 +899,13 @@ era:etcsDegradedSituation rdf:type owl:ObjectProperty ;
                           rdfs:domain era:CCSSubsystem ;
                           rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                           era:XMLName "CLD_ETCSSituation" ;
+                          era:appendixD2Index "3.4.1" ;
                           era:inSkosConceptScheme <http://data.europa.eu/949/concepts/etcs-situation/ETCSSituations> ;
-			  era:appendixD2Index "3.4.1" ;
                           era:rinfIndex "1.1.1.3.10.1" ,
                                         "1.2.1.1.9.1" ;
                           <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
-                          <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
+                          <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
+                                                              "2024-04-18"^^xsd:date ;
                           <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                           rdfs:comment "ERTMS / ETCS application level for degraded situation related to the track side equipment."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -1221,7 +1238,8 @@ era:gsmRVersion rdf:type owl:ObjectProperty ;
                             ] ;
                 rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                 era:XMLName "CRG_Version" ;
-                era:appendixD2Index "3.1.7" , "3.4.4" ;
+                era:appendixD2Index "3.1.7" ,
+                                    "3.4.4" ;
                 era:eratvIndex "4.13.2.1" ;
                 era:inSkosConceptScheme <http://data.europa.eu/949/concepts/gsmr-versions/GSMRVersions> ;
                 era:rinfIndex "1.1.1.3.3.1" ,
@@ -1293,6 +1311,15 @@ era:hasImplementation rdf:type owl:ObjectProperty ;
                       rdfs:label "Has implementation"@en ;
                       owl:deprecated "true"^^xsd:boolean ;
                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/hasOrganisationRole
+era:hasOrganisationRole rdf:type owl:ObjectProperty ;
+                        rdfs:domain era:OrganisationRole ;
+                        rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
+                        <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+                        rdfs:comment "The role of the body"@en ;
+                        rdfs:label "has organisation role"@en .
 
 
 ###  http://data.europa.eu/949/hasPart
@@ -1368,7 +1395,7 @@ era:infrastructureMgr rdf:type owl:ObjectProperty ;
                       rdfs:domain era:InfrastructureObject ;
                       rdfs:range era:InfrastructureManager ;
                       <http://purl.org/dc/terms/created> "2022-07-07"^^xsd:date ;
-                      rdfs:comment "Relates any feature implemented in the European railway infrastructure with its infrastructure manager."@en ;
+                      rdfs:comment "(deprecated) not in use. Relates any feature implemented in the European railway infrastructure with its infrastructure manager."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Infrastructure manager"@en ;
                       owl:deprecated "true"^^xsd:boolean ;
@@ -1391,14 +1418,16 @@ era:legacyRadioSystem rdf:type owl:ObjectProperty ;
                                   ] ;
                       rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                       era:XMLName "CRS_Installed" ;
-                      era:appendixD2Index "3.1.7" , "3.4.4" ;
+                      era:appendixD2Index "3.1.7" ,
+                                          "3.4.4" ;
                       era:eratvIndex "4.13.2.3" ;
                       era:inSkosConceptScheme <http://data.europa.eu/949/concepts/legacy-radio-systems/LegacyRadioSystems> ;
                       era:rinfIndex "1.1.1.3.6.1" ,
                                     "1.2.1.1.5.1" ;
                       era:usedInRCCCalculations "true"^^xsd:boolean ;
                       <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
-                      <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
+                      <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
+                                                          "2024-04-18"^^xsd:date ;
                       <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                       rdfs:comment "Indication of radio legacy systems installed."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -1650,12 +1679,13 @@ era:magneticBrakingConditionsDocument rdf:type owl:ObjectProperty ;
 ###  http://data.europa.eu/949/manufacturer
 era:manufacturer rdf:type owl:ObjectProperty ;
                  rdfs:domain era:VehicleType ;
-                 rdfs:range era:Manufacturer ;
+                 rdfs:range era:Body ;
                  <http://purl.org/dc/terms/created> "2020-07-29"^^xsd:date ;
-                 <http://purl.org/dc/terms/modified> "2020-11-19"^^xsd:date ;
+                 <http://purl.org/dc/terms/modified> "2020-11-19"^^xsd:date ,
+                                                     "2024-06-03"^^xsd:date ;
                  rdfs:comment "Vehicle manufacturer company."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                 rdfs:label "Manufacturer"@en ;
+                 rdfs:label "manufactured by"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -1708,6 +1738,32 @@ Deprecated according to the ammendment to the Regulation (EU) 2019/777."""@en ;
                                rdfs:label "Minimum axle load vehicle category"@en ;
                                owl:deprecated "true"^^xsd:boolean ;
                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/minVehicleImpedance
+era:minVehicleImpedance rdf:type owl:ObjectProperty ;
+                        rdfs:domain [ rdf:type owl:Class ;
+                                      owl:unionOf ( era:TrainDetectionSystem
+                                                    era:VehicleType
+                                                  )
+                                    ] ;
+                        rdfs:range era:MinVehicleImpedance .
+
+
+###  http://data.europa.eu/949/minVehicleImpedanceVoltages
+era:minVehicleImpedanceVoltages rdf:type owl:ObjectProperty ;
+                                rdfs:domain era:MinVehicleImpedance ;
+                                rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
+                                era:XMLName "CCD_TCVehicleImpedance" ;
+                                era:inSkosConceptScheme <http://data.europa.eu/949/concepts/energy-supply-systems/EnergySupplySystems> ;
+                                era:rinfIndex "1.1.1.3.4.2.2" ,
+                                              "1.2.1.1.3.2.2" ;
+                                era:usedInRCCCalculations "true"^^xsd:boolean ;
+                                <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
+                                rdfs:comment "Voltages with which the vehicles are equipped, if the parameter minVehicleImpedance is applicable."@en ;
+                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                rdfs:label "minimum Vehicle Impedance (Voltage applicable)"@en ;
+                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/nationalLine
@@ -1880,6 +1936,16 @@ era:operationalRestriction rdf:type owl:ObjectProperty ;
                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
+###  http://data.europa.eu/949/organisation
+era:organisation rdf:type owl:ObjectProperty ;
+                 rdfs:domain era:InfrastructureObject ;
+                 rdfs:range era:Body ;
+                 <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+                 rdfs:comment "The organisation managing the infrastructure objet (infrastructure manager)"@en ;
+                 rdfs:label "organisation"@en ;
+                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
 ###  http://data.europa.eu/949/orientation
 era:orientation rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf owl:topObjectProperty ;
@@ -1898,28 +1964,12 @@ era:osmClass rdf:type owl:ObjectProperty ;
                          ] ;
              rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
              era:inSkosConceptScheme <http://data.europa.eu/949/concepts/osmclass/OSMClasses> ;
-             rdfs:comment "TODO: review"@en ;
+             rdfs:comment "(deprecated) not in use any more"@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "Open street map class"@en ;
              owl:deprecated "true"^^xsd:boolean ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
              <http://www.w3.org/2004/02/skos/core#definition> "Additional concept class according to OpenStreetMap."@en .
-			 
-
-###  http://data.europa.eu/949/minVehicleImpedanceVoltages
-era:minVehicleImpedanceVoltages rdf:type owl:ObjectProperty ;
-                              rdfs:domain era:MinVehicleImpedance ;
-                              rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
-                              era:XMLName "CCD_TCVehicleImpedance" ;
-                              era:inSkosConceptScheme <http://data.europa.eu/949/concepts/energy-supply-systems/EnergySupplySystems> ;
-                        era:rinfIndex "1.1.1.3.4.2.2" ,           
-                                      "1.2.1.1.3.2.2" ;
-                              era:usedInRCCCalculations "true"^^xsd:boolean ;
-                              <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                              rdfs:comment "Voltages with which the vehicles are equipped, if the parameter minVehicleImpedance is applicable."@en ;
-                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                              rdfs:label "minimum Vehicle Impedance (Voltage applicable)"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/otherCantDeficiencyBasicSSP
@@ -1927,8 +1977,8 @@ era:otherCantDeficiencyBasicSSP rdf:type owl:ObjectProperty ;
                                 rdfs:domain era:CCSSubsystem ;
                                 rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                                 era:XMLName "CPE_OtherCantDef" ;
+                                era:appendixD3Index "1.3" ;
                                 era:inSkosConceptScheme <http://data.europa.eu/949/concepts/cant-deficiencies/CantDeficiencies> ;
-				era:appendixD3Index "1.3" ;
                                 era:rinfIndex "1.1.1.3.2.14.1" ,
                                               "1.2.1.1.1.14.1" ;
                                 <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -2238,6 +2288,14 @@ era:referent rdf:type owl:ObjectProperty ;
              rdfs:label "referent"@en .
 
 
+###  http://data.europa.eu/949/role
+era:role rdf:type owl:ObjectProperty ;
+         rdfs:domain era:Body ;
+         rdfs:range era:OrganisationRole ;
+         <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+         rdfs:label "role"@en .
+
+
 ###  http://data.europa.eu/949/rollingStockFireCategory
 era:rollingStockFireCategory rdf:type owl:ObjectProperty ;
                              rdfs:domain era:InfraSubsystem ;
@@ -2301,7 +2359,8 @@ era:signalOrientation rdf:type owl:ObjectProperty ;
                       rdfs:domain era:Signal ;
                       rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                       era:XMLName "SIG_LocDir" ;
-                      era:appendixD2Index "2.2.3", "2.3.3" ;
+                      era:appendixD2Index "2.2.3" ,
+                                          "2.3.3" ;
                       era:inSkosConceptScheme <http://data.europa.eu/949/concepts/track-running-directions/TrackRunningDirections> ;
                       era:rinfIndex "1.1.1.3.14.3" ,
                                     "1.2.1.0.8.3" ;
@@ -2318,7 +2377,8 @@ era:signalType rdf:type owl:ObjectProperty ;
                rdfs:domain era:Signal ;
                rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                era:XMLName "SIG_Type" ;
-               era:appendixD2Index "2.2.3", "2.3.3" ;
+               era:appendixD2Index "2.2.3" ,
+                                   "2.3.3" ;
                era:inSkosConceptScheme <http://data.europa.eu/949/concepts/signal-types/SignalTypes> ;
                era:rinfIndex "1.1.1.3.14.2" ,
                              "1.2.1.0.8.2" ;
@@ -2374,26 +2434,6 @@ era:solNature rdf:type owl:ObjectProperty ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "Nature of Section of Line"@en ;
               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
-
-###  http://data.europa.eu/949/MinVehicleImpedance
-era:minVehicleImpedance rdf:type owl:ObjectProperty ;
-                        rdfs:domain [ rdf:type owl:Class ;
-                                      owl:unionOf ( era:TrainDetectionSystem
-                                                    era:VehicleType
-                                                  )
-                                    ] ;
-                        rdfs:range era:MinVehicleImpedance ;
-                        era:eratvIndex "4.14.2.17" ;
-                        era:rinfIndex "1.1.1.3.4.2.2" ,
-                                      "1.2.1.1.3.2.2" ;
-                        <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                        rdfs:comment """
-[CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
-"""@en ;
-                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                        rdfs:label "minimum vehicle impedance"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
-                        <http://www.w3.org/2004/02/skos/core#altLabel> "Minimum vehicle impedance"@en .
 
 
 ###  http://data.europa.eu/949/specialAreaType
@@ -2993,8 +3033,7 @@ The allowed values for this property belong to the SKOS Concept Scheme http://da
 ###  http://data.europa.eu/949/validity
 era:validity rdf:type owl:ObjectProperty ;
              rdfs:domain [ rdf:type owl:Class ;
-                           owl:unionOf ( era:BaseLocation
-                                         era:Feature
+                           owl:unionOf ( era:Feature
                                          era:TopologicalObject
                                        )
                          ] ;
@@ -3005,12 +3044,13 @@ era:validity rdf:type owl:ObjectProperty ;
 ###  http://data.europa.eu/949/vehicleKeeper
 era:vehicleKeeper rdf:type owl:ObjectProperty ;
                   rdfs:domain era:Vehicle ;
-                  rdfs:range era:VehicleKeeper ;
+                  rdfs:range era:Body ;
                   <http://purl.org/dc/terms/created> "2020-11-23"^^xsd:date ;
-                  <http://purl.org/dc/terms/modified> "2020-11-23"^^xsd:date ;
+                  <http://purl.org/dc/terms/modified> "2020-11-23"^^xsd:date ,
+                                                      "2024-06-03"^^xsd:date ;
                   rdfs:comment "Indicates the organization that owns/operated a vehicle or wagon."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                  rdfs:label "Vehicle keeper"@en ;
+                  rdfs:label "vehicle keeper"@en ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -3397,7 +3437,7 @@ era:conditionalRegenerativeBrake rdf:type owl:DatatypeProperty ;
                                  rdfs:domain era:ContactLineSystem ;
                                  rdfs:range xsd:boolean ;
                                  era:XMLName "ECS_RegenerativeBraking" ;
-                        	 era:appendixD2Index "3.3.7" ;
+                                 era:appendixD2Index "3.3.7" ;
                                  era:rinfIndex "1.1.1.2.2.4" ;
                                  era:usedInRCCCalculations "true"^^xsd:boolean ;
                                  <http://purl.org/dc/terms/created> "2020-08-24"^^xsd:date ;
@@ -3495,6 +3535,14 @@ era:contactStripMaterialMetallicContent rdf:type owl:DatatypeProperty ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "Contact strip material metallic content"@en ;
                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/containerHandlingFlag
+era:containerHandlingFlag rdf:type owl:DatatypeProperty ;
+                          rdfs:domain era:PrimaryLocation ;
+                          rdfs:range xsd:boolean ;
+                          <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+                          rdfs:label "container handling flag"@en .
 
 
 ###  http://data.europa.eu/949/crossSectionArea
@@ -3852,34 +3900,6 @@ era:energyMeterInstalled rdf:type owl:DatatypeProperty ;
                          rdfs:label "Energy meter installed"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
-###  http://data.europa.eu/949/minVehicleInputImpedance
-era:minVehicleInputImpedance rdf:type owl:DatatypeProperty ;
-                              rdfs:domain era:MinVehicleImpedance ;
-                              rdfs:range xsd:double ;
-                              era:unitOfMeasure <https://qudt.org/vocab/unit/MilliH> ;
-                              era:rinfIndex "1.1.1.3.4.2.2" ,           
-                                            "1.2.1.1.3.2.2" ;
-                              era:usedInRCCCalculations "true"^^xsd:boolean ;
-                              <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                              rdfs:comment "For the selected DC voltage: [ZZZZ], as input impedance [ZZZZ](Zin)"@en ;
-                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                              rdfs:label "minimal vehicle input impedance"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
-
-###  http://data.europa.eu/949/minVehicleInputCapacitance
-era:minVehicleInputCapacitance rdf:type owl:DatatypeProperty ;
-                                rdfs:domain era:MinVehicleImpedance ;
-                                rdfs:range xsd:double ;
-                                era:unitOfMeasure <https://qudt.org/vocab/unit/NanoFARAD> ;
-                                era:rinfIndex "1.1.1.3.4.2.2" ,           
-                                              "1.2.1.1.3.2.2" ;
-                                era:usedInRCCCalculations "true"^^xsd:boolean ;
-                                <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                                rdfs:comment "For the selected DC voltage: [CCCC], as input capacitance [CCCC](Cin)"@en ;
-                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                rdfs:label "minimal vehicle input capacitance"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
-
 
 ###  http://data.europa.eu/949/energySupplyMaxPower
 era:energySupplyMaxPower rdf:type owl:DatatypeProperty ;
@@ -3907,6 +3927,20 @@ era:energySupplySystemTSICompliant rdf:type owl:DatatypeProperty ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Energy supply system TSI compliant"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/errorCorrectionsOnboardExplanation
+era:errorCorrectionsOnboardExplanation rdf:type owl:DatatypeProperty ;
+                                       rdfs:domain era:CCSSubsystem ;
+                                       rdfs:range xsd:string ;
+                                       era:XMLName "CDE_ReqErrorCorrections" ;
+                                       era:rinfIndex "1.1.1.3.1.2" ,
+                                                     "1.2.1.1.1.19" ;
+                                       <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
+                                       rdfs:comment "Explanation on why a mandatory onboard CR required to be solved in the on-board (ETCS, GSM-R and/or ATO) was accepted by the IM."@en ;
+                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                       rdfs:label "Reasons for Error corrections required, but accepted by the IM for the on-board ETCS, GSM-R and/or ATO function"@en ;
+                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/ertmsErrorCorrectionsOnBoard
@@ -3995,10 +4029,11 @@ era:etcsNationalApplications rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/etcsNationalPacket44
 era:etcsNationalPacket44 rdf:type owl:DatatypeProperty ;
                          rdfs:domain era:CCSSubsystem ;
-                         rdfs:range [
-                            rdf:type rdfs:Datatype ;     
-                            owl:unionOf ( xsd:string xsd:boolean )                    
-                         ];
+                         rdfs:range [ rdf:type rdfs:Datatype ;
+                                      owl:unionOf ( xsd:boolean
+                                                    xsd:string
+                                                  )
+                                    ] ;
                          era:XMLName "CPE_NatApplication" ;
                          era:rinfIndex "1.1.1.3.2.5" ,
                                        "1.2.1.1.1.5" ;
@@ -4139,6 +4174,14 @@ era:flangeLubricationFitted rdf:type owl:DatatypeProperty ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Flange lubrication fitted"@en ;
                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/freightFlag
+era:freightFlag rdf:type owl:DatatypeProperty ;
+                rdfs:domain era:PrimaryLocation ;
+                rdfs:range xsd:boolean ;
+                <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+                rdfs:label "freight flag"@en .
 
 
 ###  http://data.europa.eu/949/frenchTrainDetectionSystemLimitationApplicable
@@ -4293,6 +4336,14 @@ era:gsmrForcedDeregistrationFunctionalNumber rdf:type owl:DatatypeProperty ;
                                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                              rdfs:label "Is the GSM-R network configured to allow forced de-registration of a functional number by another driver?"@en ;
                                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/handoverPointFlag
+era:handoverPointFlag rdf:type owl:DatatypeProperty ;
+                      rdfs:domain era:PrimaryLocation ;
+                      rdfs:range xsd:boolean ;
+                      <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+                      rdfs:label "handover point flag"@en .
 
 
 ###  http://data.europa.eu/949/hasAdditionalBrakingInformation
@@ -4807,16 +4858,17 @@ Trackside hot axle box detector TSI compliant."""@en ;
 era:idPhoneErtmsRadioBlockCenter rdf:type owl:DatatypeProperty ;
                                  rdfs:domain era:CCSSubsystem ;
                                  rdfs:range xsd:string ;
-				 era:appendixD2Index "3.4.7" ;
+                                 era:appendixD2Index "3.4.7" ;
                                  era:rinfIndex "1.1.1.3.2.17" ,
                                                "1.2.1.1.1.17" ;
                                  <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
+                                 <http://purl.org/dc/terms/isReplacedBy> era:rbcID ,
+                                                                         era:rbcPhone ;
                                  <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                  rdfs:comment "Unique RBC identification (NID_C+NID_RBC) and calling number (NID_RADIO) as defined in the specification referenced in Appendix A-1, index [C]."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "ID [NNNN NNNN] and phone number [NNNN NNNN NNNN NNNN] of ERTMS/ETCS Radio Block Center"@en ;
                                  owl:deprecated "true"^^xsd:boolean ;
-                                 dcterms:isReplacedBy era:rbcID , era:rbcPhone ;
                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -4841,11 +4893,14 @@ era:imCode rdf:type owl:DatatypeProperty ;
                          "1.2.2.0.0.1" ,
                          "1.2.2.0.5.1" ;
            <http://purl.org/dc/terms/created> "2021-08-02"^^xsd:date ;
-           <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
+           <http://purl.org/dc/terms/isReplacedBy> era:organisationCode ;
+           <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
+                                               "2024-06-03"^^xsd:date ;
            <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
-           rdfs:comment "TODO review: Infrastructure manager means anybody or undertaking that is responsible in particular for establishing and maintaining railway infrastructure or a part thereof."@en ;
+           rdfs:comment "(deprecated) Infrastructure manager means anybody or undertaking that is responsible in particular for establishing and maintaining railway infrastructure or a part thereof."@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "Infrastructure manager (IM)'s code"@en ;
+           owl:deprecated "true"^^xsd:boolean ;
            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -4926,7 +4981,9 @@ era:length rdf:type owl:DatatypeProperty ;
                        "IPP_Length" ,
                        "ITU_Length" ,
                        "SOLLength" ;
-           era:appendixD2Index "2.3.6" , "3.2.3" , "3.2.4" ;
+           era:appendixD2Index "2.3.6" ,
+                               "3.2.3" ,
+                               "3.2.4" ;
            era:eratvIndex "4.8.1" ;
            era:rinfIndex "1.1.0.0.0.5" ,
                          "1.1.1.1.8.12.1" ,
@@ -5083,20 +5140,6 @@ The load capability is a value selected from the list of load models representin
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Load capability speed"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
-
-
-###  http://data.europa.eu/949/etcsErrorCorrectionsOnboardExplanation
-era:errorCorrectionsOnboardExplanation rdf:type owl:DatatypeProperty ;
-        rdfs:domain era:CCSSubsystem ;
-                          
-        rdfs:range xsd:string ;
-        era:XMLName "CDE_ReqErrorCorrections" ;
-        era:rinfIndex "1.1.1.3.1.2" , "1.2.1.1.1.19"  ;
-        <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
-        rdfs:comment "Explanation on why a mandatory onboard CR required to be solved in the on-board (ETCS, GSM-R and/or ATO) was accepted by the IM."@en ;
-        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-        rdfs:label "Reasons for Error corrections required, but accepted by the IM for the on-board ETCS, GSM-R and/or ATO function"@en ;
-        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/loadingPlatformHeight
@@ -5413,9 +5456,9 @@ era:maximumDesignSpeed rdf:type owl:DatatypeProperty ;
 era:maximumInterferenceCurrent rdf:type owl:DatatypeProperty ;
                                rdfs:domain era:TrainDetectionSystem ;
                                rdfs:range xsd:integer ;
-                               era:unitOfMeasure <https://qudt.org/vocab/unit/A-PER-M> ;
                                era:rinfIndex "1.1.1.3.4.2.1" ,
                                              "1.2.1.1.3.2.1" ;
+                               era:unitOfMeasure <https://qudt.org/vocab/unit/A-PER-M> ;
                                <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                rdfs:comment """Maximum interference current limits allowed for track circuits for a defined frequency band (to be expressed in A/m).
@@ -5427,16 +5470,15 @@ era:maximumInterferenceCurrent rdf:type owl:DatatypeProperty ;
 
 ###  http://data.europa.eu/949/maximumInterferenceCurrentEvaluation
 era:maximumInterferenceCurrentEvaluation rdf:type owl:DatatypeProperty ;
-								rdfs:domain era:TrainDetectionSystem ;
-								rdfs:range xsd:string ;
-								era:rinfIndex "1.1.1.3.4.2.1" ,
-											  "1.2.1.1.3.2.1" ;
-								<http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
-								rdfs:comment "If the preferred frequency bands are not used, description of the parameters for evaluation of compliance."@en ;
-								rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-								rdfs:label "Evaluation parameters if maximum interference current is not measured in the preferred bands"@en ;
-								<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
-
+                                         rdfs:domain era:TrainDetectionSystem ;
+                                         rdfs:range xsd:string ;
+                                         era:rinfIndex "1.1.1.3.4.2.1" ,
+                                                       "1.2.1.1.3.2.1" ;
+                                         <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
+                                         rdfs:comment "If the preferred frequency bands are not used, description of the parameters for evaluation of compliance."@en ;
+                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                         rdfs:label "Evaluation parameters if maximum interference current is not measured in the preferred bands"@en ;
+                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/maximumLocomotivesCoupled
@@ -5726,31 +5768,37 @@ era:minRimWidth rdf:type owl:DatatypeProperty ;
 
 ###  http://data.europa.eu/949/minVehicleImpedance
 era:minVehicleImpedance rdf:type owl:DatatypeProperty ;
-                        rdfs:domain [ rdf:type owl:Class ;
-                                      owl:unionOf ( era:TrainDetectionSystem
-                                                    era:VehicleType
-                                                  )
-                                    ] ;
-                        rdfs:range xsd:string ;
-                        era:eratvIndex "4.14.2.17" ;
-                        era:rinfIndex "1.1.1.3.4.2.2" ,
-                                      "1.2.1.1.3.2.2" ;
-                        <http://purl.org/dc/terms/created> "2021-09-01"^^xsd:date ;
-                        <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
-                        rdfs:comment """Impedance as defined in the specification referenced in Appendix A-1, index [D].
+                        rdfs:range xsd:string .
 
-Minimum vehicle impedance (between wheels and pantograph) (only for vehicles equipped for 1500V or 3000V DC).
 
-Per Voltage:
-[1500]: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
-[3000]: [CCCC]+[ZZZZ], idem.
-"""@en ;
-                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                        rdfs:label "Vehicle impedance"@en ;
-                        owl:deprecated "true"^^xsd:boolean ;
-                        dcterms:isReplacedBy era:minVehicleImpedance , era:minVehicleImpedanceVoltages, era:minVehicleInputImpedance , era:minVehicleInputCapacitance ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
-                        <http://www.w3.org/2004/02/skos/core#altLabel> "Minimum vehicle impedance"@en .
+###  http://data.europa.eu/949/minVehicleInputCapacitance
+era:minVehicleInputCapacitance rdf:type owl:DatatypeProperty ;
+                               rdfs:domain era:MinVehicleImpedance ;
+                               rdfs:range xsd:double ;
+                               era:rinfIndex "1.1.1.3.4.2.2" ,
+                                             "1.2.1.1.3.2.2" ;
+                               era:unitOfMeasure <https://qudt.org/vocab/unit/NanoFARAD> ;
+                               era:usedInRCCCalculations "true"^^xsd:boolean ;
+                               <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
+                               rdfs:comment "For the selected DC voltage: [CCCC], as input capacitance [CCCC](Cin)"@en ;
+                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                               rdfs:label "minimal vehicle input capacitance"@en ;
+                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/minVehicleInputImpedance
+era:minVehicleInputImpedance rdf:type owl:DatatypeProperty ;
+                             rdfs:domain era:MinVehicleImpedance ;
+                             rdfs:range xsd:double ;
+                             era:rinfIndex "1.1.1.3.4.2.2" ,
+                                           "1.2.1.1.3.2.2" ;
+                             era:unitOfMeasure <https://qudt.org/vocab/unit/MilliH> ;
+                             era:usedInRCCCalculations "true"^^xsd:boolean ;
+                             <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
+                             rdfs:comment "For the selected DC voltage: [ZZZZ], as input impedance [ZZZZ](Zin)"@en ;
+                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                             rdfs:label "minimal vehicle input impedance"@en ;
+                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/minWheelDiameter
@@ -5990,7 +6038,7 @@ era:nationalRollingStockFireCategory rdf:type owl:DatatypeProperty ;
 era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty ;
                              rdfs:domain era:CCSSubsystem ;
                              rdfs:range xsd:string ;
-			     era:appendixD3index "1.5.13" ;
+                             era:appendixD3index "1.5.13" ;
                              era:rinfIndex "1.1.1.3.2.16.13" ,
                                            "1.2.1.1.1.16.13" ;
                              <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -6105,6 +6153,16 @@ era:opTypeGaugeChangeover rdf:type owl:DatatypeProperty ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Type of track gauge changeover facility"@en ;
                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/organisationCode
+era:organisationCode rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf <http://purl.org/dc/terms/identifier> ;
+                     rdfs:domain era:Body ;
+                     rdfs:range xsd:string ;
+                     <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+                     rdfs:comment "Four alpha-numeric code allocated by ERA to a body. It represent's the IM code in RINF."@en ;
+                     rdfs:label "organisation code" .
 
 
 ###  http://data.europa.eu/949/parkingBrake
@@ -6375,6 +6433,30 @@ era:preventRegenerativeBrakeUse rdf:type owl:DatatypeProperty ;
                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
+###  http://data.europa.eu/949/primaryLocationCode
+era:primaryLocationCode rdf:type owl:DatatypeProperty ;
+                        rdfs:subPropertyOf <http://purl.org/dc/terms/identifier> ;
+                        rdfs:domain era:PrimaryLocation ;
+                        rdfs:range xsd:string ;
+                        era:XMLName "OPTafTapCode" ;
+                        era:appendixD2Index "2.2.2" ;
+                        era:rinfIndex "1.2.0.0.0.3" ;
+                        <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+                        rdfs:comment "Primary location code developed for information exchange in accordance with the TSIs relating to the telematics applications subsystem."@en ;
+                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                        rdfs:label "primary location code"@en ;
+                        owl:incompatibleWith era:tafTAPCode ;
+                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/primaryLocationName
+era:primaryLocationName rdf:type owl:DatatypeProperty ;
+                        rdfs:domain era:PrimaryLocation ;
+                        rdfs:range xsd:string ;
+                        <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+                        rdfs:label "primary location name"@en .
+
+
 ###  http://data.europa.eu/949/prioritySeats
 era:prioritySeats rdf:type owl:DatatypeProperty ;
                   rdfs:domain era:VehicleType ;
@@ -6458,7 +6540,7 @@ era:qNvsbtsmperm rdf:type owl:DatatypeProperty ;
                  rdfs:domain era:CCSSubsystem ;
                  rdfs:range xsd:boolean ;
                  era:XMLName "CPE_QNVSBTSMPERM" ;
-		 era:appendixD3index "1.5.12" ;
+                 era:appendixD3index "1.5.12" ;
                  era:rinfIndex "1.1.1.3.2.16.12" ,
                                "1.2.1.1.1.16.12" ;
                  <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -6492,7 +6574,7 @@ era:radioNetworkId rdf:type owl:DatatypeProperty ;
                    rdfs:domain era:CCSSubsystem ;
                    rdfs:range xsd:string ;
                    era:XMLName "CRG_RadioNID" ;
-		   era:appendixD2Index "3.4.4" ;
+                   era:appendixD2Index "3.4.4" ;
                    era:rinfIndex "1.1.1.3.3.13" ,
                                  "1.2.1.1.2.13" ;
                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -6521,7 +6603,8 @@ era:railSystemType rdf:type owl:DatatypeProperty ;
                    rdfs:domain era:SubsetWithCommonCharacteristics ;
                    rdfs:range xsd:string ;
                    <http://purl.org/dc/terms/created> "2022-11-04"^^xsd:date ;
-                   rdfs:comment "TODO: review. Type of railway system. Can be \"High-speed\" or \"Conventional\". Deprecated due to the lack of information"@en ;
+                   <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
+                   rdfs:comment "(deprecated) Type of railway system. Can be \"High-speed\" or \"Conventional\". Deprecated due to the lack of information"@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Rail system type"@en ;
                    owl:deprecated "true"^^xsd:boolean ;
@@ -6597,27 +6680,27 @@ The raised pantographs distance and speed is  the indication of maximum number o
 era:rbcID rdf:type owl:DatatypeProperty ;
           rdfs:domain era:RadioBlockCenter ;
           rdfs:range xsd:string ;
-		 era:rinfIndex "1.1.1.3.2.17" ,
-					   "1.2.1.1.1.17" ;
-		 era:appendixD2Index "3.4.7" ;
-		 <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ; # sh:regex to be added
-		 rdfs:comment "Unique RBC identification (NID_C+NID_RBC) as defined in the specification referenced in Appendix A-1, index [C]."@en ;
-		 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+          era:appendixD2Index "3.4.7" ;
+          era:rinfIndex "1.1.1.3.2.17" ,
+                        "1.2.1.1.1.17" ;
+          <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
+          rdfs:comment "Unique RBC identification (NID_C+NID_RBC) as defined in the specification referenced in Appendix A-1, index [C]."@en ;
+          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "ERTMS/ETCS Radio Block Center (RBC) identifier"@en ;
-		 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/rbcPhone
 era:rbcPhone rdf:type owl:DatatypeProperty ;
              rdfs:range xsd:string ;
-			 era:rinfIndex "1.1.1.3.2.17" ,
-						   "1.2.1.1.1.17" ;
-			 era:appendixD2Index "3.4.7" ;
-			 <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ; # sh:regex to be added
-			 rdfs:comment "Unique RBC calling number (NID_RADIO) as defined in the specification referenced in Appendix A-1, index [C]."@en ;
-			 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-			 rdfs:label "ERTMS/ETCS Radio Block Center (RBC) phone number"@en ;
-			 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+             era:appendixD2Index "3.4.7" ;
+             era:rinfIndex "1.1.1.3.2.17" ,
+                           "1.2.1.1.1.17" ;
+             <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
+             rdfs:comment "Unique RBC calling number (NID_RADIO) as defined in the specification referenced in Appendix A-1, index [C]."@en ;
+             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+             rdfs:label "ERTMS/ETCS Radio Block Center (RBC) phone number"@en ;
+             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/redLightsRequired
@@ -6651,7 +6734,8 @@ era:referencePassByNoiseLevel rdf:type owl:DatatypeProperty ;
 era:relativeDistanceDangerPoint rdf:type owl:DatatypeProperty ;
                                 rdfs:domain era:Signal ;
                                 rdfs:range xsd:integer ;
-			 	era:appendixD2Index "2.2.3" , "2.3.3" ;
+                                era:appendixD2Index "2.2.3" ,
+                                                    "2.3.3" ;
                                 era:rinfIndex "1.1.1.3.14.4" ,
                                               "1.2.1.0.8.4" ;
                                 <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -6739,7 +6823,8 @@ era:signalId rdf:type owl:DatatypeProperty ;
              rdfs:subPropertyOf <http://purl.org/dc/terms/identifier> ;
              rdfs:domain era:Signal ;
              rdfs:range xsd:string ;
-             era:appendixD2Index "2.2.3" , "2.3.3" ;
+             era:appendixD2Index "2.2.3" ,
+                                 "2.3.3" ;
              era:rinfIndex "1.1.1.3.14.1" ,
                            "1.2.1.0.8.1" ;
              <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -6897,7 +6982,17 @@ era:subsetName rdf:type owl:DatatypeProperty ;
 era:subsidiaryLocationCode rdf:type owl:DatatypeProperty ;
                            rdfs:domain era:SubsidiaryLocation ;
                            rdfs:range xsd:string ;
+                           rdfs:comment "The numeric code for the subsidiary location" ;
                            rdfs:label "subsidiary location code"@en .
+
+
+###  http://data.europa.eu/949/subsidiaryLocationName
+era:subsidiaryLocationName rdf:type owl:DatatypeProperty ;
+                           rdfs:domain era:SubsidiaryLocation ;
+                           rdfs:range xsd:string ;
+                           <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+                           rdfs:comment "The common name given to the subsidiary location"@en ;
+                           rdfs:label "subsidiary location name"@en .
 
 
 ###  http://data.europa.eu/949/switchProtectControlWarning
@@ -6905,7 +7000,7 @@ era:switchProtectControlWarning rdf:type owl:DatatypeProperty ;
                                 rdfs:domain era:CCSSubsystem ;
                                 rdfs:range xsd:boolean ;
                                 era:XMLName "CTS_SwitchProtectControlWarn" ;
-				era:appendixD2Index "3.4.2" ;
+                                era:appendixD2Index "3.4.2" ;
                                 era:rinfIndex "1.1.1.3.8.1" ,
                                               "1.2.1.1.7.1" ;
                                 <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
@@ -6921,7 +7016,7 @@ era:switchRadioSystem rdf:type owl:DatatypeProperty ;
                       rdfs:domain era:CCSSubsystem ;
                       rdfs:range xsd:boolean ;
                       era:XMLName "CTS_SwitchRadioSystem" ;
-		      era:appendixD2Index "3.4.4" ;
+                      era:appendixD2Index "3.4.4" ;
                       era:rinfIndex "1.1.1.3.8.2" ,
                                     "1.2.1.1.7.2" ;
                       <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
@@ -7079,10 +7174,12 @@ era:tafTAPCode rdf:type owl:DatatypeProperty ;
                era:appendixD2Index "2.2.2" ;
                era:rinfIndex "1.2.0.0.0.3" ;
                <http://purl.org/dc/terms/created> "2020-07-29"^^xsd:date ;
-               <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
-               rdfs:comment "TODO review: Primary location code developed for information exchange in accordance with the TSIs relating to the telematics applications subsystem."@en ;
+               <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
+                                                   "2024-06-03"^^xsd:date ;
+               rdfs:comment "Not used anymore. It has been replaced by era:primaryLocationCode."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "OP primary location code"@en ;
+               owl:deprecated "true"^^xsd:boolean ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -7245,7 +7342,7 @@ era:trainIntegrityOnBoardRequired rdf:type owl:DatatypeProperty ;
                                                          ]
                                              ] ;
                                   era:XMLName "CPE_IntegrityConfirmation" ;
-				  era:appendixD2index "3.4.11" ; 
+                                  era:appendixD2index "3.4.11" ;
                                   era:rinfIndex "1.1.1.3.2.8" ,
                                                 "1.2.1.1.1.8" ;
                                   era:usedInRCCCalculations "true"^^xsd:boolean ;
@@ -7838,21 +7935,21 @@ era:wheelchairSpaces rdf:type owl:DatatypeProperty ;
 
 
 ###  http://xmlns.com/foaf/0.1/name
-<http://xmlns.com/foaf/0.1/name> rdf:type owl:DatatypeProperty ;
-                                 rdfs:domain owl:Thing ;
-                                 rdfs:range rdfs:Literal ;
-                                 rdfs:comment "A name for some thing." ;
-                                 rdfs:isDefinedBy <http://xmlns.com/foaf/0.1/> ;
-                                 rdfs:label "name" ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "testing" .
+foaf:name rdf:type owl:DatatypeProperty ;
+          rdfs:domain owl:Thing ;
+          rdfs:range rdfs:Literal ;
+          rdfs:comment "A name for some thing." ;
+          rdfs:isDefinedBy foaf: ;
+          rdfs:label "name" ;
+          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "testing" .
 
 
 ###  http://xmlns.com/foaf/0.1/nick
-<http://xmlns.com/foaf/0.1/nick> rdf:type owl:DatatypeProperty ;
-                                 rdfs:comment "A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames)." ;
-                                 rdfs:isDefinedBy <http://xmlns.com/foaf/0.1/> ;
-                                 rdfs:label "nickname" ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "testing" .
+foaf:nick rdf:type owl:DatatypeProperty ;
+          rdfs:comment "A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames)." ;
+          rdfs:isDefinedBy foaf: ;
+          rdfs:label "nickname" ;
+          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "testing" .
 
 
 #################################################################
@@ -7893,6 +7990,19 @@ era:BasicObject rdf:type owl:Class ;
                 rdfs:label "Basic Object"@en .
 
 
+###  http://data.europa.eu/949/Body
+era:Body rdf:type owl:Class ;
+         rdfs:subClassOf [ rdf:type owl:Class ;
+                           owl:unionOf ( <http://www.w3.org/ns/org#Organization>
+                                         foaf:Person
+                                       )
+                         ] ;
+         owl:disjointWith era:OrganisationRole ;
+         <http://purl.org/dc/terms/created> "2024-06-03"^^xsd:date ;
+         rdfs:comment "Is an organisation or a physical person"@en ;
+         rdfs:label "Body"@en .
+
+
 ###  http://data.europa.eu/949/Bridge
 era:Bridge rdf:type owl:Class ;
            rdfs:subClassOf era:BasicObject ;
@@ -7905,7 +8015,7 @@ era:Bridge rdf:type owl:Class ;
                             era:Switch ,
                             era:Track ,
                             era:Tunnel ;
-           rdfs:comment "It is a structure constructed for the exclusive purpose of carrying railroad traffic across an obstruction. It can be used for defining non-stopping areas, big metal mass, etc."@en ;
+           rdfs:comment "It is a structure constructed for the exclusive purpose of carrying railroad traffic across an obstruction. It can be used for defining non-stopping areas, big metal mass, resistance to traffic load etc."@en ;
            rdfs:label "Bridge"@en .
 
 
@@ -7938,7 +8048,7 @@ era:ContactLineSystem rdf:type owl:Class ;
 
 ###  http://data.europa.eu/949/Document
 era:Document rdf:type owl:Class ;
-             rdfs:subClassOf <http://xmlns.com/foaf/0.1/Document> ;
+             rdfs:subClassOf foaf:Document ;
              <http://purl.org/dc/terms/created> "2024-04-23"^^xsd:date ;
              rdfs:comment "Document in any of the ERA systems, e.g. reference document in RINF."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -7948,7 +8058,7 @@ era:Document rdf:type owl:Class ;
 
 ###  http://data.europa.eu/949/ETCSLevel
 era:ETCSLevel rdf:type owl:Class ;
-              era:rinfIndex "1.1.1.3.2.1" ;
+              era:rinfIndex "1.1.1.3.2" ;
               <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
               <http://purl.org/dc/terms/modified> "2021-08-07"^^xsd:date ;
               rdfs:comment "TSI compliant train protection system ERTMS / ETCS application level and baseline related to the track side equipment."@en ;
@@ -7999,10 +8109,11 @@ era:InfraSubsystem rdf:type owl:Class ;
 ###  http://data.europa.eu/949/InfrastructureManager
 era:InfrastructureManager rdf:type owl:Class ;
                           rdfs:subClassOf <http://www.w3.org/ns/org#Organization> ;
-                          rdfs:comment """TODO review the ERATV part of the ontology: 
-The infrastructure manager owns and operates the railway network and related infrastructure."""@en ;
+                          <http://purl.org/dc/terms/isReplacedBy> era:Body ;
+                          rdfs:comment "(deprecated) The infrastructure manager owns and operates the railway network and related infrastructure."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Infrastructure manager"@en ;
+                          owl:deprecated "true"^^xsd:boolean ;
                           <http://www.w3.org/2004/02/skos/core#scopeNote> "See point (2) of Article 3 of Directive 2012/34/EU of the European Parliament and of the Council establishing a single European railway area."@en .
 
 
@@ -8042,6 +8153,7 @@ era:LevelCrossing rdf:type owl:Class ;
                                    era:Switch ,
                                    era:Track ,
                                    era:Tunnel ;
+                  rdfs:comment "A level crossing is an intersection where a railway line crosses a road or a path at the same level. It can be used for the implementation of the ETCS trackside or to identify potential collision scenarios"@en ;
                   rdfs:label "Level crossing"@en .
 
 
@@ -8099,11 +8211,12 @@ Each track can have several load capability (structured) values, and each one ha
 era:Manufacturer rdf:type owl:Class ;
                  rdfs:subClassOf <http://www.w3.org/ns/org#Organization> ;
                  <http://purl.org/dc/terms/created> "2020-11-19"^^xsd:date ;
-                 <http://purl.org/dc/terms/modified> "2020-11-19"^^xsd:date ;
-                 rdfs:comment """TODO review the ERATV part of the ontology:
-A company or organization that manufactures vehicles."""@en ;
+                 <http://purl.org/dc/terms/modified> "2020-11-19"^^xsd:date ,
+                                                     "2024-06-03"^^xsd:date ;
+                 rdfs:comment "(deprecated) Replaced by the era:Body class and era:manufacturer property. A company or organization that manufactures vehicles."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Manufacturer"@en ;
+                 owl:deprecated "true"^^xsd:boolean ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -8135,6 +8248,21 @@ era:MinAxleLoadVehicleCategory rdf:type owl:Class ;
                                rdfs:label "Min axle load vehicle category"@en ;
                                owl:deprecated "true"^^xsd:boolean ;
                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/MinVehicleImpedance
+era:MinVehicleImpedance rdf:type owl:Class ;
+                        <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
+                        rdfs:comment """Impedance as defined in the specification referenced in Appendix A-1, index [D].
+
+Minimum vehicle impedance (between wheels and pantograph) (only for vehicles equipped for 1500V or 3000V DC).
+
+Per Voltage:
+[1500]: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
+[3000]: [CCCC]+[ZZZZ], idem."""@en ;
+                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                        rdfs:label "Minimum Vehicle Impedance"@en ;
+                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/NationalRailwayLine
@@ -8173,6 +8301,11 @@ era:OperationalPoint rdf:type owl:Class ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Operational Point"@en ;
                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+
+
+###  http://data.europa.eu/949/OrganisationRole
+era:OrganisationRole rdf:type owl:Class ;
+                     rdfs:label "Organisation Role"@en .
 
 
 ###  http://data.europa.eu/949/Orientation
@@ -8313,7 +8446,7 @@ era:Signal rdf:type owl:Class ;
                             era:Track ,
                             era:Tunnel ;
            era:rinfIndex "1.2.1.0.8" ;
-           <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
+           <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/2023-09-28> ;
            <http://purl.org/dc/terms/created> "2021-04-01"^^xsd:date ;
            <http://purl.org/dc/terms/modified> "2022-10-27"^^xsd:date ;
            rdfs:comment """A railway signal is an installation next to the railway track for signalling the maximum allowed speed in the next block section to the train driver.
@@ -8326,41 +8459,24 @@ Definition RSM: Apparatus by means of which a conventional visual or acoustic in
 ###  http://data.europa.eu/949/SignalsGrid
 era:SignalsGrid rdf:type owl:Class ;
                 rdfs:subClassOf era:BasicObject ;
-                 owl:disjointWith era:Siding ,
-                                  era:Signal ,
-                                  era:PlatformEdge ,
-                                  era:Switch ,
-                                  era:Track ,
-                                  era:Tunnel ;
-			   rdfs:comment """Group of switches and crossings within an Operational Point with which the route protection function is realized by a group of Signals belonging together from an operational standpoint. 
+                owl:disjointWith era:Switch ,
+                                 era:Track ,
+                                 era:Tunnel ;
+                rdfs:comment """Group of switches and crossings within an Operational Point with which the route protection function is realized by a group of Signals belonging together from an operational standpoint. 
 The switches' position in a SignalsGrid are controlled together by the interlocking during normal operation and else by safety procedures."""@en ;
-			   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Signals Grid"@en .
-				
-				
-###  http://data.europa.eu/949/MinVehicleImpedance
-era:MinVehicleImpedance rdf:type owl:Class ;
-                        <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                        rdfs:comment """Impedance as defined in the specification referenced in Appendix A-1, index [D].
-
-Minimum vehicle impedance (between wheels and pantograph) (only for vehicles equipped for 1500V or 3000V DC).
-
-Per Voltage:
-[1500]: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
-[3000]: [CCCC]+[ZZZZ], idem."""@en ;
-                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                        rdfs:label "minimum Vehicle Impedance"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .				
 
 
 ###  http://data.europa.eu/949/SpecialArea
 era:SpecialArea rdf:type owl:Class ;
                 rdfs:subClassOf era:InfrastructureObject ;
-		era:annexD2Index "3.2.4" , "3.2.5" ;
+                era:annexD2Index "3.2.4" ,
+                                 "3.2.5" ;
                 <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
-                <http://purl.org/dc/terms/created> "2022-10-27"^^xsd:date ;
-		<http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
-                rdfs:comment """Encompasses all those areas (outside of the operational gauge) or sections (those in tunnels excluded) which influence operation in the gauge itself, such as 
+                <http://purl.org/dc/terms/created> "2022-10-27"^^xsd:date ,
+                                                   "2024-04-18"^^xsd:date ;
+                rdfs:comment """TODO review: Encompasses all those areas (outside of the operational gauge) or sections (those in tunnels excluded) which influence operation in the gauge itself, such as 
 - safe areas, 
 - restricted areas (non-stopping areas or industrial risk locations).
 
@@ -8377,10 +8493,10 @@ For these areas in tunnels, use era:SpecialTunnelArea."""@en ;
 ###  http://data.europa.eu/949/SpecialTunnelArea
 era:SpecialTunnelArea rdf:type owl:Class ;
                       rdfs:subClassOf era:SpecialArea ;
-		      era:annexD2Index "3.2.3" ;
+                      era:annexD2Index "3.2.3" ;
                       <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                       <http://purl.org/dc/terms/created> "2022-10-27"^^xsd:date ;
-                      rdfs:comment """Area or location within a tunnel where there are 
+                      rdfs:comment """TODO review: Area or location within a tunnel where there are 
 - a safe area: a walkway, evacuation and rescue points;
 - a restricted area (non-stopping area or industrial risk location in a tunnel)."""@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -8420,12 +8536,13 @@ era:SubsidiaryLocation rdf:type owl:Class ;
 ###  http://data.europa.eu/949/Switch
 era:Switch rdf:type owl:Class ;
            rdfs:subClassOf era:BasicObject ;
-	   rdfs:comment """A unit of track comprising two fixed rails (stock rails) and two movable rails (switch rails) used to direct vehicles from 
-one track to another track.""" ;
-	   rdfs:seeAlso "http://data.europa.eu/eli/reg/2014/1299/2019-06-16" ;
            owl:disjointWith era:Track ,
                             era:Tunnel ;
-           rdfs:label "Switch"@en .
+           <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/776/oj> ;
+           rdfs:comment "A unit of track comprising two fixed rails (stock rails) and two movable rails (switch rails) used to direct vehicles from one track to another track."@en ;
+           rdfs:label "Switch"@en ;
+           rdfs:seeAlso "http://data.europa.eu/eli/reg/2014/1299/2019-06-16" ;
+           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/SystemSeparationInfo
@@ -8465,7 +8582,7 @@ era:Track rdf:type owl:Class ;
           era:rinfIndex "1.1.1" ;
           <http://purl.org/dc/terms/created> "2020-07-29"^^xsd:date ;
           <http://purl.org/dc/terms/modified> "2022-07-07"^^xsd:date ;
-          rdfs:comment "A running track that is used for train service movements."@en ;
+          rdfs:comment "A running track means any track used for train service movements; passing loops and meeting loops on plain line or track connections only required for train operation are not published"@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "Running track"@en ;
           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -8486,7 +8603,7 @@ era:TrainDetectionSystem rdf:type owl:Class ;
 era:Tunnel rdf:type owl:Class ;
            rdfs:subClassOf era:BasicObject ;
            era:rinfIndex "1.2.2.0.5" ;
-           <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
+           <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg/2014/1303/2024-01-29> ;
            <http://purl.org/dc/terms/created> "2020-07-29"^^xsd:date ;
            <http://purl.org/dc/terms/modified> "2022-07-07"^^xsd:date ;
            rdfs:comment "A railway tunnel is an excavation or a construction around the track provided to allow the railway to pass for example higher land, buildings or water."@en ;
@@ -8509,12 +8626,14 @@ era:Vehicle rdf:type owl:Class ;
 era:VehicleKeeper rdf:type owl:Class ;
                   rdfs:subClassOf <http://www.w3.org/ns/org#Organization> ;
                   <http://purl.org/dc/terms/created> "2020-11-23"^^xsd:date ;
-                  <http://purl.org/dc/terms/modified> "2020-11-23"^^xsd:date ;
-                  <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                  rdfs:comment """The natural or legal person that, being the owner of a vehicle or having the right to use it, 
+                  <http://purl.org/dc/terms/modified> "2020-11-23"^^xsd:date ,
+                                                      "2024-04-18"^^xsd:date ,
+                                                      "2024-06-03"^^xsd:date ;
+                  rdfs:comment """(deprecated) The natural or legal person that, being the owner of a vehicle or having the right to use it, 
 exploits the vehicle as a means of transport and is registered as such in a vehicle register referred to in Article 47 of (EU)2016/797."""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Vehicle Keeper"@en ;
+                  owl:deprecated "true"^^xsd:boolean ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -8523,11 +8642,12 @@ era:VehicleType rdf:type owl:Class ;
                 rdfs:subClassOf [ rdf:type owl:Restriction ;
                                   owl:onProperty era:manufacturer ;
                                   owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                  owl:onClass era:Manufacturer
+                                  owl:onClass era:Body
                                 ] ;
                 <http://purl.org/dc/terms/created> "2020-07-29"^^xsd:date ;
-                <http://purl.org/dc/terms/modified> "2020-07-29"^^xsd:date ;
-                <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
+                <http://purl.org/dc/terms/modified> "2020-07-29"^^xsd:date ,
+                                                    "2024-04-18"^^xsd:date ,
+                                                    "2024-06-03"^^xsd:date ;
                 rdfs:comment """A vehicle type that has been authorized to operate on the EU railway infrastructure. Type means a vehicle type defining 
 the basic design characteristics of the vehicle as covered by a type or design examination certificate described in the relevant verification module. 
 
@@ -8608,7 +8728,7 @@ sameThing(P1, P2) :- type(P1, Point), type(P2, Point), spaciallyIntersects(P1, P
 
 ###  http://www.w3.org/ns/org#Organization
 <http://www.w3.org/ns/org#Organization> rdf:type owl:Class ;
-                                        rdfs:subClassOf <http://xmlns.com/foaf/0.1/Agent> ;
+                                        rdfs:subClassOf foaf:Agent ;
                                         rdfs:comment "Grupo de personas que se organiza en una comunidad u otro tipo de estructura social, comercial o política. Dicho grupo tiene un objetivo o motivo común para su existencia que va más allá del conjunto de personas que lo forman y que puede actuar como “agente”. A menudo las organizaciones se pueden agrupar en estructuras jerárquicas. Se recomienda el uso de etiquetas de SKOS para denominar a cada “organización”. En concreto, `<http://www.w3.org/2004/02/skos/core#prefLabel>` para la denominación principal o recomendada (aquella reconocida legalmente, siempre que sea posible), `<http://www.w3.org/2004/02/skos/core#altLabel>` para denominaciones alternativas (nombre comercial, sigla, denominación por la que se conoce a la organización coloquialmente) y `skos:notation` para referirse al código que identifique a la organización en una lista de códigos. Denominaciones alternativas: _colectivo_ _corporación_ _grupo_"@es ,
                                                      "Rappresenta una collezione di persone organizzate all'interno di una communità o di una qualche struttura sociale, commerciale o politica. Il gruppo condivide un obiettivo o una ragione d'essere che va oltre gli stessi membri appartenenti al gruppo e  può agire come un Agent. Le organizzazioni si possono spesso suddividere in strutture gerarchiche. Si raccomanda di usare le label per l'Organization mediante le proprietà di SKOS. In particolare, `<http://www.w3.org/2004/02/skos/core#prefLabel>` per il nome principale (possibilmente un nome legalmente riconosciuto)”, `<http://www.w3.org/2004/02/skos/core#altLabel>` come nome alternativo (denominazione commerciale, denominazione colloquiale) e `skos:notation` per indicare un codice di una lista di codici."@it ,
                                                      "Represents a collection of people organized together into a community or other social, commercial or political structure. The group has some common purpose or reason for existence which goes beyond the set of people belonging to it and can act as an Agent. Organizations are often decomposable into hierarchical structures.  It is recommended that SKOS lexical labels should be used to label the Organization. In particular `<http://www.w3.org/2004/02/skos/core#prefLabel>` for the primary (possibly legally recognized name), `<http://www.w3.org/2004/02/skos/core#altLabel>` for alternative names (trading names, colloquial names) and `skos:notation` to denote a code from a code list. Alternative names: _Collective_ _Body_ _Org_ _Group_"@en ,
@@ -8622,30 +8742,67 @@ sameThing(P1, P2) :- type(P1, Point), type(P2, Point), spaciallyIntersects(P1, P
 
 
 ###  http://xmlns.com/foaf/0.1/Agent
-<http://xmlns.com/foaf/0.1/Agent> rdf:type owl:Class .
+foaf:Agent rdf:type owl:Class .
 
 
 ###  http://xmlns.com/foaf/0.1/Document
-<http://xmlns.com/foaf/0.1/Document> rdf:type owl:Class ;
-                                     owl:disjointWith <http://xmlns.com/foaf/0.1/Organization> ,
-                                                      <http://xmlns.com/foaf/0.1/Project> ;
-                                     rdfs:comment "A document." ;
-                                     rdfs:isDefinedBy <http://xmlns.com/foaf/0.1/> ;
-                                     rdfs:label "Document" ;
-                                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+foaf:Document rdf:type owl:Class ;
+              owl:disjointWith foaf:Organization ,
+                               foaf:Project ;
+              rdfs:comment "A document." ;
+              rdfs:isDefinedBy foaf: ;
+              rdfs:label "Document" ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://xmlns.com/foaf/0.1/Organization
-<http://xmlns.com/foaf/0.1/Organization> rdf:type owl:Class .
+foaf:Organization rdf:type owl:Class .
+
+
+###  http://xmlns.com/foaf/0.1/Person
+foaf:Person rdf:type owl:Class ;
+            rdfs:subClassOf foaf:Agent ;
+            rdfs:comment "A person." ;
+            rdfs:label "Person" ;
+            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://xmlns.com/foaf/0.1/Project
-<http://xmlns.com/foaf/0.1/Project> rdf:type owl:Class .
+foaf:Project rdf:type owl:Class .
 
 
 #################################################################
 #    Annotations
 #################################################################
+
+era:minVehicleImpedance era:eratvIndex "4.14.2.17" ;
+                        era:rinfIndex "1.1.1.3.4.2.2" ,
+                                      "1.2.1.1.3.2.2" ;
+                        <http://purl.org/dc/terms/created> "2021-09-01"^^xsd:date ,
+                                                           "2024-05-30"^^xsd:date ;
+                        <http://purl.org/dc/terms/isReplacedBy> era:minVehicleImpedance ,
+                                                                era:minVehicleImpedanceVoltages ,
+                                                                era:minVehicleInputCapacitance ,
+                                                                era:minVehicleInputImpedance ;
+                        <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
+                        rdfs:comment """
+[CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
+"""@en ,
+                                     """Impedance as defined in the specification referenced in Appendix A-1, index [D].
+
+Minimum vehicle impedance (between wheels and pantograph) (only for vehicles equipped for 1500V or 3000V DC).
+
+Per Voltage:
+[1500]: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
+[3000]: [CCCC]+[ZZZZ], idem.
+"""@en ;
+                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                        rdfs:label "Vehicle impedance"@en ,
+                                   "minimum vehicle impedance"@en ;
+                        owl:deprecated "true"^^xsd:boolean ;
+                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                        <http://www.w3.org/2004/02/skos/core#altLabel> "Minimum vehicle impedance"@en .
+
 
 <http://www.w3.org/2003/01/geo/wgs84_pos#> <http://purl.org/dc/elements/1.1/date> "$Date: 2009/04/20 15:00:30 $" ;
                                            <http://purl.org/dc/elements/1.1/description> """A vocabulary for representing latitude, longitude and 


### PR DESCRIPTION
Revision 03-06-2024:
- added properties for the primary and subsidiary locations
- reuse the organisation ontology to address the ERA stakeholder organisations (bodies) and their roles
- deprecated classes related to organisation
- error corrections
- added several definitions