### PR TITLE
Updates in line with Technical Annex (CCS parameters)

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -441,8 +441,8 @@ era:atoSystemVersion rdf:type owl:ObjectProperty ;
                                    "1.2.1.1.10.2" ;
                      <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                      <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                     rdfs:comment "ATO system version according to the specification referenced in Appendix A-1, index [C]."@en ;
-                     dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                     rdfs:comment "ATO system version according to the specification referenced in TSI CCS (4.2.19)."@en ;
+                     dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "ATO System version"@en ;
                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -514,7 +514,7 @@ a) The “Cant Deficiency” SSP categories: the cant deficiency value assigned 
 """@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                           dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                           dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                            rdfs:label "cant deficiency used for the basic SSP"@en ;
                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -688,7 +688,7 @@ era:dataRadioCompatible rdf:type owl:ObjectProperty ;
 Information on RSC data requirements per country:                        
 https://www.era.europa.eu/era-folder/radio-system-compatibility-rsc-voice-and-data-documents"""@en ;
                         dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
-                        dcterms:source "https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf" ;
+                        dcterms:source <https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf> ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Radio system compatibility data"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -896,8 +896,9 @@ era:etcsBaseline rdf:type owl:ObjectProperty ;
                  <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
                  <http://purl.org/dc/terms/modified> "2021-08-31"^^xsd:date ,
                                                      "2024-04-18"^^xsd:date ;
-                 rdfs:comment "ETCS baseline installed lineside."@en ;
-                 dcterms:source "TBD"@en ;
+                 rdfs:comment "ETCS baseline installed lineside - TSI CCS (Table A2)"@en ;
+                 rdfs:label "ETCS baseline"@en ;
+		             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS baseline"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -952,9 +953,9 @@ era:etcsInfill rdf:type owl:ObjectProperty ;
                <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                    "2024-04-18"^^xsd:date ;
-               rdfs:comment "Information about installed trackside equipment capable to transmit infill information by loop or Global System for Mobile communications for Railways (GSM-R) for level 1 installations."@en ;
+               rdfs:comment "Information about installed trackside equipment capable to transmit infill information TSI CCS (4.2.2) by loop or Global System for Mobile communications for Railways (GSM-R) for level 1 installations."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-               dcterms:source "TSI CCS 4.2.2"@en ;
+		           dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                rdfs:label "ETCS infill installed line-side"@en ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -984,8 +985,10 @@ era:etcsLevelType rdf:type owl:ObjectProperty ;
                   <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
                   <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date , "2024-04-18"^^xsd:date ;
                   rdfs:comment "European Train Control System (ETCS) application level related to the track side equipment."@en ;
-		  dcterms:relation era:etcsBaseline ;
-		  dcterms:description """The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
+		              dcterms:relation era:etcsBaseline ;
+		              dcterms:description """See TSI CCS (Subset-026, Chapter 2, 2.6) 
+                  
+The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
 	
 Level definitions are principally related to the track side equipment used, to the way the track side information reaches the on-board units and to which functions are processed in the track side and in the on-board equipment respectively."""@en ;
 		  dcterms:requires """If ETCS is on the trackside (one or more levels are selected), all other ETCS parameters (from 1.1.1.3.2.2 to 1.1.1.3.2.10) are applicable.
@@ -994,7 +997,7 @@ The ETCS value NTC is only relevant when the line is dual equipped with ETCS (i.
 In those cases, this parameter should be filled relevant ETCS Level and repeated with the value “NTC”.
 	
 If the line is only equipped with Class B, this should be reflected in Parameter 1.1.1.3.5.3, and this parameter etcsLevelType should not be used. """@en ; 
-		  dcterms:source "http://data.europa.eu/eli/reg_impl/2023/1695/oj (TSI CCS, SRS Chapter 2, 2.6)"@en ; 
+		              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "ETCS level"@en ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1011,11 +1014,11 @@ era:etcsMVersion rdf:type owl:ObjectProperty ;
                  era:usedInRCCCalculations "true"^^xsd:boolean ;
                  <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                  <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
-                 rdfs:comment "ETCS M_version according to the specification referenced in Appendix A-1, index [C]."@en ;
+                 rdfs:comment "ETCS M_version according to SRS 7.5.1.9."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS M_version"@en ;
                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+		             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -1036,8 +1039,12 @@ era:etcsSystemCompatibility rdf:type owl:ObjectProperty ;
                             <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
                             <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
                             rdfs:comment "ETCS requirements used for demonstrating technical compatibility."@en ;
-                            dcterms:source "TBD"@en ;
-                            dcterms:definition "TBD"@en ; 
+                            dcterms:source <https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf> ;
+                            dcterms:definition """The Infrastructure Manager is responsible for defining the ESC type(s). All sections of the Union network which require the same set of checks for the demonstration of ESC shall have the same ESC type.
+
+The list of ESC Types is published and maintained by the European Union Agency for Railways in the technical document ‘ESC/RSC technical document, TD/011REC1028’. See Appendix A, Table A 1, 4.2.17 a. The Agency shall assess the checks unless they have been assessed by a NoBo as required in Table 6.3 row 10. The assessment by the Agency shall be done within 2 months of receipt thereof, unless a longer period is agreed between the Agency and the Infrastructure Manager but not exceeding 4 months in total. The technical document will be updated within 10 working days after positive assessment.
+
+The ESC Types shall only be used when published with status ‘Valid’ in the Agency Technical document referred above."""@en ; 
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "ETCS system compatibility"@en ;
                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1062,7 +1069,7 @@ Chapter 5, section 5.18.1.1."""@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Track conditions which can be transmitted"@en ;
                                    dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ; 
-                                   dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
 
@@ -1155,13 +1162,13 @@ era:frequencyBandsForDetection rdf:type owl:ObjectProperty ;
                                              "1.2.1.1.3.2" ;
                                <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                               rdfs:comment "Bands of the frequency management of the train detection systems as defined in the specification referenced in Appendix A-1, index [D], and in the specific cases or technical documents referred to in Article 13 of TSI CCS when they are available."@en ;
+                               rdfs:comment "Bands of the frequency management of the train detection systems as defined in the TSI CCS (Annex A- Index 77), and in the specific cases or technical documents referred to in Article 13 of TSI CCS when they are available."@en ;
                                dcterms:description """Verification of compliance with TSI includes application of notified national rules (when they exist).
 
 Multiple selection from a predefined list:
 -	Axle Counters: bands A1-A3
 -	Track circuits: bands A1-A8"""@en ;
-                               dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                               dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                                dcterms:relation era:maximumInterferenceCurrent, era:minVehicleImpedance,  era:tdsMaximumMagneticField ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "frequency bands for detection"@en ;
@@ -1331,10 +1338,11 @@ era:gsmRVersion rdf:type owl:ObjectProperty ;
                 <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                 <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                     "2024-04-18"^^xsd:date ;
-                rdfs:comment """GSM-R functional requirements specification and system requirements specification in accordance with the specification respectively referenced in Appendix A-1, index [E] and index [F], version number installed lineside.
+                rdfs:comment """GSM-R functional requirements specification and system requirements specification in accordance with the specification respectively referenced in TSI CCS (Annex ), version number installed lineside.
                 
 Since more than one version may be installed in different areas, this property can have multiple values."""@en ;
                 dcterms:requires "GSM-R must be installed for this parameter to be applicable. If this property is not used, all GSM-R related properties should not be used either."@en ;
+                dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "GSM-R version"@en ;
                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1524,7 +1532,7 @@ era:legacyRadioSystem rdf:type owl:ObjectProperty ;
                                                           "2024-04-18"^^xsd:date ;
                       <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                       rdfs:comment "Indication of radio legacy systems installed. The list is in line with ERA/TD/2011-09/INT (v1.13), Table 4. "@en ;
-                      dcterms:source "https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf" ;
+                      dcterms:source <https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf> ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Other radio systems installed (Radio Legacy Systems)"@en ;
                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1729,7 +1737,7 @@ In https://www.era.europa.eu/domains/technical-specifications-interoperability/c
 Subset 26, chapter 7. 7.5.1.74 M_NVCONTACT."""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-               dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+               dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                rdfs:label "M_NVCONTACT"@en ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
@@ -2066,7 +2074,7 @@ era:minVehicleImpedanceVoltages rdf:type owl:ObjectProperty ;
                               rdfs:comment "Indication of the voltage system valid for the minimal impedance value (track circuits)."@en ;
 			      dcterms:requires "The parameter minVehicleImpedanceVoltages is applicable for track circuits." ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                              dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                              dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                               rdfs:label "minimum Vehicle Impedance (Voltage applicable)"@en ;
                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -2090,7 +2098,7 @@ b) The “other specific” SSP categories: it groups all other specific SSP cat
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 dcterms:relation era:cantDeficiencyBasicSSP ;
                                 dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                                dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;               
+                                dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;               
                                 rdfs:label "Other Cant Deficiency train categories for which the ETCS trackside is configured to provide SSP"@en ;
                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
@@ -2299,7 +2307,7 @@ era:protectionLegacySystem rdf:type owl:ObjectProperty ;
                            <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                                "2024-04-18"^^xsd:date ;
                            rdfs:comment "Indication of which class B system is installed. The list is in line with ERA/TD/2011-09/INT (v1.13), Table 3. "@en ;
-                           dcterms:source "https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf" ;
+                           dcterms:source <https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf> ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Train protection legacy system"@en ;
                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -2319,8 +2327,7 @@ era:qNvemrrls rdf:type owl:ObjectProperty ;
               rdfs:comment """
 Qualifier defining whether the application of the emergency brake for reasons other than a trip can be revoked as soon as the conditions for it have disappeared or after the train has come to a complete standstill.
 
-According to the specification referenced in Appendix A-1, index [C]. 
-In Subset-026, chapter 7, 7.5.1.123 Q_NVEMRRLS."""@en ;
+According to the specification referenced in TSI CCS (Subset-026, chapter 7, 7.5.1.123 Q_NVEMRRLS)"""@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "Q_NVEMRRLS"@en ;
               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
@@ -2372,15 +2379,14 @@ era:reasonsEtcsRadioBlockCenterReject rdf:type owl:ObjectProperty ;
                                       <http://purl.org/dc/terms/created> "2022-11-07"^^xsd:date ;
                                       <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ,
                                                                           "2024-04-18"^^xsd:date ;
-                                      rdfs:comment """
-                                      List of cases subject to system design choices made by the infrastructure manager according to the specification referenced in Appendix A-1, index [C]. 
+                                      rdfs:comment """List of cases subject to system design choices made by the infrastructure manager according to the specification referenced in TSI CCS. 
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, Chapter 5 5.4 Procedure start of mission."""@en ;
+See: Subset 26, Chapter 5 5.4 Procedure start of mission."""@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Reasons for which an ETCS Radio Block Center can reject a train"@en ;
                                       dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                                      dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                                      dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                                      rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
 
@@ -2435,7 +2441,7 @@ era:safeConsistLengthInformationNecessary rdf:type owl:ObjectProperty ;
                                           rdfs:comment """Indication whether safe consist train length information from on-board is required to access the line for safety reasons and the required safety integrity level."""@en ;
                                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                           rdfs:label "Safe consist length information from on-board necessary for access the line and SIL"@en ;
-                                          dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                                          dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                                           dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -2555,11 +2561,11 @@ era:minVehicleImpedance rdf:type owl:ObjectProperty ;
                         era:rinfIndex "1.1.1.3.4.2.2" ,
                                       "1.2.1.1.3.2.2" ;
                         <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                        rdfs:comment """Per voltage: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin) as defined in TSI CCS Annex A - Index 77.
+                        rdfs:comment """Per voltage: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin) as defined in TSI CCS (Annex A- Index 77).
                         
 Verification of compliance with TSI includes application of notified national rules (when they exist)."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                        dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                        dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
 			                  dcterms:requires "The parameter minVehicleImpedance is applicable for track circuits." ;
                         rdfs:label "minimum vehicle impedance"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
@@ -2733,7 +2739,7 @@ era:tdsMaximumMagneticField rdf:type owl:ObjectProperty ;
 The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band.
 It should be provided in 3 directions."""@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                            dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                            dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                             rdfs:label "Maximum magnetic field"@en ;
                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -2932,11 +2938,11 @@ era:trainDetectionSystemSpecificCheckDocument rdf:type owl:ObjectProperty ;
                                               <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
                                                                                   "2024-04-18"^^xsd:date ,
                                                                                   "2024-04-23"^^xsd:date ;
-                                              rdfs:comment "Electronic document from the IM stored by the Agency with precise values in accordance with TSI CCS Article 13 and the specification referenced in Appendix A-1, index [D], for the specific check to be performed for train detection systems identified in parameter \"\"Type of track circuits or axle counters to which specific checks are needed\"."@en ;
+                                              rdfs:comment "Electronic document from the IM stored by the Agency with precise values in accordance with TSI CCS (Article 13 and Annex A, Index 77), for the specific check to be performed for train detection systems identified in parameter \"\"Type of track circuits or axle counters to which specific checks are needed\"."@en ;
                                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                               rdfs:label "Document with the procedure(s) related to the type of train detection systems declared in 1.1.1.3.7.1.2 or 1.2.1.1.6.1"@en ;
                                               dcterms:requires "The document itself has to be upload by the NRE via the “reference document management” functionality. The reference of the document is provided for the parameter using the characterstring format."@en ;
-		                              dcterms:source "According to the specification referenced in Appendix A-1, index [D]"@en ;
+                                              dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
                                               <http://www.w3.org/2004/02/skos/core#changeNote> "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
@@ -3260,7 +3266,7 @@ https://www.era.europa.eu/era-folder/radio-system-compatibility-rsc-voice-and-da
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable.
 In case of RSC-EU-0 or None, no other values are allowed."""@en ;
-                         dcterms:source "https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf" ;
+                         dcterms:source <https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf> ;
                          rdfs:label "Radio system compatibility voice"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -3309,7 +3315,7 @@ era:wheelSetGaugeChangeoverFacility rdf:type owl:ObjectProperty ;
                                                    era:XMLName "OPGeographicLocation" ;
                                                    era:rinfIndex "1.1.0.0.1.1" ,
                                                                  "1.1.1.0.1.1" ,
-                                                                 "1.1.1.3.14.6" ,
+                                                                 "1.1.1.3.14.5" ,
                                                                  "1.2.0.0.0.5" ,
                                                                  "1.2.1.0.8.5" ;
                                                    era:usedInRCCCalculations "true"^^xsd:boolean ;
@@ -3477,7 +3483,7 @@ era:bigMetalMass rdf:type owl:DatatypeProperty ;
                  rdfs:comment "Indication of existence of metal mass in the vicinity of the location, susceptible of perturbating the reading of balises by the on-board system."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                  rdfs:label "Big Metal Mass"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -3746,7 +3752,7 @@ era:currentlyValid rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/dNvovtrp
 era:dNvovtrp rdf:type owl:DatatypeProperty ;
              rdfs:domain era:CCSSubsystem ;
-             rdfs:range xsd:integer ;
+             rdfs:range xsd:number ;
              era:XMLName "CPE_DNVOVTRP" ;
              era:appendixD3Index "1.5.5" ;
              era:rinfIndex "1.1.1.3.2.16.5" ,
@@ -3757,11 +3763,13 @@ era:dNvovtrp rdf:type owl:DatatypeProperty ;
                                                  "2024-04-18"^^xsd:date ;
              rdfs:comment """Maximum distance for overriding the train trip in metres.
 
+Precision: [NNNNNN.N] with N a decimal number (0÷9) 
+
 In Subset 26, chapter 7. 7.5.1.15 D_NVOVTRP.
 https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-             dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
+             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
              rdfs:label "D_NVOVTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -3769,7 +3777,7 @@ https://www.era.europa.eu/domains/technical-specifications-interoperability/cont
 ###  http://data.europa.eu/949/dNvpotrp
 era:dNvpotrp rdf:type owl:DatatypeProperty ;
              rdfs:domain era:CCSSubsystem ;
-             rdfs:range xsd:integer ;
+             rdfs:range xsd:number ;
              era:XMLName "CPE_DNVPOTRP" ;
              era:appendixD3Index "1.5.7" ;
              era:rinfIndex "1.1.1.3.2.16.7" ,
@@ -3780,11 +3788,13 @@ era:dNvpotrp rdf:type owl:DatatypeProperty ;
                                                  "2024-04-18"^^xsd:date ;
              rdfs:comment """Maximum distance for reversing in Post Trip mode in metres. 
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, chapter 7. 7.5.1.16 D_NVPOTRP."""@en ;
+Precision: [NNNNNN.N], with N a decimal number (0÷9)
+
+See: TSI CCS (Subset 26, chapter 7. 7.5.1.16 D_NVPOTRP)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-             dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
+             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+             rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              rdfs:label "D_NVPOTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -3792,7 +3802,7 @@ Subset 26, chapter 7. 7.5.1.16 D_NVPOTRP."""@en ;
 ###  http://data.europa.eu/949/dNvroll
 era:dNvroll rdf:type owl:DatatypeProperty ;
             rdfs:domain era:CCSSubsystem ;
-            rdfs:range xsd:integer ;
+            rdfs:range xsd:number ;
             era:XMLName "CPE_DNVROLL" ;
             era:appendixD3Index "1.5.1" ;
             era:rinfIndex "1.1.1.3.2.16.1" ,
@@ -3803,11 +3813,13 @@ era:dNvroll rdf:type owl:DatatypeProperty ;
                                                 "2024-04-18"^^xsd:date ;
             rdfs:comment """Parameter used by the ETCS on-board to supervise the distance allowed to be travelled under the roll-away protection and the reverse movement protection, in metres.
 
+Precision: [NNNNNN.N], with N a decimal number (0÷9).
+
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.17 D_NVROLL."""@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-            dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
+            dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
             rdfs:label "D_NVROLL"@en ;
             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4073,7 +4085,7 @@ era:minVehicleInputImpedance rdf:type owl:DatatypeProperty ;
                               era:usedInRCCCalculations "true"^^xsd:boolean ;
                               <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
                               rdfs:comment "For the selected DC voltage: [ZZZZ], as input impedance [ZZZZ](Zin)"@en ;
-                              dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                              dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
 	  		      dcterms:requires "The minVehicleInputImpedance parameter is applicable for track circuits." @en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "minimal vehicle input impedance"@en ;
@@ -4090,7 +4102,7 @@ era:minVehicleInputCapacitance rdf:type owl:DatatypeProperty ;
                                 era:usedInRCCCalculations "true"^^xsd:boolean ;
                                 <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
                                 rdfs:comment "For the selected DC voltage: [CCCC], as input capacitance [CCCC](Cin)"@en ;
-                                dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                                dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
 	  		        dcterms:requires "The minVehicleInputCapacitance parameter is applicable for track circuits." @en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "minimal vehicle input capacitance"@en ;
@@ -4145,7 +4157,7 @@ era:ertmsErrorCorrectionsOnBoard rdf:type owl:DatatypeProperty ;
                                  rdfs:range xsd:anyURI ;
                                  <http://purl.org/dc/terms/created> "2024-01-08"^^xsd:date ;
                                  <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                                 rdfs:comment "List of unacceptable errors impacting the IM network that are required to be solved in the on-board according to the TSI CCS point 7.2.10.3 specification maintenance point."@en ;
+                                 rdfs:comment "List of unacceptable errors impacting the IM network that are required to be solved in the on-board according to the TSI CCS (point 7.2.10.3 - specification maintenance point)."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "(Deprecated) ERTMS error corrections required for the on-board. Use: errorCorrectionsOnboard"@en ;
                                  owl:deprecated "true"^^xsd:boolean ;
@@ -4193,7 +4205,7 @@ era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "ETCS trackside implements level crossing procedure or an equivalent solution"@en ;
                                          dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                                         dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
+                                         dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -4282,7 +4294,7 @@ era:etcsSystemFunctionalitiesNextFiveYears rdf:type owl:DatatypeProperty ;
                                            <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                            <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
                                                                                "2024-04-18"^^xsd:date ;
-                                           rdfs:comment "(Deprecated) List of ETCS system version 2.2 or 3.0 functionalities to be required in the next 5 years according to TSI CCS point 6.1.1.2 and Appendix G."@en ;
+                                           rdfs:comment "(Deprecated) List of ETCS system version 2.2 or 3.0 functionalities to be required in the next 5 years according to TSI CCS (6.1.1.2) and Appendix G."@en ;
                                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                            rdfs:label "ETCS system version 2.2 or 3.0 functionalities to be required in the next 5 years. Deprecated with TWG RINF CCS 2024."@en ;
                                            owl:deprecated "true"^^xsd:boolean ;
@@ -4304,7 +4316,7 @@ era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Is the ETCS trackside engineered to transmit Track Conditions"@en ;
                                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ; 
-                                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -4429,7 +4441,8 @@ era:gprsForETCS rdf:type owl:DatatypeProperty ;
                 dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
                 dcterms:relation era:etcsLevelType ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                dcterms:source "Sections of EIRENE and ETCS subsets for trackside in TSI"@en ; 
+                dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                dcterms:description "Sections of EIRENE and ETCS subsets for trackside in TSI"@en ;
                 rdfs:label "GPRS for ETCS"@en ;
                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4639,8 +4652,12 @@ era:hasETCSRestrictionsConditions rdf:type owl:DatatypeProperty ;
                                   <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                                   <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
                                                                       "2024-04-18"^^xsd:date ;
-                                  rdfs:comment "Indication whether restrictions or conditions due to partial compliance with the TSI CCS exist. If not `false`, a link to the conditions must be provided."@en ;
+                                  rdfs:comment """Indication whether restrictions or conditions due to partial compliance with the TSI CCS exist. If not `false`, a link to the conditions must be provided.
+                                  
+These conditions and restrictions of use are considered in section 6.4 of the CCS TSI. They should be described using the template available on Agency website (Certification 
+and deviations – Guidelines for using the ERA template) with the following link: https://www.era.europa.eu/system/files/2022-11/restrictions_and_added_functions_en_1.doc."""@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                  dcterms:source <https://www.era.europa.eu/content/certification-issues>
                                   rdfs:label "Existence of operating restrictions or conditions"@en ;
                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4908,8 +4925,8 @@ era:hasTSITrainDetection rdf:type owl:DatatypeProperty ;
                                        "1.2.1.1.3.1" ;
                          <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
                          <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
-                         rdfs:comment "Indication if there is any train detection system installed and fully compliant with the TSI CCS."@en ;
-                         dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                         rdfs:comment "Indication if there is any train detection system installed and fully compliant with the TSI CCS (Annex A- Index 77)."@en ;
+                         dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Existence of train detection system fully compliant with the TSI"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -5077,7 +5094,7 @@ era:idPhoneErtmsRadioBlockCenter rdf:type owl:DatatypeProperty ;
                                  <http://purl.org/dc/terms/isReplacedBy> era:rbcID ,
                                                                          era:rbcPhone ;
                                  <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                                 rdfs:comment "Unique RBC identification (NID_C+NID_RBC) and calling number (NID_RADIO) as defined in the specification referenced in Appendix A-1, index [C]."@en ;
+                                 rdfs:comment "Unique RBC identification (NID_C+NID_RBC) and calling number (NID_RADIO) as defined in the specification referenced in TSI CCS."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "ID [NNNN NNNN] and phone number [NNNN NNNN NNNN NNNN] of ERTMS/ETCS Radio Block Center"@en ;
                                  owl:deprecated "true"^^xsd:boolean ;
@@ -5114,9 +5131,9 @@ era:imCode rdf:type owl:DatatypeProperty ;
 - In other cases, it corresponds to the "organisation code” assigned by the Agency for the specific needs of the RINF
 Each Section of Line may concern only one IM. """@en ; 
            rdfs:comment """(deprecated) Infrastructure manager means any body or firm responsible in particular for establishing, managing and maintaining railway infrastructure, including traffic management and control-command and signalling; 
-the functions of the infrastructure manager on a network or part of a network may be allocated to different bodies or firms."""@en ;
+the functions of the infrastructure manager on a network or part of a network may be allocated to different bodies or firms. Definition in (Article 3(2))"""@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-	         rdfs:seeAlso "http://data.europa.eu/eli/dir/2012/34/oj (Article 3(2))." ;
+	         rdfs:seeAlso <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02012L0034-20190101#tocId45> ;
            rdfs:label "Infrastructure manager (IM)'s code"@en ;
            owl:deprecated "true"^^xsd:boolean ;
            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -5167,6 +5184,7 @@ era:kilometer rdf:type owl:DatatypeProperty ;
               era:rinfIndex "1.1.1.1.8.12.1" ,
                             "1.1.1.1.8.13.1" ,
                             "1.1.1.3.14.3" ,
+                            "1.1.1.3.14.7" ,
                             "1.2.0.0.0.6" ,
                             "1.2.1.0.5.10.1" ,
                             "1.2.1.0.5.11.1" ,
@@ -5198,6 +5216,7 @@ era:length rdf:type owl:DatatypeProperty ;
            era:XMLName "IPL_Length" ,
                        "IPP_Length" ,
                        "ITU_Length" ,
+                       "SIG_NSTALength" ,
                        "SOLLength" ;
            era:appendixD2Index "2.3.6" ,
                                "3.2.3" ,
@@ -5207,7 +5226,7 @@ era:length rdf:type owl:DatatypeProperty ;
                          "1.1.1.1.8.12.1" ,
                          "1.1.1.1.8.13.1" ,
                          "1.1.1.1.8.7" ,
-                         "1.1.1.3.14.5" ,
+                         "1.1.1.3.14.6" ,
                          "1.2.1.0.5.10.1" ,
                          "1.2.1.0.5.11.1" ,
                          "1.2.1.0.5.5" ,
@@ -5409,7 +5428,7 @@ In https://www.era.europa.eu/domains/technical-specifications-interoperability/c
 Subset 26, chapter 7. 7.5.1.75 M_NVDERUN."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-             dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
              rdfs:label "M_NVDERUN"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5684,7 +5703,7 @@ era:maximumInterferenceCurrent rdf:type owl:DatatypeProperty ;
                                <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                rdfs:comment """Maximum interference current limits allowed for track circuits for a defined frequency band (to be expressed in A/m)."""@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                               dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                               dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                                rdfs:label "maximum interference current"@en ;
                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5700,7 +5719,7 @@ era:maximumInterferenceCurrentEvaluation rdf:type owl:DatatypeProperty ;
 					 rdfs:comment """"If the preferred frequency bands are not used, (mandatory) description of the parameters for evaluation of compliance.
 If the preferred frequency bands are used, this parameter is optional."""@en ;
 					 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                			 dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                			 dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
 					 rdfs:label "Evaluation parameters if maximum interference current is not measured in the preferred bands"@en ;
 					 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5728,7 +5747,7 @@ era:maximumMagneticFieldDirectionX rdf:type owl:DatatypeProperty ;
                                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction X."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                   dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                                   dcterms:source https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
 	  		           dcterms:requires "The maximumMagneticFieldDirectionX parameter is applicable for axle counters." @en ;
                                    rdfs:label "Maximum magnetic field direction X"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -5744,7 +5763,7 @@ era:maximumMagneticFieldDirectionY rdf:type owl:DatatypeProperty ;
                                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction Y."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                   dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                                   dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
 	  		           dcterms:requires "The maximumMagneticFieldDirectionY parameter is applicable for axle counters." @en ;
                                    rdfs:label "Maximum magnetic field direction Y"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -5760,8 +5779,8 @@ era:maximumMagneticFieldDirectionZ rdf:type owl:DatatypeProperty ;
                                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction Z."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                   dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
-	  		           dcterms:requires "The maximumMagneticFieldDirectionZ parameter is applicable for axle counters." @en ;
+                                   dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
+	  		                           dcterms:requires "The maximumMagneticFieldDirectionZ parameter is applicable for axle counters." @en ;
                                    rdfs:label "Maximum magnetic field direction Z"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6015,7 +6034,7 @@ era:minVehicleImpedance rdf:type owl:DatatypeProperty ;
                         <http://purl.org/dc/terms/created> "2021-09-01"^^xsd:date ;
                         <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
                         <http://purl.org/dc/terms/modified> "2024-05-30"^^xsd:date ;
-                        rdfs:comment """Impedance as defined in the specification referenced in Appendix A-1, index [D].
+                        rdfs:comment """Impedance as defined in the TSI CCS (Annex A- Index 77).
 
 Per Voltage:
 [1500]: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
@@ -6273,11 +6292,11 @@ era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty ;
                              <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                              <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
                              rdfs:comment """Set of parameters for adapting the braking curves calculated by the ETCS on-board system to match accuracy, performance and safety margins imposed by the infrastructure manager.
-It copies the content of Packet 3 or of Packet 203 as defined in the specification referenced in Appendix A-1, index [C]."""@en ;
+It copies the content of Packet 3 or of Packet 203 as defined in the specification referenced in TSI CCS (Annex A- Subset-026)."""@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "National Values used for the brake model"@en ;
                              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                             dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -6767,7 +6786,7 @@ In https://www.era.europa.eu/domains/technical-specifications-interoperability/c
 Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES."""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                   dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
+                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                    rdfs:label "Q_NVDRIVER_ADHES"@en ;
                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6788,7 +6807,7 @@ In https://www.era.europa.eu/domains/technical-specifications-interoperability/c
 Subset 26, chapter 7. 7.5.1.124 Q_NVSBTSMPERM."""@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
+                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                  rdfs:label "Q_NVSBTSMPERM"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6811,17 +6830,17 @@ era:radioNetworkId rdf:type owl:DatatypeProperty ;
                    rdfs:domain era:CCSSubsystem ;
                    rdfs:range xsd:string ;
                    era:XMLName "CRG_RadioNID" ;
-		   era:appendixD2Index "3.4.4" ;
+		               era:appendixD2Index "3.4.4" ;
                    era:rinfIndex "1.1.1.3.3.13" ,
                                  "1.2.1.1.2.13" ;
                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                    <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                   rdfs:comment """Unique identification of the GSM-R network the calling mobile station has to register with, as defined in the specification referenced in Appendix A-1, index [C].
+                   rdfs:comment """Unique identification of the GSM-R network the calling mobile station has to register with, as defined in the specification referenced in TSI CCS.
 
 Format: [NNNNNN] with N a decimal number (0÷9)"""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
-                   dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                    rdfs:label "Radio Network ID"@en ;
                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6926,11 +6945,13 @@ era:rbcID rdf:type owl:DatatypeProperty ;
                         "1.2.1.1.1.17" ;
           era:appendixD2Index "3.4.7" ;
           <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ; # sh:regex to be added
-          rdfs:comment "Unique RBC identification (NID_C+NID_RBC) [NNNN NNNN] as defined in the specification referenced in Appendix A-1, index [C]."@en ;
+          rdfs:comment """Unique RBC identification (NID_C+NID_RBC) as defined in the specification referenced in TSI CCS.
+          
+Format: [NNNN NNNN] with N a decimal number (0÷9)"""@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "ERTMS/ETCS Radio Block Center (RBC) identifier"@en ;
           dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-          dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+          dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -6943,11 +6964,13 @@ era:rbcPhone rdf:type owl:DatatypeProperty ;
                            "1.2.1.1.1.17" ;
              era:appendixD2Index "3.4.7" ;
              <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ; # sh:regex to be added
-             rdfs:comment "Unique RBC calling number (NID_RADIO) [NNNN NNNN NNNN NNNN] as defined in the specification referenced in Appendix A-1, index [C]."@en ;
+             rdfs:comment """Unique RBC calling number (NID_RADIO) as defined in the specification referenced in TSI CCS.
+             
+Format: [NNNN NNNN NNNN NNNN] with N a decimal number (0÷9)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "ERTMS/ETCS Radio Block Center (RBC) phone number"@en ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-             dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -7382,11 +7405,13 @@ era:tNvcontact rdf:type owl:DatatypeProperty ;
                                                    "2024-04-18"^^xsd:date ;
                rdfs:comment """Maximum time without a safe message from Radio Block Center before train reacts in seconds. 
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, chapter 7. 7.5.1.148 T_NVCONTACT."""@en ;
+Precision: [NNN], with N a decimal number (0÷9), NNN = 255 means ∞ seconds, so values cannot be higher.
+
+See TSI CCS (Subset 26, chapter 7. 7.5.1.148 T_NVCONTACT)"""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-               dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+               dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+               rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                rdfs:label "T_NVCONTACT"@en ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7405,11 +7430,13 @@ era:tNvovtrp rdf:type owl:DatatypeProperty ;
                                                  "2024-04-18"^^xsd:date ;
              rdfs:comment """Maximum time for overriding the train trip in seconds.
 
+Precision: [NNN], with N a decimal number (0÷9)
+
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-             dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
              rdfs:label "T_NVOVTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7573,7 +7600,7 @@ era:trainDetectionSystemSpecificCheck rdf:type owl:DatatypeProperty ;
                                       rdfs:label "Type of track circuits or axle counters to which specific checks are needed. "@en ;
                                       dcterms:relation era:trainDetectionSystemSpecificCheckDocument ;
                                       dcterms:requires "String containing the name of the TD system for which checks are mentioned in 1.1.1.3.7.1.3." ;
-	                              dcterms:source "According to the specification referenced in Appendix A-1, index [D]"@en ;
+                                      dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                                       owl:deprecated "false"^^xsd:boolean ;
                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7643,7 +7670,7 @@ era:tsiMagneticFields rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Indication whether rules exist and are compliant with the TSI."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Existence and TSI compliance of rules for magnetic fields emitted by a vehicle"@en ;
-                      dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                      dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -7811,7 +7838,7 @@ In https://www.era.europa.eu/domains/technical-specifications-interoperability/c
 Chapter 7. 7.5.1.161"""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                  dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                  dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                   rdfs:label "V_NVALLOWOVTRP"@en ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7833,7 +7860,7 @@ In https://www.era.europa.eu/domains/technical-specifications-interoperability/c
 Subset 26, chapter 7. 7.5.1.163 V_NVSUPOVTRP."""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-                dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                 rdfs:label "V_NVSUPOVTRP"@en ;
                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -8148,7 +8175,7 @@ era:wheelchairSpaces rdf:type owl:DatatypeProperty ;
                                                                  "2.2.2" ;
                                              era:rinfIndex "1.1.0.0.1.1" ,
                                                            "1.1.1.0.1.1" ,
-                                                           "1.1.1.3.14.6" ,
+                                                           "1.1.1.3.14.5" ,
                                                            "1.2.0.0.0.5" ,
                                                            "1.2.1.0.8.5" ;
                                              <http://purl.org/dc/elements/1.1/contributor> "Matthew Perry" ;
@@ -8489,7 +8516,7 @@ It should be provided in 3 directions."""@en ;
 			    	       "1.2.1.1.3.2.3" ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
     	                 dcterms:requires "The MaximumMagneticField class is applicable for axle counters." @en ;
-                         dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                         dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                          rdfs:label "Maximum magnetic field"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -8517,7 +8544,7 @@ era:MinAxleLoadVehicleCategory rdf:type owl:Class ;
 ###  http://data.europa.eu/949/MinVehicleImpedance
 era:MinVehicleImpedance rdf:type owl:Class ;
                         <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                        rdfs:comment """Impedance as defined in the specification referenced in Appendix A-1, index [D].
+                        rdfs:comment """Impedance as defined in the TSI CCS (Annex A- Index 77).
 
 Minimum vehicle impedance (between wheels and pantograph) (only for vehicles equipped for 1500V or 3000V DC).
 
@@ -8525,8 +8552,9 @@ Per Voltage:
 [1500]: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
 [3000]: [CCCC]+[ZZZZ], idem."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-  		        dcterms:requires "The MinVehicleImpedance class is applicable for track circuits." @en ;
-                        dcterms:source "According to the specification referenced in Appendix A-1, index [D]"@en ;
+  		                  dcterms:requires "The MinVehicleImpedance class is applicable for track circuits." @en ;
+                        dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
+
                         rdfs:label "Minimum Vehicle Impedance"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -8618,11 +8646,12 @@ era:PrimaryLocation rdf:type owl:Class ;
                     rdfs:subClassOf era:AggregatedObject ;
                     owl:disjointWith era:RadioBlockCenter ;
                     rdfs:label "Primary Location"@en ;
-                    rdfs:seeAlso """Primary Location is a place used by IM to define a path for a train in TAF/TAP TSI framework/messages. This location is a rail point inside the rail network where train starts, ends, stops, or runs through or change line. This location must be managed by an Infrastructure Manager (IM) identified by company code.
+                    rdfs:comment """Primary Location is a place used by IM to define a path for a train in TAF/TAP TSI framework/messages. This location is a rail point inside the rail network where train starts, ends, stops, or runs through or change line. This location must be managed by an Infrastructure Manager (IM) identified by company code.
 Primary locations are for example: stations, yards, halts, handover points, border points, open access terminals. 
-Primary locations are identified by single and unique Primary Location codes. Primary location code is allocated based on processes defined by national entity. Primary location codes are used in any kind of TAF/TAP communication."""@en ,
-                                 """http://taf-jsg.info/wp-content/uploads/2024/01/20231018-JGS-Handbook-3.4-with-XSD-3.4.0.0.pdf
-9.3.3 / page 60"""@en .
+Primary locations are identified by single and unique Primary Location codes. Primary location code is allocated based on processes defined by national entity. Primary location codes are used in any kind of TAF/TAP communication.
+
+See Handbook 9.3.3 / page 60"""@en ;
+                    rdfs:seeAlso <http://taf-jsg.info/wp-content/uploads/2024/01/20231018-JGS-Handbook-3.4-with-XSD-3.4.0.0.pdf> .
 
 
 ###  http://data.europa.eu/949/RadioBlockCenter
@@ -8632,8 +8661,8 @@ era:RadioBlockCenter rdf:type owl:Class ;
 
 A centralised safety unit that receives train position information via radio and sends movement authorities via radio to trains."""@en ;
                      rdfs:label "Radio Block Center"@en ;
-                     rdfs:seeAlso "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32023R1693&qid=1698394526534"@en ,
-                                  "https://www.era.europa.eu/system/files/2023-09/index003_-_SUBSET-023_v400.pdf"@en .
+                     rdfs:seeAlso <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32023R1693&qid=1698394526534> ,
+                                  <https://www.era.europa.eu/system/files/2023-09/index003_-_SUBSET-023_v400.pdf> .
 
 
 ###  http://data.europa.eu/949/RaisedPantographsDistanceAndSpeed
@@ -8796,7 +8825,7 @@ era:SubsidiaryLocation rdf:type owl:Class ;
                                        ] ;
                        rdfs:comment "Subsidiary location must be linked to a Primary Location and specifies in more detailed way part, attributes, or usage of Primary location. It may be also a non-rail point or a rail point that is not managed by an Infrastructure Manager (IM). It may be defined by entity having company code according to their needs. The Subsidiary location is optional and dependent upon business needs."@en ;
                        rdfs:label "Subsidiary location"@en ;
-                       rdfs:seeAlso "http://taf-jsg.info/wp-content/uploads/2024/01/20231018-JGS-Handbook-3.4-with-XSD-3.4.0.0.pdf" .
+                       rdfs:seeAlso <http://taf-jsg.info/wp-content/uploads/2024/01/20231018-JGS-Handbook-3.4-with-XSD-3.4.0.0.pdf> .
 
 
 ###  http://data.europa.eu/949/Switch
@@ -8807,7 +8836,7 @@ era:Switch rdf:type owl:Class ;
            <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/776/oj> ;
            rdfs:comment "A unit of track comprising two fixed rails (stock rails) and two movable rails (switch rails) used to direct vehicles from one track to another track."@en ;
            rdfs:label "Switch"@en ;
-           rdfs:seeAlso "http://data.europa.eu/eli/reg/2014/1299/2019-06-16" ;
+           rdfs:seeAlso <http://data.europa.eu/eli/reg/2014/1299/2019-06-16> ;
            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -9054,7 +9083,7 @@ era:minVehicleImpedance era:eratvIndex "4.14.2.17" ;
                         rdfs:comment """
 [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
 """@en ,
-                                     """Impedance as defined in the specification referenced in Appendix A-1, index [D].
+                                     """Impedance as defined in the TSI CCS (Annex A- Index 77).
 
 Minimum vehicle impedance (between wheels and pantograph) (only for vehicles equipped for 1500V or 3000V DC).
 
@@ -9168,7 +9197,7 @@ basic geo vocab
 
 <http://www.w3.org/2003/01/geo/wgs84_pos#location> era:rinfIndex "1.1.0.0.1.1" ,
                                                                  "1.1.1.0.1.1" ,
-                                                                 "1.1.1.3.14.6" ,
+                                                                 "1.1.1.3.14.5" ,
                                                                  "1.2.0.0.0.5" ,
                                                                  "1.2.1.0.8.5" ;
                                                    era:usedInRCCCalculations "true"^^xsd:boolean ;

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -442,6 +442,7 @@ era:atoSystemVersion rdf:type owl:ObjectProperty ;
                      <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                      <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                      rdfs:comment "ATO system version according to the specification referenced in Appendix A-1, index [C]."@en ;
+                     dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "ATO System version"@en ;
                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -499,7 +500,7 @@ era:cantDeficiencyBasicSSP rdf:type owl:ObjectProperty ;
                            rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                            era:appendixD3Index "1.3" ;
                            era:inSkosConceptScheme <http://data.europa.eu/949/concepts/cant-deficiencies/CantDeficiencies> ;
-                           era:XMLName: "CPE_SSPUsesCantDef" ;
+                           era:XMLName "CPE_SSPUsesCantDef" ;
 		   	                   era:appendixD3Index "1.3" ;
                            era:rinfIndex "1.1.1.3.2.14" ,
                                          "1.2.1.1.1.14" ;
@@ -512,7 +513,7 @@ Subset-026 (3.11.3.2.1.1) definition:
 a) The “Cant Deficiency” SSP categories: the cant deficiency value assigned to one category shall define the maximum speed, determined by suspension design, at which a particular train can traverse a curve and thus can be used to set a specific speed limit in a curve with regards to this category.
 """@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                           rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                           dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                            dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                            rdfs:label "cant deficiency used for the basic SSP"@en ;
                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -686,7 +687,7 @@ era:dataRadioCompatible rdf:type owl:ObjectProperty ;
 
 Information on RSC data requirements per country:                        
 https://www.era.europa.eu/era-folder/radio-system-compatibility-rsc-voice-and-data-documents"""@en ;
-                        rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                        dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
                         dcterms:source "https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf" ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Radio system compatibility data"@en ;
@@ -983,17 +984,17 @@ era:etcsLevelType rdf:type owl:ObjectProperty ;
                   <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
                   <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date , "2024-04-18"^^xsd:date ;
                   rdfs:comment "European Train Control System (ETCS) application level related to the track side equipment."@en ;
-		              dcterms:relation era:etcsBaseline ;
-		              dcterms:description """The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
-
+		  dcterms:relation era:etcsBaseline ;
+		  dcterms:description """The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
+	
 Level definitions are principally related to the track side equipment used, to the way the track side information reaches the on-board units and to which functions are processed in the track side and in the on-board equipment respectively."""@en
-		              dcterms:requires """If ETCS is on the trackside (‘N’ is not selected), all other ETCS parameters (from 1.1.1.3.2.2 to 1.1.1.3.2.10) are applicable.
-
+		  dcterms:requires """If ETCS is on the trackside (one or more levels are selected), all other ETCS parameters (from 1.1.1.3.2.2 to 1.1.1.3.2.10) are applicable.
+	
 The ETCS value NTC is only relevant when the line is dual equipped with ETCS (i.e., balises are placed in the track) and Class B system, and both systems are in operation at the same time. 
 In those cases, this parameter should be filled relevant ETCS Level and repeated with the value “NTC”.
-
-If the line is only equipped with Class B, this should be reflected in Parameter 1.1.1.3.5.3, and this parameter should be set to “N”. """@en ; 
-		              dcterms:source "http://data.europa.eu/eli/reg_impl/2023/1695/oj (TSI CCS, SRS Chapter 2, 2.6)"@en ; 
+	
+If the line is only equipped with Class B, this should be reflected in Parameter 1.1.1.3.5.3, and this parameter etcsLevelType should not be used. """@en ; 
+		  dcterms:source "http://data.europa.eu/eli/reg_impl/2023/1695/oj (TSI CCS, SRS Chapter 2, 2.6)"@en ; 
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "ETCS level"@en ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1013,7 +1014,7 @@ era:etcsMVersion rdf:type owl:ObjectProperty ;
                  rdfs:comment "ETCS M_version according to the specification referenced in Appendix A-1, index [C]."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS M_version"@en ;
-                 rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                 dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                  dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -1060,7 +1061,7 @@ In https://www.era.europa.eu/domains/technical-specifications-interoperability/c
 Chapter 5, section 5.18.1.1."""@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Track conditions which can be transmitted"@en ;
-                                   rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ; 
+                                   dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ; 
                                    dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
@@ -1232,7 +1233,7 @@ Please select ”1” or “2”, taking into account that TSI compliant trains 
 """@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Number of active GSM-R mobiles (EDOR) or simultaneous communication session on-board for ETCS Level 2 needed to perform radio block centre handovers without having an operational disruption"@en ;
-                      rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                      dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
                       dcterms:relation era:etcsLevelType ;
                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -1253,7 +1254,7 @@ era:gsmRAdditionalInfo rdf:type owl:ObjectProperty ;
                        dcterms:description """Please use this field to indicate any additional information on the GSM-R network. 
 
 The document(s) itself has(have) to be upload by the NRE via the “reference document management” functionality. The reference of the document(s) is(are) provided as (a) link(s)."""@en ;
-                       rdfs:requires "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable"@en ;
+                       dcterms:requires "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable"@en ;
                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
                        <http://www.w3.org/2004/02/skos/core#changeNote> "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
@@ -1293,7 +1294,7 @@ In case there is a balise used to announce the change of the network, or if ther
 (*11) Please use this field to indicate any additional information on network characteristics, e.g.; interference level, leading to the need of additional on-board protection; areas where GPRS for ETCS can be used;
 """ @en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                          rdfs:requires "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable"@en ;
+                          dcterms:requires "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable"@en ;
                           rdfs:label "Optional GSM-R functions"@en ;
                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -1333,7 +1334,7 @@ era:gsmRVersion rdf:type owl:ObjectProperty ;
                 rdfs:comment """GSM-R functional requirements specification and system requirements specification in accordance with the specification respectively referenced in Appendix A-1, index [E] and index [F], version number installed lineside.
                 
 Since more than one version may be installed in different areas, this property can have multiple values."""@en ;
-                rdfs:requires "GSM-R must be installed for this parameter to be applicable"@en ;
+                dcterms:requires "GSM-R must be installed for this parameter to be applicable. If this property is not used, all GSM-R related properties should not be used either."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "GSM-R version"@en ;
                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1351,7 +1352,7 @@ era:gsmrConstraintsOperateOnlyInCircuitSwitch rdf:type owl:ObjectProperty ;
                                               <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                               rdfs:comment """These constraints, where applicable, are meant to manage the limited number of circuit-switched radio connections that can be handled simultaneously by a Radio Block Center."""@en ;
                                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                              rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable.
+                                              dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable.
 Multiple values are allowed."""@en ;
                                               rdfs:label "Specific constraints imposed by the GSM-R network operator on ETCS on-board units only able to operate in circuit-switch"@en ;
                                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1369,7 +1370,7 @@ era:gsmrNetworkCoverage rdf:type owl:ObjectProperty ;
                         <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
                         <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
                         rdfs:comment "List of GSM-R networks which are covered by a roaming agreement."@en ;
-                        rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
+                        dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
                         dcterms:description """Name of the own GSM-R network and list of GSM-R networks which are covered by a roaming agreement for CS services. 
 This list is managed by UIC. The Agency will monitor it in order to update the list of possible values when necessary. 
 For Route Compatibility purposes and simplicity, the own network needs to be declared by the IM, so the RUs can systematically check the compatibility.
@@ -1727,7 +1728,7 @@ era:mNvcontact rdf:type owl:ObjectProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.74 M_NVCONTACT."""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-               rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+               dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                rdfs:label "M_NVCONTACT"@en ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
@@ -1844,22 +1845,6 @@ era:minVehicleImpedance rdf:type owl:ObjectProperty ;
                                                   )
                                     ] ;
                         rdfs:range era:MinVehicleImpedance .
-
-
-###  http://data.europa.eu/949/minVehicleImpedanceVoltages
-era:minVehicleImpedanceVoltages rdf:type owl:ObjectProperty ;
-                                rdfs:domain era:MinVehicleImpedance ;
-                                rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
-                                era:XMLName "CCD_TCVehicleImpedance" ;
-                                era:inSkosConceptScheme <http://data.europa.eu/949/concepts/energy-supply-systems/EnergySupplySystems> ;
-                                era:rinfIndex "1.1.1.3.4.2.2" ,
-                                              "1.2.1.1.3.2.2" ;
-                                era:usedInRCCCalculations "true"^^xsd:boolean ;
-                                <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                                rdfs:comment "Voltages with which the vehicles are equipped, if the parameter minVehicleImpedance is applicable."@en ;
-                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                rdfs:label "minimum Vehicle Impedance (Voltage applicable)"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/nationalLine
@@ -2068,16 +2053,18 @@ era:osmClass rdf:type owl:ObjectProperty ;
              <http://www.w3.org/2004/02/skos/core#definition> "Additional concept class according to OpenStreetMap."@en .
 		 
 
-###  http://data.europa.eu/949/minVehicleImpedanceVoltages
+###  http://data.europa.eu/949/minVehicleImpedanceVoltages - 1
 era:minVehicleImpedanceVoltages rdf:type owl:ObjectProperty ;
                               rdfs:domain era:MinVehicleImpedance ;
                               rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                               era:XMLName "CCD_TCVehicleImpedance" ;
                               era:inSkosConceptScheme <http://data.europa.eu/949/concepts/energy-supply-systems/EnergySupplySystems> ;
-                              era:rinfIndex "1.1.1.3.4.2.2" , "1.2.1.1.3.2.2" ;
+                              era:rinfIndex "1.1.1.3.4.2.2" , 
+					    "1.2.1.1.3.2.2" ;
                               era:usedInRCCCalculations "true"^^xsd:boolean ;
                               <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                              rdfs:comment "If the parameter minVehicleImpedance is applicable (track circuits), indication of the ENE voltage system valid for the minimal impedance value."@en ;
+                              rdfs:comment "Indication of the voltage system valid for the minimal impedance value (track circuits)."@en ;
+			      dcterms:requires "The parameter minVehicleImpedanceVoltages is applicable for track circuits." ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                               rdfs:label "minimum Vehicle Impedance (Voltage applicable)"@en ;
@@ -2102,7 +2089,7 @@ b) The “other specific” SSP categories: it groups all other specific SSP cat
 """@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 dcterms:relation era:cantDeficiencyBasicSSP ;
-                                rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                                dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;               
                                 rdfs:label "Other Cant Deficiency train categories for which the ETCS trackside is configured to provide SSP"@en ;
                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
@@ -2392,7 +2379,7 @@ In https://www.era.europa.eu/domains/technical-specifications-interoperability/c
 Subset 26, Chapter 5 5.4 Procedure start of mission."""@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Reasons for which an ETCS Radio Block Center can reject a train"@en ;
-                                      rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                                      dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                                       dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
@@ -2449,7 +2436,7 @@ era:safeConsistLengthInformationNecessary rdf:type owl:ObjectProperty ;
                                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                           rdfs:label "Safe consist length information from on-board necessary for access the line and SIL"@en ;
                                           dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
-                                          rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                                          dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -2573,6 +2560,7 @@ era:minVehicleImpedance rdf:type owl:ObjectProperty ;
 Verification of compliance with TSI includes application of notified national rules (when they exist)."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+			dcterms:requires "The parameter minVehicleImpedance is applicable for track circuits."
                         rdfs:label "minimum vehicle impedance"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
                         <http://www.w3.org/2004/02/skos/core#altLabel> "Minimum vehicle impedance"@en .
@@ -2947,7 +2935,8 @@ era:trainDetectionSystemSpecificCheckDocument rdf:type owl:ObjectProperty ;
                                               rdfs:comment "Electronic document from the IM stored by the Agency with precise values in accordance with TSI CCS Article 13 and the specification referenced in Appendix A-1, index [D], for the specific check to be performed for train detection systems identified in parameter \"\"Type of track circuits or axle counters to which specific checks are needed\"."@en ;
                                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                               rdfs:label "Document with the procedure(s) related to the type of train detection systems declared in 1.1.1.3.7.1.2 or 1.2.1.1.6.1"@en ;
-                                              dcterms:requires "The document itself has to be upload by the NRE via the “reference document management” functionality. The reference of the document is provided for the parameter using the characterstring format."@en
+                                              dcterms:requires "The document itself has to be upload by the NRE via the “reference document management” functionality. The reference of the document is provided for the parameter using the characterstring format."@en ;
+		                              dcterms:source "According to the specification referenced in Appendix A-1, index [D]"@en ;
                                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
                                               <http://www.w3.org/2004/02/skos/core#changeNote> "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
@@ -3269,7 +3258,7 @@ This concept scheme is temporatily non-deferenceable.
 Information on RSC voice requirements per country:                        
 https://www.era.europa.eu/era-folder/radio-system-compatibility-rsc-voice-and-data-documents"""@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                         rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable.
+                         dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable.
 In case of RSC-EU-0 or None, no other values are allowed."""@en ;
                          dcterms:source "https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf" ;
                          rdfs:label "Radio system compatibility voice"@en ;
@@ -3487,7 +3476,7 @@ era:bigMetalMass rdf:type owl:DatatypeProperty ;
                  <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date , "2024-04-18"^^xsd:date ;
                  rdfs:comment "Indication of existence of metal mass in the vicinity of the location, susceptible of perturbating the reading of balises by the on-board system."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                 rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                 dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                  dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                  rdfs:label "Big Metal Mass"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -3771,7 +3760,7 @@ era:dNvovtrp rdf:type owl:DatatypeProperty ;
 In Subset 26, chapter 7. 7.5.1.15 D_NVOVTRP.
 https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+             dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
              dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
              rdfs:label "D_NVOVTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -3794,7 +3783,7 @@ era:dNvpotrp rdf:type owl:DatatypeProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.16 D_NVPOTRP."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+             dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
              dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
              rdfs:label "D_NVPOTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -3817,7 +3806,7 @@ era:dNvroll rdf:type owl:DatatypeProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.17 D_NVROLL."""@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-            rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+            dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
             dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
             rdfs:label "D_NVROLL"@en ;
             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -4073,7 +4062,7 @@ era:energyMeterInstalled rdf:type owl:DatatypeProperty ;
                          rdfs:label "Energy meter installed"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
-<###  http://data.europa.eu/949/minVehicleInputImpedance
+###  http://data.europa.eu/949/minVehicleInputImpedance
 era:minVehicleInputImpedance rdf:type owl:DatatypeProperty ;
                               rdfs:domain era:MinVehicleImpedance ;
                               rdfs:range xsd:double ;
@@ -4085,6 +4074,7 @@ era:minVehicleInputImpedance rdf:type owl:DatatypeProperty ;
                               <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
                               rdfs:comment "For the selected DC voltage: [ZZZZ], as input impedance [ZZZZ](Zin)"@en ;
                               dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+	  		      dcterms:requires "The minVehicleInputImpedance parameter is applicable for track circuits." @en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "minimal vehicle input impedance"@en ;
                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -4101,6 +4091,7 @@ era:minVehicleInputCapacitance rdf:type owl:DatatypeProperty ;
                                 <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
                                 rdfs:comment "For the selected DC voltage: [CCCC], as input capacitance [CCCC](Cin)"@en ;
                                 dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+	  		        dcterms:requires "The minVehicleInputCapacitance parameter is applicable for track circuits." @en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "minimal vehicle input capacitance"@en ;
                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -4201,7 +4192,7 @@ era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty ;
                                          rdfs:comment "If the trackside does not implement any solution to cover defective LXs (which are normally protected by means of a technical system), then drivers will be required to comply with instructions received from other sources."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "ETCS trackside implements level crossing procedure or an equivalent solution"@en ;
-                                         rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                                         dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                                          dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
                                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4312,7 +4303,7 @@ era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty ;
                                  rdfs:comment """If the trackside does not provide Track Conditions, the driver will need to be informed about such conditions via alternative methods."""@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Is the ETCS trackside engineered to transmit Track Conditions"@en ;
-                                 rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ; 
+                                 dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ; 
                                  dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4435,7 +4426,7 @@ era:gprsForETCS rdf:type owl:DatatypeProperty ;
                 <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                 <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
                 rdfs:comment "Indication if GPRS can be used for ETCS."@en ;
-                rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
                 dcterms:relation era:etcsLevelType ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 dcterms:source "Sections of EIRENE and ETCS subsets for trackside in TSI"@en ; 
@@ -4454,7 +4445,7 @@ era:gprsImplementationArea rdf:type owl:DatatypeProperty ;
                            <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date  ;
                            rdfs:comment "Indication of the area in which GPRS can be used for ETCS, expressed as a list of GPRS-enabled RBC's."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                           rdfs:requires """GSM-R (parameter 1.1.1.3.3.1), ETCS L2 (parameter 1.1.1.3.2.1) and GPRS for ETCS (parameter 1.1.1.3.3.3.2) must be installed for this parameter to be applicable."""@en ;
+                           dcterms:requires """GSM-R (parameter 1.1.1.3.3.1), ETCS L2 (parameter 1.1.1.3.2.1) and GPRS for ETCS (parameter 1.1.1.3.3.3.2) must be installed for this parameter to be applicable."""@en ;
                            rdfs:label "Area of implementation of GPRS"@en ;
                            dcterms:relation era:etcsLevelType , era:gprsForETCS ;
                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -4503,7 +4494,7 @@ era:gsmRNoCoverage rdf:type owl:DatatypeProperty ;
                    <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
                    <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
                    rdfs:comment "Indication if there is no GSMR coverage."@en ;
-                   rdfs:requires "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."@en ;
+                   dcterms:requires "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."@en ;
                    dcterms:description """If GSM-R is not installed, this parameter should not be used.
 This parameter is mainly to capture the case of Radio Hole functionality (lack of GSM-R coverage), that is foreseen in the ETCS specifications as packet 68. 
 Another possible use is the declaration of a temporary situation where, although the area is in principle covered by GSM-R, there is a long-term outage or a project for replacement of the radio (i.e. a section that will not be covered with GSM-R for half a year or longer)."""@en ;
@@ -4554,7 +4545,7 @@ era:gsmrForcedDeregistrationFunctionalNumber rdf:type owl:DatatypeProperty ;
                                              rdfs:comment "This feature will condition the applicable operational rules for drivers and signallers when dealing with cab radios registered under wrong numbers."@en ;
                                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                              rdfs:label "Is the GSM-R network configured to allow forced de-registration of a functional number by another driver?"@en ;
-                                             rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                                             dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
                                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -4918,6 +4909,7 @@ era:hasTSITrainDetection rdf:type owl:DatatypeProperty ;
                          <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
                          <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
                          rdfs:comment "Indication if there is any train detection system installed and fully compliant with the TSI CCS."@en ;
+                         dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Existence of train detection system fully compliant with the TSI"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -5416,7 +5408,7 @@ era:mNvderun rdf:type owl:DatatypeProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.75 M_NVDERUN."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+             dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
              dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
              rdfs:label "M_NVDERUN"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -5553,9 +5545,10 @@ era:maxImpedanceWheelset rdf:type owl:DatatypeProperty ;
                          era:rinfIndex "1.1.1.3.7.15.2" ;
                          <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                          <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
-                         rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. The value of maximum permitted impedance given in ohm in case of TSI non-compliance."@en ;
+                         rdfs:comment "The value of maximum permitted impedance given in ohm in case of TSI non-compliance. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Maximum permitted impedance between opposite wheels of a wheelset when not TSI compliant"@en ;
+                         owl:deprecated "true"^^xsd:boolean ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -5698,18 +5691,18 @@ era:maximumInterferenceCurrent rdf:type owl:DatatypeProperty ;
 
 ###  http://data.europa.eu/949/maximumInterferenceCurrentEvaluation
 era:maximumInterferenceCurrentEvaluation rdf:type owl:DatatypeProperty ;
-								rdfs:domain era:TrainDetectionSystem ;
-								rdfs:range xsd:string ;
-                era:XMLName "CCD_IInterferenceMax" ;
-								era:rinfIndex "1.1.1.3.4.2.1" ,
-										     	    "1.2.1.1.3.2.1" ;
-								<http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
-								rdfs:comment """"If the preferred frequency bands are not used, (mandatory) description of the parameters for evaluation of compliance.
-                If the preferred frequency bands are used, this parameter is optional."""@en ;
-								rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
-								rdfs:label "Evaluation parameters if maximum interference current is not measured in the preferred bands"@en ;
-								<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+					 rdfs:domain era:TrainDetectionSystem ;
+					 rdfs:range xsd:string ;
+                			 era:XMLName "CCD_IInterferenceMax" ;
+					 era:rinfIndex "1.1.1.3.4.2.1" ,
+					       	       "1.2.1.1.3.2.1" ;
+					 <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
+					 rdfs:comment """"If the preferred frequency bands are not used, (mandatory) description of the parameters for evaluation of compliance.
+If the preferred frequency bands are used, this parameter is optional."""@en ;
+					 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                			 dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+					 rdfs:label "Evaluation parameters if maximum interference current is not measured in the preferred bands"@en ;
+					 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/maximumLocomotivesCoupled
@@ -5736,6 +5729,7 @@ era:maximumMagneticFieldDirectionX rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction X."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+	  		           dcterms:requires "The maximumMagneticFieldDirectionX parameter is applicable for axle counters." @en ;
                                    rdfs:label "Maximum magnetic field direction X"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5751,6 +5745,7 @@ era:maximumMagneticFieldDirectionY rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction Y."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+	  		           dcterms:requires "The maximumMagneticFieldDirectionY parameter is applicable for axle counters." @en ;
                                    rdfs:label "Maximum magnetic field direction Y"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5766,6 +5761,7 @@ era:maximumMagneticFieldDirectionZ rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction Z."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+	  		           dcterms:requires "The maximumMagneticFieldDirectionZ parameter is applicable for axle counters." @en ;
                                    rdfs:label "Maximum magnetic field direction Z"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6033,36 +6029,6 @@ Per Voltage:
                         <http://www.w3.org/2004/02/skos/core#altLabel> "Minimum vehicle impedance"@en .
 
 
-###  http://data.europa.eu/949/minVehicleInputCapacitance
-era:minVehicleInputCapacitance rdf:type owl:DatatypeProperty ;
-                               rdfs:domain era:MinVehicleImpedance ;
-                               rdfs:range xsd:double ;
-                               era:rinfIndex "1.1.1.3.4.2.2" ,
-                                             "1.2.1.1.3.2.2" ;
-                               era:unitOfMeasure <https://qudt.org/vocab/unit/NanoFARAD> ;
-                               era:usedInRCCCalculations "true"^^xsd:boolean ;
-                               <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                               rdfs:comment "For the selected DC voltage: [CCCC], as input capacitance [CCCC](Cin)"@en ;
-                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                               rdfs:label "minimal vehicle input capacitance"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
-
-
-###  http://data.europa.eu/949/minVehicleInputImpedance
-era:minVehicleInputImpedance rdf:type owl:DatatypeProperty ;
-                             rdfs:domain era:MinVehicleImpedance ;
-                             rdfs:range xsd:double ;
-                             era:rinfIndex "1.1.1.3.4.2.2" ,
-                                           "1.2.1.1.3.2.2" ;
-                             era:unitOfMeasure <https://qudt.org/vocab/unit/MilliH> ;
-                             era:usedInRCCCalculations "true"^^xsd:boolean ;
-                             <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                             rdfs:comment "For the selected DC voltage: [ZZZZ], as input impedance [ZZZZ](Zin)"@en ;
-                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                             rdfs:label "minimal vehicle input impedance"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
-
-
 ###  http://data.europa.eu/949/minWheelDiameter
 era:minWheelDiameter rdf:type owl:DatatypeProperty ;
                      rdfs:domain [ rdf:type owl:Class ;
@@ -6310,7 +6276,7 @@ era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty ;
 It copies the content of Packet 3 or of Packet 203 as defined in the specification referenced in Appendix A-1, index [C]."""@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "National Values used for the brake model"@en ;
-                             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                             dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                              dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6761,7 +6727,7 @@ era:publicNetworkRoaming rdf:type owl:DatatypeProperty ;
 In case of Y, provide the name of the public network(s) under parameter \"Details on GSM-R roaming to public networks\"."""@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Existence of GSM-R roaming to public networks"@en ;
-                         rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
+                         dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
                          dcterms:relation era:publicNetworkRoamingDetails ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6782,7 +6748,7 @@ era:publicNetworkRoamingDetails rdf:type owl:DatatypeProperty ;
 3. also add if there is any operational restriction for vehicles that cannot roam into any of the available public networks."""@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Details on GSM-R roaming to public networks"@en ;
-                                rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
+                                dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -6800,7 +6766,7 @@ era:qNvdriverAdhes rdf:type owl:DatatypeProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES."""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                   rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                   dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                    dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
                    rdfs:label "Q_NVDRIVER_ADHES"@en ;
                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -6821,7 +6787,7 @@ era:qNvsbtsmperm rdf:type owl:DatatypeProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.124 Q_NVSBTSMPERM."""@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                 rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                 dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                  dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
                  rdfs:label "Q_NVSBTSMPERM"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -6845,14 +6811,17 @@ era:radioNetworkId rdf:type owl:DatatypeProperty ;
                    rdfs:domain era:CCSSubsystem ;
                    rdfs:range xsd:string ;
                    era:XMLName "CRG_RadioNID" ;
-		               era:appendixD2Index "3.4.4" ;
+		   era:appendixD2Index "3.4.4" ;
                    era:rinfIndex "1.1.1.3.3.13" ,
                                  "1.2.1.1.2.13" ;
                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                    <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                   rdfs:comment "Unique identification of the GSM-R network the calling mobile station has to register with, as defined in the specification referenced in Appendix A-1, index [C]."@en ;
+                   rdfs:comment """Unique identification of the GSM-R network the calling mobile station has to register with, as defined in the specification referenced in Appendix A-1, index [C].
+
+Format: [NNNNNN] with N a decimal number (0÷9)"""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                   rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
+                   dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
+                   dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                    rdfs:label "Radio Network ID"@en ;
                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6960,7 +6929,7 @@ era:rbcID rdf:type owl:DatatypeProperty ;
           rdfs:comment "Unique RBC identification (NID_C+NID_RBC) [NNNN NNNN] as defined in the specification referenced in Appendix A-1, index [C]."@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "ERTMS/ETCS Radio Block Center (RBC) identifier"@en ;
-          rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+          dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
           dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6977,7 +6946,7 @@ era:rbcPhone rdf:type owl:DatatypeProperty ;
              rdfs:comment "Unique RBC calling number (NID_RADIO) [NNNN NNNN NNNN NNNN] as defined in the specification referenced in Appendix A-1, index [C]."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "ERTMS/ETCS Radio Block Center (RBC) phone number"@en ;
-             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+             dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
              dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7416,7 +7385,7 @@ era:tNvcontact rdf:type owl:DatatypeProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.148 T_NVCONTACT."""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-               rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+               dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                rdfs:label "T_NVCONTACT"@en ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -7439,7 +7408,7 @@ era:tNvovtrp rdf:type owl:DatatypeProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+             dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
              dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
              rdfs:label "T_NVOVTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -7599,11 +7568,12 @@ era:trainDetectionSystemSpecificCheck rdf:type owl:DatatypeProperty ;
                                       <http://purl.org/dc/terms/created> "2020-08-24"^^xsd:date ;
                                       <http://purl.org/dc/terms/modified> "2021-08-08"^^xsd:date ,
                                                                           "2024-04-18"^^xsd:date ;
-                                      rdfs:comment "Reference to the technical specification of train detection system, in accordance with the specification referenced in Appendix A-1, index [D]."@en ;
+                                      rdfs:comment "Reference to the technical specification of train detection system."@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Type of track circuits or axle counters to which specific checks are needed. "@en ;
                                       dcterms:relation era:trainDetectionSystemSpecificCheckDocument ;
                                       dcterms:requires "String containing the name of the TD system for which checks are mentioned in 1.1.1.3.7.1.3." ;
+	                              dcterms:source "According to the specification referenced in Appendix A-1, index [D]"@en ;
                                       owl:deprecated "false"^^xsd:boolean ;
                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7673,6 +7643,7 @@ era:tsiMagneticFields rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Indication whether rules exist and are compliant with the TSI."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Existence and TSI compliance of rules for magnetic fields emitted by a vehicle"@en ;
+                      dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -7816,7 +7787,7 @@ era:usesGroup555 rdf:type owl:DatatypeProperty ;
                  <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
                  <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date;
                  rdfs:comment "Indication if group 555 is used."@en ;
-                 rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                 dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
                  dcterms:relation era:etcsLevelType ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "GSM-R use of group 555"@en ;
@@ -7839,7 +7810,7 @@ era:vNvallowovtrp rdf:type owl:DatatypeProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Chapter 7. 7.5.1.161"""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                  rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                   dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                   rdfs:label "V_NVALLOWOVTRP"@en ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -7861,7 +7832,7 @@ era:vNvsupovtrp rdf:type owl:DatatypeProperty ;
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.163 V_NVSUPOVTRP."""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                 rdfs:label "V_NVSUPOVTRP"@en ;
                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -8513,7 +8484,12 @@ era:MaximumMagneticField rdf:type owl:Class ;
                          <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                          rdfs:comment """The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band.
 It should be provided in 3 directions."""@en ;
+		         era:XMLName "CCD_ACMagFieldMax" ;
+		         era:rinfIndex "1.1.1.3.4.2.3" ,
+			    	       "1.2.1.1.3.2.3" ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+    	                 dcterms:requires "The MaximumMagneticField class is applicable for axle counters." @en ;
+                         dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                          rdfs:label "Maximum magnetic field"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -8549,6 +8525,8 @@ Per Voltage:
 [1500]: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
 [3000]: [CCCC]+[ZZZZ], idem."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+  		        dcterms:requires "The MinVehicleImpedance class is applicable for track circuits." @en ;
+                        dcterms:source "According to the specification referenced in Appendix A-1, index [D]"@en ;
                         rdfs:label "Minimum Vehicle Impedance"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -44,7 +44,7 @@ Revision 18-04-2024:
 - updated as per results of the Topical Working Group RINF-CCS (Draft report 0.2);
 - include upcoming remarks from TWG members (inclusing those as documented in Report 0.3);
 - linked with existing (updated) or new SKOS Concepts, related to the TWG RINF CCS;
-- included references and guidelines as in Table 5 of the RINF Applicatoin Guide.
+- included references and guidelines as in Table 5 of the RINF Application Guide.
 					  
 							  """@en ;
                               <http://purl.org/dc/terms/issued> "2024-04-18"^^xsd:date ;
@@ -496,13 +496,13 @@ era:borderPointOf rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/cantDeficiencyBasicSSP
-era:cantDeficiencyBasicSSP rdf:type owl:ObjectProperty ;
+era:cantDeficiencyBasicSSP rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                            rdfs:domain era:CCSSubsystem ;
                            rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                            era:appendixD3Index "1.3" ;
                            era:inSkosConceptScheme <http://data.europa.eu/949/concepts/cant-deficiencies/CantDeficiencies> ;
                            era:XMLName "CPE_SSPUsesCantDef" ;
-		   	                   era:appendixD3Index "1.3" ;
+		   	   era:appendixD3Index "1.3" ;
                            era:rinfIndex "1.1.1.3.2.14" ,
                                          "1.2.1.1.1.14" ;
                            <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -874,7 +874,7 @@ era:errorCorrectionsOnboard rdf:type owl:ObjectProperty ;
                             era:rinfIndex "1.1.1.3.1.2" ,
                                           "1.2.1.1.1.19" ;
                             <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
-                            rdfs:comment "List of unacceptable errors impacting operation on the network that are required to be solved in the on-board (ETCS, GSM-R and/or ATO) according to the CCS TSI point 7.2.10.3 specification maintenance point. An additional string must document if a non-implemented CR has been accpted by the IM."@en ;
+                            rdfs:comment "List of unacceptable errors impacting the IM network that are required to be solved in the on-board according to the TSI CCS point 7.2.10.3 specification maintenance point (ETCS, GSM-R and/or ATO). An additional parameter (era:errorCorrectionsOnboardExplanation) must document if a non-implemented CR has been accepted by the IM."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Error corrections required for the on-board ETCS, GSM-R and/or ATO function"@en ;
                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -899,7 +899,7 @@ era:etcsBaseline rdf:type owl:ObjectProperty ;
                                                      "2024-04-18"^^xsd:date ;
                  rdfs:comment "ETCS baseline installed lineside - TSI CCS (Table A2)"@en ;
                  rdfs:label "ETCS baseline"@en ;
-		             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
+		 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS baseline"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -919,6 +919,14 @@ era:etcsDegradedSituation rdf:type owl:ObjectProperty ;
                                                               "2024-04-18"^^xsd:date ;
                           <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                           rdfs:comment "ERTMS / ETCS application level for degraded situation related to the track side equipment."@en ;
+			  dcterms:description """System for degraded situation. See also TSI OPE 4.2.3.6. Degraded operation.
+
+In case of failure of the ETCS Level for normal operation, train movement can be supervised in another ETCS Level. 
+Example: Level 1 as a degraded mode for Level 2.
+
+If parameter 1.1.1.3.2.1 is not used (no ETCS), no degradation is possible, so only ‘none’ level is possible for degraded case."""@en ;
+	                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present). Degraded level must be lower than actual operating level."@en ;
+		 	  dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> , <http://data.europa.eu/eli/reg_impl/2019/773/2023-09-28> ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "ETCS level for degraded situation"@en ;
                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1005,7 +1013,7 @@ If the line is only equipped with Class B, this should be reflected in Parameter
 
 
 ###  http://data.europa.eu/949/etcsMVersion
-era:etcsMVersion rdf:type owl:ObjectProperty ;
+era:etcsMVersion rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                  rdfs:domain era:CCSSubsystem ;
                  rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                  era:XMLName "CPE_MVersion" ;
@@ -1016,10 +1024,11 @@ era:etcsMVersion rdf:type owl:ObjectProperty ;
                  <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                  <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
                  rdfs:comment "ETCS M_version according to SRS 7.5.1.9."@en ;
+	     	 rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS M_version"@en ;
                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-		             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
+		 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -1052,7 +1061,7 @@ The ESC Types shall only be used when published with status ‘Valid’ in the A
 
 
 ###  http://data.europa.eu/949/etcsTransmittedTrackConditions
-era:etcsTransmittedTrackConditions rdf:type owl:ObjectProperty ;
+era:etcsTransmittedTrackConditions rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                                    rdfs:domain era:CCSSubsystem ;
                                    rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                                    era:XMLName "CPE_TransmittedTCs" ;
@@ -1065,10 +1074,10 @@ era:etcsTransmittedTrackConditions rdf:type owl:ObjectProperty ;
                                                                        "2023-04-18"^^xsd:date ;
                                    rdfs:comment """Transmittable track conditions by the CCSSubsystem, as per CCS TSI.
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Chapter 5, section 5.18.1.1."""@en ;
+See TSI CCS (Subset-026, Chapter 5, section 5.18.1.1)"""@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Track conditions which can be transmitted"@en ;
+		 	           rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                    dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ; 
                                    dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
@@ -1163,7 +1172,7 @@ era:frequencyBandsForDetection rdf:type owl:ObjectProperty ;
                                              "1.2.1.1.3.2" ;
                                <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                               rdfs:comment "Bands of the frequency management of the train detection systems as defined in the TSI CCS (Annex A- Index 77), and in the specific cases or technical documents referred to in Article 13 of TSI CCS when they are available."@en ;
+                               rdfs:comment "Bands of the frequency management of the train detection systems as defined in the TSI CCS (Annex I, Appendix A, Table A.2 -Index 77), and in the specific cases or technical documents referred to in Article 13 of TSI CCS when they are available."@en ;
                                dcterms:description """Verification of compliance with TSI includes application of notified national rules (when they exist).
 
 Multiple selection from a predefined list:
@@ -1224,7 +1233,7 @@ era:gaugingTransversalDocument rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/gsmRActiveMobiles
-era:gsmRActiveMobiles rdf:type owl:ObjectProperty ;
+era:gsmRActiveMobiles rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                       rdfs:domain era:CCSSubsystem ;
                       rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                       era:XMLName "CRG_NumActiveMob" ;
@@ -1721,7 +1730,7 @@ era:lrsMethod rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/mNvcontact
-era:mNvcontact rdf:type owl:ObjectProperty ;
+era:mNvcontact rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                rdfs:domain era:CCSSubsystem ;
                rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                era:XMLName "CPE_MNVCONTACT" ;
@@ -1734,9 +1743,9 @@ era:mNvcontact rdf:type owl:ObjectProperty ;
                                                    "2024-04-18"^^xsd:date ;
                rdfs:comment """On-Board system reaction when T_NVCONTACT expires.
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, chapter 7. 7.5.1.74 M_NVCONTACT."""@en ;
+See TSI CCS (Subset-026, chapter 7. 7.5.1.74 M_NVCONTACT)"""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+	       rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                rdfs:label "M_NVCONTACT"@en ;
@@ -2081,7 +2090,7 @@ era:minVehicleImpedanceVoltages rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/otherCantDeficiencyBasicSSP
-era:otherCantDeficiencyBasicSSP rdf:type owl:ObjectProperty ;
+era:otherCantDeficiencyBasicSSP rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                                 rdfs:domain era:CCSSubsystem ;
                                 rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                                 era:XMLName "CPE_OtherCantDef" ;
@@ -2121,7 +2130,7 @@ era:otherPantographHead rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/otherTrainProtection
-era:otherTrainProtection rdf:type owl:ObjectProperty ;
+era:otherTrainProtection rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                          rdfs:domain era:CCSSubsystem ;
                          rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                          era:XMLName "CLD_OtherProtectControlWarn" ;
@@ -2133,6 +2142,10 @@ era:otherTrainProtection rdf:type owl:ObjectProperty ;
                          <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                              "2024-04-18"^^xsd:date ;
                          rdfs:comment "Indication of existence of other system than ETCS for degraded situation."@en ;
+			 dcterms:description "Selected value shall answer the question whether any other system than ETCS exists on the respective track. The list is in line with ERA/TD/2011-09/INT (v1.13), Table 3."@en ;
+		 	 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> , <http://data.europa.eu/eli/reg_impl/2019/773/2023-09-28> ;
+			 rdfs:seeAlso <https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf> ;
+	                 dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Other train protection, control and warning systems for degraded situation"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -2315,7 +2328,7 @@ era:protectionLegacySystem rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/qNvemrrls
-era:qNvemrrls rdf:type owl:ObjectProperty ;
+era:qNvemrrls rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
               rdfs:domain era:CCSSubsystem ;
               rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
               era:XMLName "CPE_QNVEMRRLS" ;
@@ -2369,7 +2382,7 @@ era:railInclination rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/reasonsEtcsRadioBlockCenterReject
-era:reasonsEtcsRadioBlockCenterReject rdf:type owl:ObjectProperty ;
+era:reasonsEtcsRadioBlockCenterReject rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                                       rdfs:domain era:CCSSubsystem ;
                                       rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                                       era:XMLName "CPE_RBCRejectReasons" ;
@@ -2430,7 +2443,7 @@ Passenger train fire category in accordance with point 4.1.4 of TSI LOC&PAS."""@
 
 
 ###  http://data.europa.eu/949/safeConsistLengthInformationNecessary
-era:safeConsistLengthInformationNecessary rdf:type owl:ObjectProperty ;
+era:safeConsistLengthInformationNecessary rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                                           rdfs:domain era:CCSSubsystem ;
                                           rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                                           era:XMLName "CPE_SafeConsistLength" ;
@@ -2441,6 +2454,7 @@ era:safeConsistLengthInformationNecessary rdf:type owl:ObjectProperty ;
                                           <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                           rdfs:comment """Indication whether safe consist train length information from on-board is required to access the line for safety reasons and the required safety integrity level."""@en ;
                                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+	   				  rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                           rdfs:label "Safe consist length information from on-board necessary for access the line and SIL"@en ;
                                           dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                                           dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
@@ -2562,7 +2576,7 @@ era:minVehicleImpedance rdf:type owl:ObjectProperty ;
                         era:rinfIndex "1.1.1.3.4.2.2" ,
                                       "1.2.1.1.3.2.2" ;
                         <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                        rdfs:comment """Per voltage: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin) as defined in TSI CCS (Annex A- Index 77).
+                        rdfs:comment """Per voltage: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin) as defined in TSI CCS (Annex I, Appendix A, Table A.2 -Index 77).
                         
 Verification of compliance with TSI includes application of notified national rules (when they exist)."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -2939,7 +2953,7 @@ era:trainDetectionSystemSpecificCheckDocument rdf:type owl:ObjectProperty ;
                                               <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
                                                                                   "2024-04-18"^^xsd:date ,
                                                                                   "2024-04-23"^^xsd:date ;
-                                              rdfs:comment "Electronic document from the IM stored by the Agency with precise values in accordance with TSI CCS (Article 13 and Annex A, Index 77), for the specific check to be performed for train detection systems identified in parameter \"\"Type of track circuits or axle counters to which specific checks are needed\"."@en ;
+                                              rdfs:comment "Electronic document from the IM stored by the Agency with precise values in accordance with TSI CCS (Article 13 and Annex I, Appendix A, Table A.2, Index 77), for the specific check to be performed for train detection systems identified in parameter \"\"Type of track circuits or axle counters to which specific checks are needed\"."@en ;
                                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                               rdfs:label "Document with the procedure(s) related to the type of train detection systems declared in 1.1.1.3.7.1.2 or 1.2.1.1.6.1"@en ;
                                               dcterms:requires "The document itself has to be upload by the NRE via the “reference document management” functionality. The reference of the document is provided for the parameter using the characterstring format."@en ;
@@ -2965,12 +2979,9 @@ era:trainDetectionSystemType rdf:type owl:ObjectProperty ;
                              <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
                              <http://purl.org/dc/terms/modified> "2021-08-07"^^xsd:date , "2024-04-18"^^xsd:date;
                              rdfs:comment "Indication of types of train detection systems installed. "@en ;
-                             dcterms:requires """Applicable: 
-- N for 1.1.1.3.7.1.1 will trigger “N” for parameters 1.1.1.3.7.1.2 to 1.1.1.3.7.23.
-- NYA for 1.1.1.3.7.1.1 will trigger NYA for parameters 1.1.1.3.7.1.2 to 1.1.1.3.7.23.
-
-If this parameter is repeated, parameters 1.1.1.3.7.2 to 1.1.1.3.7.23 shall be created also for the corresponding type. 
-These parameters are to be considered children of the current. But not all parameters are applicable to all types of train detection systems; it depends on the applicability condition."""@en ;
+			     dcterms:description """Explanation on data presentation: 
+The option of ‘wheel detector’ has to be also selected for: wheel sensor for axle counter, pedal or treadle."""@en ;
+                             dcterms:requires """Not all parameters are applicable to all types of train detection systems; it depends on the applicability condition."""@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Type of train detection system"@en ;
                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -3472,7 +3483,7 @@ era:axleSpacing rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/bigMetalMass
-era:bigMetalMass rdf:type owl:DatatypeProperty ;
+era:bigMetalMass rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                  rdfs:domain era:CCSSubsystem ;
                  rdfs:range xsd:boolean ;
                  era:XMLName "CPE_BigMetalMass" ;
@@ -3751,7 +3762,7 @@ era:currentlyValid rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/dNvovtrp
-era:dNvovtrp rdf:type owl:DatatypeProperty ;
+era:dNvovtrp rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
              rdfs:domain era:CCSSubsystem ;
              rdfs:range xsd:number ;
              era:XMLName "CPE_DNVOVTRP" ;
@@ -3766,8 +3777,7 @@ era:dNvovtrp rdf:type owl:DatatypeProperty ;
 
 Precision: [NNNNNN.N] with N a decimal number (0÷9) 
 
-In Subset 26, chapter 7. 7.5.1.15 D_NVOVTRP.
-https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632."""@en ;
+In Subset 26, chapter 7. 7.5.1.15 D_NVOVTRP."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -3776,7 +3786,7 @@ https://www.era.europa.eu/domains/technical-specifications-interoperability/cont
 
 
 ###  http://data.europa.eu/949/dNvpotrp
-era:dNvpotrp rdf:type owl:DatatypeProperty ;
+era:dNvpotrp rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
              rdfs:domain era:CCSSubsystem ;
              rdfs:range xsd:number ;
              era:XMLName "CPE_DNVPOTRP" ;
@@ -3801,7 +3811,7 @@ See: TSI CCS (Subset 26, chapter 7. 7.5.1.16 D_NVPOTRP)"""@en ;
 
 
 ###  http://data.europa.eu/949/dNvroll
-era:dNvroll rdf:type owl:DatatypeProperty ;
+era:dNvroll rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
             rdfs:domain era:CCSSubsystem ;
             rdfs:range xsd:number ;
             era:XMLName "CPE_DNVROLL" ;
@@ -3816,11 +3826,11 @@ era:dNvroll rdf:type owl:DatatypeProperty ;
 
 Precision: [NNNNNN.N], with N a decimal number (0÷9).
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, chapter 7. 7.5.1.17 D_NVROLL."""@en ;
+See: TSI CCS (Subset 26, chapter 7. 7.5.1.17 D_NVROLL)"""@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+	    rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
             rdfs:label "D_NVROLL"@en ;
             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4194,16 +4204,18 @@ era:etcsErrorCorrectionsOnboard rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/etcsImplementsLevelCrossingProcedure
-era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty ;
+era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                                          rdfs:domain era:CCSSubsystem ;
                                          rdfs:range xsd:boolean ;
                                          era:XMLName "CPE_LXProcedure" ;
                                          era:appendixD3Index "1.2" ;
-                                         era:rinfIndex "1.1.1.3.2.13" , # HERE
+                                         era:rinfIndex "1.1.1.3.2.13" ,
                                                        "1.2.1.1.1.13" ;
                                          <http://purl.org/dc/terms/created> "2022-11-04"^^xsd:date ;
+                                 	 <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                          rdfs:comment "If the trackside does not implement any solution to cover defective LXs (which are normally protected by means of a technical system), then drivers will be required to comply with instructions received from other sources."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+	    				 rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                          rdfs:label "ETCS trackside implements level crossing procedure or an equivalent solution"@en ;
                                          dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                                          dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -4303,7 +4315,7 @@ era:etcsSystemFunctionalitiesNextFiveYears rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/etcsTransmitsTrackConditions
-era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty ;
+era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                                  rdfs:domain era:CCSSubsystem ;
                                  rdfs:range xsd:boolean ;
                                  era:XMLName "CPE_CanTransmitTCs" ;
@@ -4315,6 +4327,7 @@ era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty ;
                                                                      "2024-04-18"^^xsd:date ;
                                  rdfs:comment """If the trackside does not provide Track Conditions, the driver will need to be informed about such conditions via alternative methods."""@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+	     			 rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                  rdfs:label "Is the ETCS trackside engineered to transmit Track Conditions"@en ;
                                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ; 
                                  dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -4430,7 +4443,7 @@ era:gaugingCheckLocation rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/gprsForETCS
-era:gprsForETCS rdf:type owl:DatatypeProperty ;
+era:gprsForETCS rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                 rdfs:domain era:CCSSubsystem ;
                 rdfs:range xsd:boolean ;
                 era:XMLName "CRG_GPRSForETCS" ;
@@ -4499,7 +4512,7 @@ era:gradientProfile rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/gsmRNoCoverage
-era:gsmRNoCoverage rdf:type owl:DatatypeProperty ;
+era:gsmRNoCoverage rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                    rdfs:domain era:CCSSubsystem ;
                    rdfs:range xsd:boolean ;
                    era:XMLName "CRG_GSMRNoCoverage" ;
@@ -4546,7 +4559,7 @@ The reason for deprecation is that this parameter does not appear in the latest 
 
 
 ###  http://data.europa.eu/949/gsmrForcedDeregistrationFunctionalNumber
-era:gsmrForcedDeregistrationFunctionalNumber rdf:type owl:DatatypeProperty ;
+era:gsmrForcedDeregistrationFunctionalNumber rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                                              rdfs:domain era:CCSSubsystem ;
                                              rdfs:range xsd:boolean ;
                                              era:XMLName "CRG_ForcedDeReg" ;
@@ -4556,7 +4569,7 @@ era:gsmrForcedDeregistrationFunctionalNumber rdf:type owl:DatatypeProperty ;
                                              <http://purl.org/dc/terms/created> "2022-11-07"^^xsd:date ;
                                              <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ,
                                                                                  "2024-04-18"^^xsd:date ;
-                                             rdfs:comment "This feature will condition the applicable operational rules for drivers and signallers when dealing with cab radios registered under wrong numbers."@en ;
+                                             rdfs:comment "This feature will determine the applicable operational rules for drivers and signallers when dealing with cab radios registered under wrong numbers."@en ;
                                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                              rdfs:label "Is the GSM-R network configured to allow forced de-registration of a functional number by another driver?"@en ;
                                              dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
@@ -4918,7 +4931,7 @@ era:hasSystemSeparation rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/hasTSITrainDetection
-era:hasTSITrainDetection rdf:type owl:DatatypeProperty ;
+era:hasTSITrainDetection rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                          rdfs:domain era:CCSSubsystem ;
                          rdfs:range xsd:boolean ;
                          era:XMLName "CCD_TSITrainDetection" ;
@@ -4926,7 +4939,7 @@ era:hasTSITrainDetection rdf:type owl:DatatypeProperty ;
                                        "1.2.1.1.3.1" ;
                          <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
                          <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
-                         rdfs:comment "Indication if there is any train detection system installed and fully compliant with the TSI CCS (Annex A- Index 77)."@en ;
+                         rdfs:comment "Indication if there is any train detection system installed and fully compliant with the TSI CCS (Annex I, Appendix A, Table A.2 -Index 77)."@en ;
                          dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Existence of train detection system fully compliant with the TSI"@en ;
@@ -5413,7 +5426,7 @@ era:localRulesOrRestrictions rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/mNvderun
-era:mNvderun rdf:type owl:DatatypeProperty ;
+era:mNvderun rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
              rdfs:domain era:CCSSubsystem ;
              rdfs:range xsd:boolean ;
              era:XMLName "CPE_MNVDERUN" ;
@@ -5425,10 +5438,10 @@ era:mNvderun rdf:type owl:DatatypeProperty ;
                                                  "2023-04-18"^^xsd:date ;
              rdfs:comment """Entry of Driver ID permitted while running. 
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, chapter 7. 7.5.1.75 M_NVDERUN."""@en ;
+See: TSI CCS (Subset 26, chapter 7. 7.5.1.75 M_NVDERUN)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
+	     rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
              rdfs:label "M_NVDERUN"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -5710,14 +5723,14 @@ era:maximumInterferenceCurrent rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/maximumInterferenceCurrentEvaluation
-era:maximumInterferenceCurrentEvaluation rdf:type owl:DatatypeProperty ;
+era:maximumInterferenceCurrentEvaluation rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
 					 rdfs:domain era:TrainDetectionSystem ;
 					 rdfs:range xsd:string ;
                 			 era:XMLName "CCD_IInterferenceMax" ;
 					 era:rinfIndex "1.1.1.3.4.2.1" ,
 					       	       "1.2.1.1.3.2.1" ;
 					 <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
-					 rdfs:comment """"If the preferred frequency bands are not used, (mandatory) description of the parameters for evaluation of compliance.
+					 rdfs:comment """If the preferred frequency bands are not used, (mandatory) description of the parameters for evaluation of compliance.
 If the preferred frequency bands are used, this parameter is optional."""@en ;
 					 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 			 dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
@@ -5739,7 +5752,7 @@ era:maximumLocomotivesCoupled rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/maximumMagneticFieldDirectionX
-era:maximumMagneticFieldDirectionX rdf:type owl:DatatypeProperty ;
+era:maximumMagneticFieldDirectionX rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                                    rdfs:domain era:MaximumMagneticField ;
                                    rdfs:range xsd:integer ;
                                    era:XMLName "CCD_ACMagFieldMax" ;
@@ -5755,7 +5768,7 @@ era:maximumMagneticFieldDirectionX rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/maximumMagneticFieldDirectionY
-era:maximumMagneticFieldDirectionY rdf:type owl:DatatypeProperty ;
+era:maximumMagneticFieldDirectionY rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                                    rdfs:domain era:MaximumMagneticField ;
                                    rdfs:range xsd:integer ;
                                    era:XMLName "CCD_ACMagFieldMax" ;
@@ -5771,7 +5784,7 @@ era:maximumMagneticFieldDirectionY rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/maximumMagneticFieldDirectionZ
-era:maximumMagneticFieldDirectionZ rdf:type owl:DatatypeProperty ;
+era:maximumMagneticFieldDirectionZ rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                                    rdfs:domain era:MaximumMagneticField ;
                                    rdfs:range xsd:integer ;
                                    era:XMLName "CCD_ACMagFieldMax" ;
@@ -5787,7 +5800,7 @@ era:maximumMagneticFieldDirectionZ rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/maximumPermittedSpeed
-era:maximumPermittedSpeed rdf:type owl:DatatypeProperty ;
+era:maximumPermittedSpeed rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                           rdfs:domain era:InfraSubsystem ;
                           rdfs:range xsd:integer ;
                           era:XMLName "IPP_MaxSpeed" ;
@@ -6035,7 +6048,7 @@ era:minVehicleImpedance rdf:type owl:DatatypeProperty ;
                         <http://purl.org/dc/terms/created> "2021-09-01"^^xsd:date ;
                         <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
                         <http://purl.org/dc/terms/modified> "2024-05-30"^^xsd:date ;
-                        rdfs:comment """Impedance as defined in the TSI CCS (Annex A- Index 77).
+                        rdfs:comment """Impedance as defined in the TSI CCS (Annex I, Appendix A, Table A.2 -Index 77).
 
 Per Voltage:
 [1500]: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
@@ -6283,17 +6296,17 @@ era:nationalRollingStockFireCategory rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/nationalValuesBrakeModel
-era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty ;
+era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                              rdfs:domain era:CCSSubsystem ;
                              rdfs:range xsd:string ;
                              era:XMLName "CPE_NVBRAKEMOD" ;
-			                       era:appendixD3index "1.5.13" ;
+			     era:appendixD3index "1.5.13" ;
                              era:rinfIndex "1.1.1.3.2.16.13" ,
                                            "1.2.1.1.1.16.13" ;
                              <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                              <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
                              rdfs:comment """Set of parameters for adapting the braking curves calculated by the ETCS on-board system to match accuracy, performance and safety margins imposed by the infrastructure manager.
-It copies the content of Packet 3 or of Packet 203 as defined in the specification referenced in TSI CCS (Annex A- Subset-026)."""@en ;
+It copies the content of Packet 3 or of Packet 203 as defined in the specification referenced in TSI CCS (Annex I, Appendix A, Table A.2 -Subset-026)."""@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "National Values used for the brake model"@en ;
                              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
@@ -6735,7 +6748,7 @@ era:prmAccessibleToilets rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/publicNetworkRoaming
-era:publicNetworkRoaming rdf:type owl:DatatypeProperty ;
+era:publicNetworkRoaming rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                          rdfs:domain era:CCSSubsystem ;
                          rdfs:range xsd:boolean ;
                          era:XMLName "CRG_RoamingPublic" ;
@@ -6753,7 +6766,7 @@ In case of Y, provide the name of the public network(s) under parameter \"Detail
 
 
 ###  http://data.europa.eu/949/publicNetworkRoamingDetails
-era:publicNetworkRoamingDetails rdf:type owl:DatatypeProperty ;
+era:publicNetworkRoamingDetails rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                                 rdfs:domain era:CCSSubsystem ;
                                 rdfs:range xsd:string ;
                                 era:XMLName "CRG_RoamingPublicDetails" ;
@@ -6773,7 +6786,7 @@ era:publicNetworkRoamingDetails rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/qNvdriverAdhes
-era:qNvdriverAdhes rdf:type owl:DatatypeProperty ;
+era:qNvdriverAdhes rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                    rdfs:domain era:CCSSubsystem ;
                    rdfs:range xsd:boolean ;
                    era:XMLName "CPE_QNVDRIVERADHES" ;
@@ -6783,17 +6796,17 @@ era:qNvdriverAdhes rdf:type owl:DatatypeProperty ;
                    <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
                    rdfs:comment """Boolean determining whether the driver is allowed to modify the adhesion factor used by the ETCS on-board to calculate the braking curves. 
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES."""@en ;
+See TSI CCS (Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES)"""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                    dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+		   rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                    rdfs:label "Q_NVDRIVER_ADHES"@en ;
                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/qNvsbtsmperm
-era:qNvsbtsmperm rdf:type owl:DatatypeProperty ;
+era:qNvsbtsmperm rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                  rdfs:domain era:CCSSubsystem ;
                  rdfs:range xsd:boolean ;
                  era:XMLName "CPE_QNVSBTSMPERM" ;
@@ -6804,9 +6817,9 @@ era:qNvsbtsmperm rdf:type owl:DatatypeProperty ;
                  <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                  rdfs:comment """Permission to use service brake in target speed monitoring.
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, chapter 7. 7.5.1.124 Q_NVSBTSMPERM."""@en ;
+See TSI CCS (Subset-026, chapter 7. 7.5.1.124 Q_NVSBTSMPERM)"""@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+	         rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                  dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                  rdfs:label "Q_NVSBTSMPERM"@en ;
@@ -6838,7 +6851,7 @@ era:radioNetworkId rdf:type owl:DatatypeProperty ;
                    <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                    rdfs:comment """Unique identification of the GSM-R network the calling mobile station has to register with, as defined in the specification referenced in TSI CCS.
 
-Format: [NNNNNN] with N a decimal number (0÷9)"""@en ;
+Format: [NNNNNN] with N a decimal number (0÷9)(sh:minCount 1)."""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    dcterms:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
                    dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -6938,7 +6951,7 @@ The raised pantographs distance and speed is  the indication of maximum number o
 
 
 ###  http://data.europa.eu/949/rbcID
-era:rbcID rdf:type owl:DatatypeProperty ;
+era:rbcID rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
           rdfs:domain era:RadioBlockCenter ;
           rdfs:range xsd:string ;
           era:XMLName "CPE_IDRBC" ;
@@ -6957,7 +6970,7 @@ Format: [NNNN NNNN] with N a decimal number (0÷9)"""@en ;
 
 
 ###  http://data.europa.eu/949/rbcPhone
-era:rbcPhone rdf:type owl:DatatypeProperty ;
+era:rbcPhone rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
              rdfs:domain era:RadioBlockCenter ;
              rdfs:range xsd:string ;
              era:XMLName "CPE_PHONERBC" ;
@@ -7393,7 +7406,7 @@ The system separation info is the Indication of required several information on 
 
 
 ###  http://data.europa.eu/949/tNvcontact
-era:tNvcontact rdf:type owl:DatatypeProperty ;
+era:tNvcontact rdf:type owl:DatatypeProperty, owl:FunctionalProperty ;
                rdfs:domain era:CCSSubsystem ;
                rdfs:range xsd:integer ;
                era:XMLName "CPE_TNVCONTACT" ;
@@ -7408,7 +7421,7 @@ era:tNvcontact rdf:type owl:DatatypeProperty ;
 
 Precision: [NNN], with N a decimal number (0÷9), NNN = 255 means ∞ seconds, so values cannot be higher.
 
-See TSI CCS (Subset 26, chapter 7. 7.5.1.148 T_NVCONTACT)"""@en ;
+See: TSI CCS (Subset 26, chapter 7. 7.5.1.148 T_NVCONTACT)"""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -7418,7 +7431,7 @@ See TSI CCS (Subset 26, chapter 7. 7.5.1.148 T_NVCONTACT)"""@en ;
 
 
 ###  http://data.europa.eu/949/tNvovtrp
-era:tNvovtrp rdf:type owl:DatatypeProperty ;
+era:tNvovtrp rdf:type owl:DatatypeProperty, owl:FunctionalProperty ;
              rdfs:domain era:CCSSubsystem ;
              rdfs:range xsd:integer ;
              era:XMLName "CPE_TNVOVTRP" ;
@@ -7433,11 +7446,11 @@ era:tNvovtrp rdf:type owl:DatatypeProperty ;
 
 Precision: [NNN], with N a decimal number (0÷9)
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP."""@en ;
+See TSI CCS (Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+	     rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              rdfs:label "T_NVOVTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7804,7 +7817,7 @@ era:uopid rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/usesGroup555
-era:usesGroup555 rdf:type owl:DatatypeProperty ;
+era:usesGroup555 rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                  rdfs:domain era:CCSSubsystem ;
                  rdfs:range xsd:boolean ;
                  era:XMLName "CRG_Needof555" ;
@@ -7823,7 +7836,7 @@ era:usesGroup555 rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/vNvallowovtrp
-era:vNvallowovtrp rdf:type owl:DatatypeProperty ;
+era:vNvallowovtrp rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                   rdfs:domain era:CCSSubsystem ;
                   rdfs:range xsd:integer ;
                   era:XMLName "CPE_VNVALLOWOVTRP" ;
@@ -7835,17 +7848,19 @@ era:vNvallowovtrp rdf:type owl:DatatypeProperty ;
                   <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
                   rdfs:comment """Speed limit allowing the driver to select the “override” function in km/h.
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Chapter 7. 7.5.1.161"""@en ;
+Format: [NNF], with N a decimal number (0÷9), F=(0|5), max. `600`.
+
+See: TSI CCS (Subset-026, Chapter 7. 7.5.1.161)"""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
+	          rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                   rdfs:label "V_NVALLOWOVTRP"@en ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/vNvsupovtrp
-era:vNvsupovtrp rdf:type owl:DatatypeProperty ;
+era:vNvsupovtrp rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                 rdfs:domain era:CCSSubsystem ;
                 rdfs:range xsd:integer ;
                 era:XMLName "CPE_VNVSUPOVTRP" ;
@@ -7857,9 +7872,11 @@ era:vNvsupovtrp rdf:type owl:DatatypeProperty ;
                 <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
                 rdfs:comment """Override speed limit to be supervised when the “override” function is active in km/h.
 
-In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
-Subset 26, chapter 7. 7.5.1.163 V_NVSUPOVTRP."""@en ;
+Format: [NNF], with N a decimal number (0÷9), F=(0|5), max. `600`.
+
+See: TSI CCS (Subset-026, chapter 7. 7.5.1.163 V_NVSUPOVTRP)"""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+	        rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                 dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                 rdfs:label "V_NVSUPOVTRP"@en ;
@@ -8545,7 +8562,7 @@ era:MinAxleLoadVehicleCategory rdf:type owl:Class ;
 ###  http://data.europa.eu/949/MinVehicleImpedance
 era:MinVehicleImpedance rdf:type owl:Class ;
                         <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                        rdfs:comment """Impedance as defined in the TSI CCS (Annex A- Index 77).
+                        rdfs:comment """Impedance as defined in the TSI CCS (Annex I, Appendix A, Table A.2 -Index 77).
 
 Minimum vehicle impedance (between wheels and pantograph) (only for vehicles equipped for 1500V or 3000V DC).
 
@@ -9084,7 +9101,7 @@ era:minVehicleImpedance era:eratvIndex "4.14.2.17" ;
                         rdfs:comment """
 [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
 """@en ,
-                                     """Impedance as defined in the TSI CCS (Annex A- Index 77).
+                                     """Impedance as defined in the TSI CCS (Annex I, Appendix A, Table A.2 -Index 77).
 
 Minimum vehicle impedance (between wheels and pantograph) (only for vehicles equipped for 1500V or 3000V DC).
 

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -43,7 +43,8 @@ Revision 24-05-2024:
 Revision 18-04-2024:
 - updated as per results of the Topical Working Group RINF-CCS (Draft report 0.2);
 - include upcoming remarks from TWG members (inclusing those as documented in Report 0.3);
-- linked with existing (updated) or new SKOS Concepts, related to the TWG RINF CCS
+- linked with existing (updated) or new SKOS Concepts, related to the TWG RINF CCS;
+- included references and guidelines as in Table 5 of the RINF Applicatoin Guide.
 					  
 							  """@en ;
                               <http://purl.org/dc/terms/issued> "2024-04-18"^^xsd:date ;
@@ -4657,7 +4658,7 @@ era:hasETCSRestrictionsConditions rdf:type owl:DatatypeProperty ;
 These conditions and restrictions of use are considered in section 6.4 of the CCS TSI. They should be described using the template available on Agency website (Certification 
 and deviations – Guidelines for using the ERA template) with the following link: https://www.era.europa.eu/system/files/2022-11/restrictions_and_added_functions_en_1.doc."""@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                  dcterms:source <https://www.era.europa.eu/content/certification-issues>
+                                  dcterms:source <https://www.era.europa.eu/content/certification-issues> ;
                                   rdfs:label "Existence of operating restrictions or conditions"@en ;
                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5747,8 +5748,8 @@ era:maximumMagneticFieldDirectionX rdf:type owl:DatatypeProperty ;
                                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction X."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                   dcterms:source https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
-	  		           dcterms:requires "The maximumMagneticFieldDirectionX parameter is applicable for axle counters." @en ;
+                                   dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
+	  		                           dcterms:requires "The maximumMagneticFieldDirectionX parameter is applicable for axle counters."@en ;
                                    rdfs:label "Maximum magnetic field direction X"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5764,7 +5765,7 @@ era:maximumMagneticFieldDirectionY rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction Y."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
-	  		           dcterms:requires "The maximumMagneticFieldDirectionY parameter is applicable for axle counters." @en ;
+	  		                           dcterms:requires "The maximumMagneticFieldDirectionY parameter is applicable for axle counters." @en ;
                                    rdfs:label "Maximum magnetic field direction Y"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -664,8 +664,13 @@ era:dataRadioCompatible rdf:type owl:ObjectProperty ;
                         era:rinfIndex "1.1.1.3.3.10" ,
                                       "1.2.1.1.2.10" ;
                         <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
-                        <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
-                        rdfs:comment "Radio requirements used for demonstrating technical compatibility data."@en ;
+                        <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
+                        rdfs:comment """Radio requirements used for demonstrating technical compatibility data.
+
+Information on RSC data requirements per country:                        
+https://www.era.europa.eu/era-folder/radio-system-compatibility-rsc-voice-and-data-documents"""@en ;
+                        rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                        dcterms:source "https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf" ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Radio system compatibility data"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1209,7 +1214,7 @@ Please select ”1” or “2”, taking into account that TSI compliant trains 
 """@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Number of active GSM-R mobiles (EDOR) or simultaneous communication session on-board for ETCS Level 2 needed to perform radio block centre handovers without having an operational disruption"@en ;
-                      rdfs:requires """GSM-R and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                      rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
                       dcterms:relation era:etcsLevelType ;
                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -1230,7 +1235,7 @@ era:gsmRAdditionalInfo rdf:type owl:ObjectProperty ;
                        dcterms:description """Please use this field to indicate any additional information on the GSM-R network. 
 
 The document(s) itself has(have) to be upload by the NRE via the “reference document management” functionality. The reference of the document(s) is(are) provided as (a) link(s)."""@en ;
-                       rdfs:requires "GSM-R must be installed for this parameter to be applicable"@en ;
+                       rdfs:requires "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable"@en ;
                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
                        <http://www.w3.org/2004/02/skos/core#changeNote> "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
@@ -1270,7 +1275,7 @@ In case there is a balise used to announce the change of the network, or if ther
 (*11) Please use this field to indicate any additional information on network characteristics, e.g.; interference level, leading to the need of additional on-board protection; areas where GPRS for ETCS can be used;
 """ @en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                          rdfs:requires "GSM-R must be installed for this parameter to be applicable"@en ;
+                          rdfs:requires "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable"@en ;
                           rdfs:label "Optional GSM-R functions"@en ;
                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -1322,12 +1327,13 @@ era:gsmrConstraintsOperateOnlyInCircuitSwitch rdf:type owl:ObjectProperty ;
                                               era:XMLName "CRG_ConstraintsCS" ;
                                               era:appendixD3Index "2.2" ;
                                               era:inSkosConceptScheme <http://data.europa.eu/949/concepts/gsmr-cs-constraints/GSMRConstraints> ;
-                                              era:rinfIndex "1.2.1.1.2.12" ;
+                                              era:rinfIndex "1.1.1.3.3.12" , "1.2.1.1.2.12" ;
                                               <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                               <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                               rdfs:comment """These constraints, where applicable, are meant to manage the limited number of circuit-switched radio connections that can be handled simultaneously by a Radio Block Center."""@en ;
                                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                              rdfs:requires "GSM-R must be installed for this parameter to be applicable"@en ;
+                                              rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable.
+Multiple values are allowed."""@en ;
                                               rdfs:label "Specific constraints imposed by the GSM-R network operator on ETCS on-board units only able to operate in circuit-switch"@en ;
                                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -1344,6 +1350,12 @@ era:gsmrNetworkCoverage rdf:type owl:ObjectProperty ;
                         <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
                         <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
                         rdfs:comment "List of GSM-R networks which are covered by a roaming agreement."@en ;
+                        rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
+                        dcterms:description """Name of the own GSM-R network and list of GSM-R networks which are covered by a roaming agreement for CS services. 
+This list is managed by UIC. The Agency will monitor it in order to update the list of possible values when necessary. 
+For Route Compatibility purposes and simplicity, the own network needs to be declared by the IM, so the RUs can systematically check the compatibility.
+For voice services, roaming for CS is applicable.  For ETCS, as long as roaming for CS is ensured, the interoperability will be guaranteed.""" @en ;
+
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "GSM-R networks covered by a roaming agreement"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -3170,10 +3182,18 @@ era:voiceRadioCompatible rdf:type owl:ObjectProperty ;
                          era:rinfIndex "1.1.1.3.3.9" ,
                                        "1.2.1.1.2.9" ;
                          <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
-                         <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
+                         <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
                          rdfs:comment """Radio requirements used for demonstrating technical compatibility voice.
- The allowed values for this property belong to the SKOS Concept Scheme http://data.europa.eu/949/concepts/voice-radio-system-compatibilities/VoiceRadioSystemCompatibilities. This concept scheme is temporatily non-deferenceable."""@en ;
+
+The allowed values for this property belong to the SKOS Concept Scheme http://data.europa.eu/949/concepts/voice-radio-system-compatibilities/VoiceRadioSystemCompatibilities. 
+This concept scheme is temporatily non-deferenceable.
+ 
+Information on RSC voice requirements per country:                        
+https://www.era.europa.eu/era-folder/radio-system-compatibility-rsc-voice-and-data-documents"""@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                         rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable.
+In case of RSC-EU-0 or None, no other values are allowed."""@en ;
+                         dcterms:source "https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf" ;
                          rdfs:label "Radio system compatibility voice"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4306,7 +4326,8 @@ era:gprsForETCS rdf:type owl:DatatypeProperty ;
                 <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                 <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
                 rdfs:comment "Indication if GPRS can be used for ETCS."@en ;
-                rdfs:requires """GSM-R and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                dcterms:relation era:etcsLevelType ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 dcterms:source "Sections of EIRENE and ETCS subsets for trackside in TSI"@en ; 
                 rdfs:label "GPRS for ETCS"@en ;
@@ -4324,8 +4345,9 @@ era:gprsImplementationArea rdf:type owl:DatatypeProperty ;
                            <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date  ;
                            rdfs:comment "Indication of the area in which GPRS can be used for ETCS, expressed as a list of GPRS-enabled RBC's."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                           rdfs:requires """GSM-R, ETCS L2 (parameter 1.1.1.3.2.1) and GPRS for ETCS (parameter 1.1.1.3.3.3.2) must be installed for this parameter to be applicable."""@en ;
+                           rdfs:requires """GSM-R (parameter 1.1.1.3.3.1), ETCS L2 (parameter 1.1.1.3.2.1) and GPRS for ETCS (parameter 1.1.1.3.3.3.2) must be installed for this parameter to be applicable."""@en ;
                            rdfs:label "Area of implementation of GPRS"@en ;
+                           dcterms:relation era:etcsLevelType , era:gprsForETCS ;
                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -4372,6 +4394,10 @@ era:gsmRNoCoverage rdf:type owl:DatatypeProperty ;
                    <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
                    <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
                    rdfs:comment "Indication if there is no GSMR coverage."@en ;
+                   rdfs:requires "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."@en ;
+                   dcterms:description """If GSM-R is not installed, this parameter should not be used.
+This parameter is mainly to capture the case of Radio Hole functionality (lack of GSM-R coverage), that is foreseen in the ETCS specifications as packet 68. 
+Another possible use is the declaration of a temporary situation where, although the area is in principle covered by GSM-R, there is a long-term outage or a project for replacement of the radio (i.e. a section that will not be covered with GSM-R for half a year or longer)."""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "No GSMR coverage"@en ;
                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -4419,6 +4445,7 @@ era:gsmrForcedDeregistrationFunctionalNumber rdf:type owl:DatatypeProperty ;
                                              rdfs:comment "This feature will condition the applicable operational rules for drivers and signallers when dealing with cab radios registered under wrong numbers."@en ;
                                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                              rdfs:label "Is the GSM-R network configured to allow forced de-registration of a functional number by another driver?"@en ;
+                                             rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
                                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -6562,6 +6589,8 @@ era:publicNetworkRoaming rdf:type owl:DatatypeProperty ;
 In case of Y, provide the name of the public network(s) under parameter \"Details on GSM-R roaming to public networks\"."""@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Existence of GSM-R roaming to public networks"@en ;
+                         rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
+                         dcterms:relation era:publicNetworkRoamingDetails ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -6573,11 +6602,15 @@ era:publicNetworkRoamingDetails rdf:type owl:DatatypeProperty ;
                                 era:rinfIndex "1.1.1.3.3.7" ,
                                               "1.2.1.1.2.7" ;
                                 <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
-                                <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
-                                rdfs:comment """If roaming to public networks is configured, please indicate to which networks, 
-for which users and in which areas."""@en ;
+                                <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date , "2024-04-18"^^xsd:date ;
+                                rdfs:comment """If roaming to public networks is configured, please:
+
+1. indicate to which networks, for which users and in which areas.
+2. list if any GSM-R functionality is not available when roaming to a public network (e.g. REC, Functional Addressing, Group Calls). 
+3. also add if there is any operational restriction for vehicles that cannot roam into any of the available public networks."""@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Details on GSM-R roaming to public networks"@en ;
+                                rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -6647,6 +6680,7 @@ era:radioNetworkId rdf:type owl:DatatypeProperty ;
                    <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                    rdfs:comment "Unique identification of the GSM-R network the calling mobile station has to register with, as defined in the specification referenced in Appendix A-1, index [C]."@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                   rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."""@en ;
                    rdfs:label "Radio Network ID"@en ;
                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7593,8 +7627,10 @@ era:usesGroup555 rdf:type owl:DatatypeProperty ;
                                "1.2.1.1.2.4" ;
                  era:usedInRCCCalculations "true"^^xsd:boolean ;
                  <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
-                 <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
+                 <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date;
                  rdfs:comment "Indication if group 555 is used."@en ;
+                 rdfs:requires """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                 dcterms:relation era:etcsLevelType ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "GSM-R use of group 555"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -987,7 +987,7 @@ era:etcsLevelType rdf:type owl:ObjectProperty ;
 		  dcterms:relation era:etcsBaseline ;
 		  dcterms:description """The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
 	
-Level definitions are principally related to the track side equipment used, to the way the track side information reaches the on-board units and to which functions are processed in the track side and in the on-board equipment respectively."""@en
+Level definitions are principally related to the track side equipment used, to the way the track side information reaches the on-board units and to which functions are processed in the track side and in the on-board equipment respectively."""@en ;
 		  dcterms:requires """If ETCS is on the trackside (one or more levels are selected), all other ETCS parameters (from 1.1.1.3.2.2 to 1.1.1.3.2.10) are applicable.
 	
 The ETCS value NTC is only relevant when the line is dual equipped with ETCS (i.e., balises are placed in the track) and Class B system, and both systems are in operation at the same time. 
@@ -2560,7 +2560,7 @@ era:minVehicleImpedance rdf:type owl:ObjectProperty ;
 Verification of compliance with TSI includes application of notified national rules (when they exist)."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
-			dcterms:requires "The parameter minVehicleImpedance is applicable for track circuits."
+			                  dcterms:requires "The parameter minVehicleImpedance is applicable for track circuits." ;
                         rdfs:label "minimum vehicle impedance"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
                         <http://www.w3.org/2004/02/skos/core#altLabel> "Minimum vehicle impedance"@en .
@@ -3616,7 +3616,7 @@ era:conditionsAppliedRegenerativeBraking rdf:type owl:DatatypeProperty ;
                                          rdfs:comment "Name and/or reference of the document specifying the conditions applying in regards to regenerative braking."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Conditions applying in regards to regenerative braking"@en ;
-                                         dcterms:requires "When `not electrified` is chosen in parameter 1.1.1.2.2.1.1, then this parameter is not applicable."
+                                         dcterms:requires "When `not electrified` is chosen in parameter 1.1.1.2.2.1.1, then this parameter is not applicable." ;
                                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -5116,7 +5116,7 @@ Each Section of Line may concern only one IM. """@en ;
            rdfs:comment """(deprecated) Infrastructure manager means any body or firm responsible in particular for establishing, managing and maintaining railway infrastructure, including traffic management and control-command and signalling; 
 the functions of the infrastructure manager on a network or part of a network may be allocated to different bodies or firms."""@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-	   rdfs:seeAlso "http://data.europa.eu/eli/dir/2012/34/oj (Article 3(2))."
+	         rdfs:seeAlso "http://data.europa.eu/eli/dir/2012/34/oj (Article 3(2))." ;
            rdfs:label "Infrastructure manager (IM)'s code"@en ;
            owl:deprecated "true"^^xsd:boolean ;
            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -1,4 +1,5 @@
 @prefix : <http://data.europa.eu/949/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix era: <http://data.europa.eu/949/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -955,8 +956,19 @@ era:etcsLevelType rdf:type owl:ObjectProperty ;
                   era:rinfIndex "1.1.1.3.2.1" ,
                                 "1.2.1.1.1.1" ;
                   <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
-                  <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
+                  <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date , "2024-04-18"^^xsd:date ;
                   rdfs:comment "European Train Control System (ETCS) application level related to the track side equipment."@en ;
+		  dcterms:relation era:etcsBaseline ;
+		  dcterms:description """The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
+
+Level definitions are principally related to the track side equipment used, to the way the track side information reaches the on-board units and to which functions are processed in the track side and in the on-board equipment respectively.
+The ETCS value NTC is only relevant when the line is dual equipped with ETCS (i.e., balises are placed in the track) and Class B system, and both systems are in operation at the same time. 
+In those cases, this parameter should be filled relevant ETCS Level and repeated with the value “NTC”.
+
+If the line is only equipped with Class B, this should be reflected in Parameter 1.1.1.3.5.3, and this parameter should be set to “N”."""@en
+		  dcterms:requires """If ETCS is on the trackside (‘N’ is not selected), all other ETCS parameters (from 1.1.1.3.2.2 to 1.1.1.3.2.10) are applicable.
+If the line is only equipped with Class B, this should be reflected in Parameter 1.1.1.3.5.3, and this parameter should be set to “N”. """@en ; 
+		  dcterms:source "http://data.europa.eu/eli/reg_impl/2023/1695/oj (TSI CCS, SRS Chapter 2, 2.6)"@en ; 
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "ETCS level"@en ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -4843,8 +4855,14 @@ era:imCode rdf:type owl:DatatypeProperty ;
            <http://purl.org/dc/terms/created> "2021-08-02"^^xsd:date ;
            <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
            <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
-           rdfs:comment "TODO review: Infrastructure manager means anybody or undertaking that is responsible in particular for establishing and maintaining railway infrastructure or a part thereof."@en ;
+	   dcterms:description """The Code is a unique identifier for the Infrastructure Manager and it shall be verified on national level. 
+- If the IM is subject to TAF/TAP TSIs, it corresponds to the code used in TAF/TAP TSIs. 
+- In other cases, it corresponds to the "organisation code” assigned by the Agency for the specific needs of the RINF
+Each Section of Line may concern only one IM. """@en ; 
+           rdfs:comment """Infrastructure manager means any body or firm responsible in particular for establishing, managing and maintaining railway infrastructure, including traffic management and control-command and signalling; 
+the functions of the infrastructure manager on a network or part of a network may be allocated to different bodies or firms."""@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+	   rdfs:seeAlso "http://data.europa.eu/eli/dir/2012/34/oj (Article 3(2))."
            rdfs:label "Infrastructure manager (IM)'s code"@en ;
            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -8476,7 +8494,7 @@ era:TrainDetectionSystem rdf:type owl:Class ;
                          era:rinfIndex "1.1.1.3.4" ;
                          <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
                          <http://purl.org/dc/terms/modified> "2021-08-07"^^xsd:date ;
-                         rdfs:comment "System used to detect the position of vehicles in the railway track."@en ;
+                         rdfs:comment "Safety system used to detect the presence of vehicles on the railway track."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Train Detection System"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -8499,7 +8517,7 @@ era:Tunnel rdf:type owl:Class ;
 era:Vehicle rdf:type owl:Class ;
             <http://purl.org/dc/terms/created> "2020-11-22"^^xsd:date ;
             <http://purl.org/dc/terms/modified> "2020-11-22"^^xsd:date ;
-            rdfs:comment "A specific vehicle or wagon able to operate over railway lines."@en ;
+            rdfs:comment "A specific vehicle or wagon able and allowed to operate over railway infrastructure."@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             rdfs:label "Vehicle"@en ;
             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -482,21 +482,21 @@ era:cantDeficiencyBasicSSP rdf:type owl:ObjectProperty ;
                            rdfs:domain era:CCSSubsystem ;
                            rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                            era:inSkosConceptScheme <http://data.europa.eu/949/concepts/cant-deficiencies/CantDeficiencies> ;
-		   	   era:appendixD3Index "1.3" ;
+                           era:XMLName: "CPE_SSPUsesCantDef" ;
+		   	                   era:appendixD3Index "1.3" ;
                            era:rinfIndex "1.1.1.3.2.14" ,
                                          "1.2.1.1.1.14" ;
-                           era:XMLName: "CPE_SSPUsesCantDef" ;
                            <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                            <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
                                                                "2024-04-18"^^xsd:date ;
                            rdfs:comment """Essential information for drivers of trains with a worse (lower) tolerated cant deficiency than those for which the ETCS trackside provides SSP (Static Speed Profiles) in conjunction with  parameter \"Other Cant Deficiency train categories for which the ETCS trackside is configured to provide SSP\".
 
-According to the specification referenced in Appendix A-1, index [C]:
-
 Subset-026 (3.11.3.2.1.1) definition:
 a) The “Cant Deficiency” SSP categories: the cant deficiency value assigned to one category shall define the maximum speed, determined by suspension design, at which a particular train can traverse a curve and thus can be used to set a specific speed limit in a curve with regards to this category.
 """@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                           rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                           dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                            rdfs:label "cant deficiency used for the basic SSP"@en ;
                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -874,6 +874,7 @@ era:etcsBaseline rdf:type owl:ObjectProperty ;
                  <http://purl.org/dc/terms/modified> "2021-08-31"^^xsd:date ,
                                                      "2024-04-18"^^xsd:date ;
                  rdfs:comment "ETCS baseline installed lineside."@en ;
+                 dcterms:source "TBD"@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS baseline"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -929,6 +930,7 @@ era:etcsInfill rdf:type owl:ObjectProperty ;
                                                    "2024-04-18"^^xsd:date ;
                rdfs:comment "Information about installed trackside equipment capable to transmit infill information by loop or Global System for Mobile communications for Railways (GSM-R) for level 1 installations."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+               dcterms:source "TSI CCS 4.2.2"@en ;
                rdfs:label "ETCS infill installed line-side"@en ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -958,17 +960,17 @@ era:etcsLevelType rdf:type owl:ObjectProperty ;
                   <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
                   <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date , "2024-04-18"^^xsd:date ;
                   rdfs:comment "European Train Control System (ETCS) application level related to the track side equipment."@en ;
-		  dcterms:relation era:etcsBaseline ;
-		  dcterms:description """The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
+		              dcterms:relation era:etcsBaseline ;
+		              dcterms:description """The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
 
-Level definitions are principally related to the track side equipment used, to the way the track side information reaches the on-board units and to which functions are processed in the track side and in the on-board equipment respectively.
+Level definitions are principally related to the track side equipment used, to the way the track side information reaches the on-board units and to which functions are processed in the track side and in the on-board equipment respectively."""@en
+		              dcterms:requires """If ETCS is on the trackside (‘N’ is not selected), all other ETCS parameters (from 1.1.1.3.2.2 to 1.1.1.3.2.10) are applicable.
+
 The ETCS value NTC is only relevant when the line is dual equipped with ETCS (i.e., balises are placed in the track) and Class B system, and both systems are in operation at the same time. 
 In those cases, this parameter should be filled relevant ETCS Level and repeated with the value “NTC”.
 
-If the line is only equipped with Class B, this should be reflected in Parameter 1.1.1.3.5.3, and this parameter should be set to “N”."""@en
-		  dcterms:requires """If ETCS is on the trackside (‘N’ is not selected), all other ETCS parameters (from 1.1.1.3.2.2 to 1.1.1.3.2.10) are applicable.
 If the line is only equipped with Class B, this should be reflected in Parameter 1.1.1.3.5.3, and this parameter should be set to “N”. """@en ; 
-		  dcterms:source "http://data.europa.eu/eli/reg_impl/2023/1695/oj (TSI CCS, SRS Chapter 2, 2.6)"@en ; 
+		              dcterms:source "http://data.europa.eu/eli/reg_impl/2023/1695/oj (TSI CCS, SRS Chapter 2, 2.6)"@en ; 
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "ETCS level"@en ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -984,10 +986,12 @@ era:etcsMVersion rdf:type owl:ObjectProperty ;
                                "1.2.1.1.1.10" ;
                  era:usedInRCCCalculations "true"^^xsd:boolean ;
                  <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
-                 <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
+                 <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
                  rdfs:comment "ETCS M_version according to the specification referenced in Appendix A-1, index [C]."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS M_version"@en ;
+                 rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -1008,6 +1012,8 @@ era:etcsSystemCompatibility rdf:type owl:ObjectProperty ;
                             <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
                             <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
                             rdfs:comment "ETCS requirements used for demonstrating technical compatibility."@en ;
+                            dcterms:source "TBD"@en ;
+                            dcterms:definition "TBD"@en ; 
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "ETCS system compatibility"@en ;
                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1025,11 +1031,14 @@ era:etcsTransmittedTrackConditions rdf:type owl:ObjectProperty ;
                                    <http://purl.org/dc/terms/created> "2022-11-16"^^xsd:date ;
                                    <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ,
                                                                        "2023-04-18"^^xsd:date ;
-                                   rdfs:comment """According to the specification referenced in Appendix A-1, index [C]. 
+                                   rdfs:comment """Transmittable track conditions by the CCSSubsystem, as per CCS TSI.
+
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Chapter 5, section 5.18.1.1."""@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Track conditions which can be transmitted"@en ;
+                                   rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ; 
+                                   dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
 
@@ -1093,9 +1102,22 @@ era:frenchTrainDetectionSystemLimitationNumber rdf:type owl:ObjectProperty ;
                                                              "1.2.1.1.6.3" ;
                                                era:usedInRCCCalculations "true"^^xsd:boolean ;
                                                <http://purl.org/dc/terms/created> "2023-04-05"^^xsd:date ;
-                                               rdfs:comment "Part of the section with train detection limitation that indicates the type of train detection limitation."@en ;
+                                               <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
+                                               rdfs:comment """Part of the section with train detection limitation that indicates the type of train detection limitation.
+
+Specific for route compatibility check on French network.
+
+Sections with:
+[1]	Tonnage circulated per track is inferior to 15000 tons/day/track
+[2]	Directional Interlocking
+[3]	45-second delay for directional interlocking
+[4]	Installation with track circuit announcement
+[5]	Absence of a shunting assistance pedal in the normal direction of circulation for non-reversible double track lines
+[6]	Absence of a shunting assistance pedal regardless of the direction of traffic for single track lines and tracks for two way working
+[7]	Absence of a pedal announcement mechanism
+[8]	45-second delay for specific announcement reset devices"""@en ;
                                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                               rdfs:label "Section with train detection limitation number, only for French  network"@en ;
+                                               rdfs:label "Section with train detection limitation number, only for French network"@en ;
                                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -1103,12 +1125,20 @@ era:frenchTrainDetectionSystemLimitationNumber rdf:type owl:ObjectProperty ;
 era:frequencyBandsForDetection rdf:type owl:ObjectProperty ;
                                rdfs:domain era:TrainDetectionSystem ;
                                rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
+                               era:XMLName "CCD_TSIFreqBandsDet" ;
                                era:inSkosConceptScheme <http://data.europa.eu/949/concepts/train-detection/FrequencyBandsForDetection> ;
                                era:rinfIndex "1.1.1.3.4.2" ,
                                              "1.2.1.1.3.2" ;
                                <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                rdfs:comment "Bands of the frequency management of the train detection systems as defined in the specification referenced in Appendix A-1, index [D], and in the specific cases or technical documents referred to in Article 13 of TSI CCS when they are available."@en ;
+                               dcterms:description """Verification of compliance with TSI includes application of notified national rules (when they exist).
+
+Multiple selection from a predefined list:
+-	Axle Counters: bands A1-A3
+-	Track circuits: bands A1-A8"""@en ;
+                               dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                               dcterms:relation era:maximumInterferenceCurrent, era:minVehicleImpedance,  era:tdsMaximumMagneticField ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "frequency bands for detection"@en ;
                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
@@ -1171,9 +1201,16 @@ era:gsmRActiveMobiles rdf:type owl:ObjectProperty ;
                                     "1.2.1.1.2.2" ;
                       <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                       <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
-                      rdfs:comment "Number of simultaneous communication session on board for ETCS level R required for a smooth running of the train. This relates to the radio block centre (RBC) handling of communication sessions. Not safety critical and no matter of interoperability."@en ;
+                      rdfs:comment "Number of simultaneous communication session on board for ETCS level 2 required for a smooth running of the train. This relates to the radio block centre (RBC) handling of communication sessions. Not safety critical and no matter of interoperability."@en ;
+                      dcterms:description """In case there is no ETCS Level 2 in the line, do not use this property.
+In case there is ETCS Level 2 in the line, the minimum number of EDOR required on board would be 1. 
+In case ETCS baseline 3 release 2 or baseline 4 is selected, select “2”.
+Please select ”1” or “2”, taking into account that TSI compliant trains may only be fitted with 1 EDOR.
+"""@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Number of active GSM-R mobiles (EDOR) or simultaneous communication session on-board for ETCS Level 2 needed to perform radio block centre handovers without having an operational disruption"@en ;
+                      rdfs:requires """GSM-R and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
+                      dcterms:relation era:etcsLevelType ;
                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -1190,6 +1227,10 @@ era:gsmRAdditionalInfo rdf:type owl:ObjectProperty ;
                        rdfs:comment "Any additional information on network characteristics or corresponding document available from the IM and stored by the Agency, e.g.; interference level, leading to the recommendation of additional on-board protection."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Additional information on network characteristics"@en ;
+                       dcterms:description """Please use this field to indicate any additional information on the GSM-R network. 
+
+The document(s) itself has(have) to be upload by the NRE via the “reference document management” functionality. The reference of the document(s) is(are) provided as (a) link(s)."""@en ;
+                       rdfs:requires "GSM-R must be installed for this parameter to be applicable"@en ;
                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
                        <http://www.w3.org/2004/02/skos/core#changeNote> "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
@@ -1203,9 +1244,33 @@ era:gsmROptionalFunctions rdf:type owl:ObjectProperty ;
                           era:rinfIndex "1.1.1.3.3.3" ,
                                         "1.2.1.1.2.3" ;
                           <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
-                          <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
+                          <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date, "2024-04-18"^^xsd:date ;
                           rdfs:comment "Use of optional GSM-R functions which might improve operation on the line. They are for information only and not for network access criteria."@en ;
+                          dcterms:description """(*1) These inputs refer to the expected behaviour by the network, i.e. if there is any area or point where an automatic selection of network should be done or if there is any location where balises to instruct a change of radio network have been installed. 
+In order to be able to attend to these indications (automatic network, network change by balise) some configuration is needed in the mobile.
+In case there is a balise used to announce the change of the network, or if there are locations where the network selection is planned by the IM to be done automatically (and not manually, as stated in the requirements). It should be considered as an item that is related to the design of the infrastructure.
+
+(*2) the possibility to dial 112 is something specific to the network that should be communicated to the vehicles accessing it.
+
+(*3) the use of broadcast calls is something specific to the network that has to be configured in it.
+
+(*4) it is something specific to the network that has to be configured in it if the service is provided.
+
+(*5) it is something specific to the network that has to be configured in it if the service is provided; something may need to be configured on the network but also in the mobile subscriber data if it wants to use the service. What is requested here is the information of the network capability.
+
+(*6) if they are configured on the network. Please indicate which in the “Other information” box.
+
+(*7) To be selected if other data applications, different from ETCS L2, can be used within the network – 
+
+(*8) if it is configured on the network.
+ “GSM-R Shunting used” in order to make public if the GSM-R is used in the network for shunting activities. 
+
+(*9) Please specify in the “Other information“ box for which services /applications are they planned and which are the frequencies in use.
+
+(*11) Please use this field to indicate any additional information on network characteristics, e.g.; interference level, leading to the need of additional on-board protection; areas where GPRS for ETCS can be used;
+""" @en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                          rdfs:requires "GSM-R must be installed for this parameter to be applicable"@en ;
                           rdfs:label "Optional GSM-R functions"@en ;
                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -1241,7 +1306,10 @@ era:gsmRVersion rdf:type owl:ObjectProperty ;
                 <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                 <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                     "2024-04-18"^^xsd:date ;
-                rdfs:comment "GSM-R functional requirements specification and system requirements specification in accordance with the specification respectively referenced in Appendix A-1, index [E] and index [F], version number installed lineside."@en ;
+                rdfs:comment """GSM-R functional requirements specification and system requirements specification in accordance with the specification respectively referenced in Appendix A-1, index [E] and index [F], version number installed lineside.
+                
+Since more than one version may be installed in different areas, this property can have multiple values."""@en ;
+                rdfs:requires "GSM-R must be installed for this parameter to be applicable"@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "GSM-R version"@en ;
                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1257,9 +1325,9 @@ era:gsmrConstraintsOperateOnlyInCircuitSwitch rdf:type owl:ObjectProperty ;
                                               era:rinfIndex "1.2.1.1.2.12" ;
                                               <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                               <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                                              rdfs:comment """These constraints, where applicable, are meant to manage the limited number of circuit-switched radio connections that can be handled simultaneously by a Radio Block Center.
-"""@en ;
+                                              rdfs:comment """These constraints, where applicable, are meant to manage the limited number of circuit-switched radio connections that can be handled simultaneously by a Radio Block Center."""@en ;
                                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                              rdfs:requires "GSM-R must be installed for this parameter to be applicable"@en ;
                                               rdfs:label "Specific constraints imposed by the GSM-R network operator on ETCS on-board units only able to operate in circuit-switch"@en ;
                                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -1412,7 +1480,8 @@ era:legacyRadioSystem rdf:type owl:ObjectProperty ;
                       <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
                       <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
                       <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
-                      rdfs:comment "Indication of radio legacy systems installed."@en ;
+                      rdfs:comment "Indication of radio legacy systems installed. The list is in line with ERA/TD/2011-09/INT (v1.13), Table 4. "@en ;
+                      dcterms:source "https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf" ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Other radio systems installed (Radio Legacy Systems)"@en ;
                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1607,15 +1676,17 @@ era:mNvcontact rdf:type owl:ObjectProperty ;
                era:appendixD3Index "1.5.9" ;
                era:inSkosConceptScheme <http://data.europa.eu/949/concepts/etcs-reactions-contact/ETCSReactionsNVContact> ;
                era:rinfIndex "1.1.1.3.2.16.9" ,
-                             "1.2.1.1.1.16.9Â " ;
+                             "1.2.1.1.1.16.9" ;
                <http://purl.org/dc/terms/created> "2022-11-07"^^xsd:date ;
                <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ,
                                                    "2024-04-18"^^xsd:date ;
-               rdfs:comment """On-Board system reaction when T_NVCONTACT expires.  
-According to the specification referenced in Appendix A-1, index [C]. 
+               rdfs:comment """On-Board system reaction when T_NVCONTACT expires.
+
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.74 M_NVCONTACT."""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+               rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+               dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                rdfs:label "M_NVCONTACT"@en ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
@@ -1924,12 +1995,12 @@ era:minVehicleImpedanceVoltages rdf:type owl:ObjectProperty ;
                               rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                               era:XMLName "CCD_TCVehicleImpedance" ;
                               era:inSkosConceptScheme <http://data.europa.eu/949/concepts/energy-supply-systems/EnergySupplySystems> ;
-                        era:rinfIndex "1.1.1.3.4.2.2" ,           
-                                      "1.2.1.1.3.2.2" ;
+                              era:rinfIndex "1.1.1.3.4.2.2" , "1.2.1.1.3.2.2" ;
                               era:usedInRCCCalculations "true"^^xsd:boolean ;
                               <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                              rdfs:comment "Voltages with which the vehicles are equipped, if the parameter minVehicleImpedance is applicable."@en ;
+                              rdfs:comment "If the parameter minVehicleImpedance is applicable (track circuits), indication of the ENE voltage system valid for the minimal impedance value."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                              dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                               rdfs:label "minimum Vehicle Impedance (Voltage applicable)"@en ;
                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -1946,11 +2017,14 @@ era:otherCantDeficiencyBasicSSP rdf:type owl:ObjectProperty ;
                                 <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                 <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                 rdfs:comment """Essential information for drivers of trains with a worse (lower) tolerated cant deficiency than those for which the ETCS trackside provides SSP (Static Speed Profiles) in conjunction with parameter \"Cant Deficiency used for the basic SSP\". 
-According to the specification referenced in Appendix A-1, index [C].
+
 Subset-026 (3.11.3.2.1.1) definition:
 b) The “other specific” SSP categories: it groups all other specific SSP categories corresponding to the other international train categories.
 """@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                dcterms:relation era:cantDeficiencyBasicSSP ;
+                                rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                                dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;               
                                 rdfs:label "Other Cant Deficiency train categories for which the ETCS trackside is configured to provide SSP"@en ;
                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
@@ -2159,6 +2233,7 @@ era:protectionLegacySystem rdf:type owl:ObjectProperty ;
                            <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                                "2024-04-18"^^xsd:date ;
                            rdfs:comment "Indication of which class B system is installed. The list is in line with ERA/TD/2011-09/INT (v1.13), Table 3. "@en ;
+                           dcterms:source "https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf" ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Train protection legacy system"@en ;
                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -2172,11 +2247,11 @@ era:qNvemrrls rdf:type owl:ObjectProperty ;
               era:appendixD3Index "1.5.2" ;
               era:inSkosConceptScheme <http://data.europa.eu/949/concepts/ebr-qualifier/EBReleaseQualifier> ;
               era:rinfIndex "1.1.1.3.2.16.2" ,
-                            "1.2.1.1.1.16.2Â " ;
+                            "1.2.1.1.1.16.2" ;
               <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
               <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
               rdfs:comment """
-Qualifier to revoke the emergency brake command when the Permitted Speed limit is no longer exceeded or at standstill (for ceiling speed and target speed monitoring).
+Qualifier defining whether the application of the emergency brake for reasons other than a trip can be revoked as soon as the conditions for it have disappeared or after the train has come to a complete standstill.
 
 According to the specification referenced in Appendix A-1, index [C]. 
 In Subset-026, chapter 7, 7.5.1.123 Q_NVEMRRLS."""@en ;
@@ -2238,6 +2313,8 @@ In https://www.era.europa.eu/domains/technical-specifications-interoperability/c
 Subset 26, Chapter 5 5.4 Procedure start of mission."""@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Reasons for which an ETCS Radio Block Center can reject a train"@en ;
+                                      rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                                      dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
 
 
@@ -2281,10 +2358,11 @@ era:safeConsistLengthInformationNecessary rdf:type owl:ObjectProperty ;
                                                         "1.2.1.1.1.11" ;
                                           <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                           <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                                          rdfs:comment """Indication whether safe consist train length information from on-board is required to access the line for safety reasons and the required safety integrity level.
-"""@en ;
+                                          rdfs:comment """Indication whether safe consist train length information from on-board is required to access the line for safety reasons and the required safety integrity level."""@en ;
                                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                           rdfs:label "Safe consist length information from on-board necessary for access the line and SIL"@en ;
+                                          dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+                                          rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
                                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -2395,14 +2473,16 @@ era:minVehicleImpedance rdf:type owl:ObjectProperty ;
                                                   )
                                     ] ;
                         rdfs:range era:MinVehicleImpedance ;
+                        era:XMLName "CCD_TCVehicleImpedance" ;
                         era:eratvIndex "4.14.2.17" ;
                         era:rinfIndex "1.1.1.3.4.2.2" ,
                                       "1.2.1.1.3.2.2" ;
                         <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
-                        rdfs:comment """
-[CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin)
-"""@en ;
+                        rdfs:comment """Per voltage: [CCCC]+[ZZZZ], with input capacitance [CCCC](Cin) and input impedance [ZZZZ](Zin) as defined in TSI CCS Annex A - Index 77.
+                        
+Verification of compliance with TSI includes application of notified national rules (when they exist)."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                        dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                         rdfs:label "minimum vehicle impedance"@en ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
                         <http://www.w3.org/2004/02/skos/core#altLabel> "Minimum vehicle impedance"@en .
@@ -2556,6 +2636,7 @@ era:tdsFrenchTrainDetectionSystemLimitation rdf:type owl:ObjectProperty ;
                                             rdfs:comment """Relates the class train detection system with the class that represents the section with train detection limitation. 
 Specific for route compatibility check on French network."""@en ;
                                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                            dcterms:relation era:frenchTrainDetectionSystemLimitationApplicable ;
                                             rdfs:label "Section with train detection limitation, only for the French network"@en ;
                                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -2564,13 +2645,17 @@ Specific for route compatibility check on French network."""@en ;
 era:tdsMaximumMagneticField rdf:type owl:ObjectProperty ;
                             rdfs:domain era:TrainDetectionSystem ;
                             rdfs:range era:MaximumMagneticField ;
+                            era:XMLName "CCD_ACMagFieldMax" ;
                             era:rinfIndex "1.1.1.3.4.2.3" ,
                                           "1.2.1.1.3.2.3" ;
                             <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
-                            rdfs:comment """Relates the TrainDetectionSystem with the MaximumMagneticField.
+                            <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
+                            rdfs:comment """Relates the Axle Counter TrainDetectionSystem with its MaximumMagneticField in (X,Y,Z).
+
 The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band.
 It should be provided in 3 directions."""@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                            dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                             rdfs:label "Maximum magnetic field"@en ;
                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -2769,9 +2854,10 @@ era:trainDetectionSystemSpecificCheckDocument rdf:type owl:ObjectProperty ;
                                               <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
                                                                                   "2024-04-18"^^xsd:date ,
                                                                                   "2024-04-23"^^xsd:date ;
-                                              rdfs:comment "Electronic document from the IM stored by the Agency with precise values in accordance with TSI CCS Article13 and the specification referenced in Appendix A-1, index [D], for the specific check to be performed for train detection systems identified in parameter \"\"Type of track circuits or axle counters to which specific checks are needed\"."@en ;
+                                              rdfs:comment "Electronic document from the IM stored by the Agency with precise values in accordance with TSI CCS Article 13 and the specification referenced in Appendix A-1, index [D], for the specific check to be performed for train detection systems identified in parameter \"\"Type of track circuits or axle counters to which specific checks are needed\"."@en ;
                                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                               rdfs:label "Document with the procedure(s) related to the type of train detection systems declared in 1.1.1.3.7.1.2 or 1.2.1.1.6.1"@en ;
+                                              dcterms:requires "The document itself has to be upload by the NRE via the “reference document management” functionality. The reference of the document is provided for the parameter using the characterstring format."@en
                                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
                                               <http://www.w3.org/2004/02/skos/core#changeNote> "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
@@ -2791,8 +2877,14 @@ era:trainDetectionSystemType rdf:type owl:ObjectProperty ;
                                            "1.2.1.1.3.1.1" ;
                              era:usedInRCCCalculations "true"^^xsd:boolean ;
                              <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
-                             <http://purl.org/dc/terms/modified> "2021-08-07"^^xsd:date ;
-                             rdfs:comment "Indication of types of train detection systems installed."@en ;
+                             <http://purl.org/dc/terms/modified> "2021-08-07"^^xsd:date , "2024-04-18"^^xsd:date;
+                             rdfs:comment "Indication of types of train detection systems installed. "@en ;
+                             dcterms:requires """Applicable: 
+- N for 1.1.1.3.7.1.1 will trigger “N” for parameters 1.1.1.3.7.1.2 to 1.1.1.3.7.23.
+- NYA for 1.1.1.3.7.1.1 will trigger NYA for parameters 1.1.1.3.7.1.2 to 1.1.1.3.7.23.
+
+If this parameter is repeated, parameters 1.1.1.3.7.2 to 1.1.1.3.7.23 shall be created also for the corresponding type. 
+These parameters are to be considered children of the current. But not all parameters are applicable to all types of train detection systems; it depends on the applicability condition."""@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Type of train detection system"@en ;
                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -3289,13 +3381,16 @@ era:axleSpacing rdf:type owl:DatatypeProperty ;
 era:bigMetalMass rdf:type owl:DatatypeProperty ;
                  rdfs:domain era:CCSSubsystem ;
                  rdfs:range xsd:boolean ;
+                 era:XMLName "CPE_BigMetalMass" ;
                  era:appendixD2Index "3.4.10" ;
                  era:rinfIndex "1.1.1.3.2.18" ,
                                "1.2.1.1.1.18" ;
                  <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
-                 <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ;
+                 <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date , "2024-04-18"^^xsd:date ;
                  rdfs:comment "Indication of existence of metal mass in the vicinity of the location, susceptible of perturbating the reading of balises by the on-board system."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                 rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                  rdfs:label "Big Metal Mass"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -3425,14 +3520,16 @@ era:conditionsAppliedRegenerativeBraking rdf:type owl:DatatypeProperty ;
                                          rdfs:domain era:ContactLineSystem ;
                                          rdfs:range xsd:anyURI ;
                                          era:appendixD2Index "3.3.7" ;
+                                         era:XMLName "ECS_RegBrakingConditions" ;
                                          era:rinfIndex "1.1.1.2.2.4.1" ;
                                          <http://purl.org/dc/terms/created> "2022-11-10"^^xsd:date ;
-                                         <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
+                                         <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date , "2024-04-18"^^xsd:date ;
                                          <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ,
                                                                            <https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019R0777&from=EN> ;
                                          rdfs:comment "Name and/or reference of the document specifying the conditions applying in regards to regenerative braking."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Conditions applying in regards to regenerative braking"@en ;
+                                         dcterms:requires "When `not electrified` is chosen in parameter 1.1.1.2.2.1.1, then this parameter is not applicable."
                                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -3563,11 +3660,13 @@ era:dNvovtrp rdf:type owl:DatatypeProperty ;
              <http://purl.org/dc/terms/created> "2022-11-07"^^xsd:date ;
              <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
                                                  "2024-04-18"^^xsd:date ;
-             rdfs:comment """Maximum distance for overriding the train trip in metres
-According to the specification referenced in Appendix A-1, index [C]. 
+             rdfs:comment """Maximum distance for overriding the train trip in metres.
+
 In Subset 26, chapter 7. 7.5.1.15 D_NVOVTRP.
 https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+             dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
              rdfs:label "D_NVOVTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -3585,10 +3684,12 @@ era:dNvpotrp rdf:type owl:DatatypeProperty ;
              <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ,
                                                  "2024-04-18"^^xsd:date ;
              rdfs:comment """Maximum distance for reversing in Post Trip mode in metres. 
-According to the specification referenced in Appendix A-1, index [C]. 
+
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
- Subset 26, chapter 7. 7.5.1.16 D_NVPOTRP."""@en ;
+Subset 26, chapter 7. 7.5.1.16 D_NVPOTRP."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+             dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
              rdfs:label "D_NVPOTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -3606,10 +3707,12 @@ era:dNvroll rdf:type owl:DatatypeProperty ;
             <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ,
                                                 "2024-04-18"^^xsd:date ;
             rdfs:comment """Parameter used by the ETCS on-board to supervise the distance allowed to be travelled under the roll-away protection and the reverse movement protection, in metres.
-According to the specification referenced in Appendix A-1, index [C].
+
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
- Subset 26, chapter 7. 7.5.1.17 D_NVROLL."""@en ;
+Subset 26, chapter 7. 7.5.1.17 D_NVROLL."""@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+            rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+            dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
             rdfs:label "D_NVROLL"@en ;
             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -3869,11 +3972,13 @@ era:minVehicleInputImpedance rdf:type owl:DatatypeProperty ;
                               rdfs:domain era:MinVehicleImpedance ;
                               rdfs:range xsd:double ;
                               era:unitOfMeasure <https://qudt.org/vocab/unit/MilliH> ;
+                              era:XMLName "CCD_TCVehicleImpedance" ;
                               era:rinfIndex "1.1.1.3.4.2.2" ,           
                                             "1.2.1.1.3.2.2" ;
                               era:usedInRCCCalculations "true"^^xsd:boolean ;
                               <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
                               rdfs:comment "For the selected DC voltage: [ZZZZ], as input impedance [ZZZZ](Zin)"@en ;
+                              dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "minimal vehicle input impedance"@en ;
                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -3883,11 +3988,13 @@ era:minVehicleInputCapacitance rdf:type owl:DatatypeProperty ;
                                 rdfs:domain era:MinVehicleImpedance ;
                                 rdfs:range xsd:double ;
                                 era:unitOfMeasure <https://qudt.org/vocab/unit/NanoFARAD> ;
+                                era:XMLName "CCD_TCVehicleImpedance" ;
                                 era:rinfIndex "1.1.1.3.4.2.2" ,           
                                               "1.2.1.1.3.2.2" ;
                                 era:usedInRCCCalculations "true"^^xsd:boolean ;
                                 <http://purl.org/dc/terms/created> "2024-05-30"^^xsd:date ;
                                 rdfs:comment "For the selected DC voltage: [CCCC], as input capacitance [CCCC](Cin)"@en ;
+                                dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "minimal vehicle input capacitance"@en ;
                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -3966,13 +4073,16 @@ era:etcsErrorCorrectionsOnboard rdf:type owl:DatatypeProperty ;
 era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty ;
                                          rdfs:domain era:CCSSubsystem ;
                                          rdfs:range xsd:boolean ;
+                                         era:XMLName "CPE_LXProcedure" ;
                                          era:appendixD3Index "1.2" ;
-                                         era:rinfIndex "1.1.1.3.2.13" ,
+                                         era:rinfIndex "1.1.1.3.2.13" , # HERE
                                                        "1.2.1.1.1.13" ;
                                          <http://purl.org/dc/terms/created> "2022-11-04"^^xsd:date ;
                                          rdfs:comment "If the trackside does not implement any solution to cover defective LXs (which are normally protected by means of a technical system), then drivers will be required to comply with instructions received from other sources."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "ETCS trackside implements level crossing procedure or an equivalent solution"@en ;
+                                         rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                                         dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
                                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -4078,10 +4188,11 @@ era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty ;
                                  <http://purl.org/dc/terms/created> "2022-11-04"^^xsd:date ;
                                  <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ,
                                                                      "2024-04-18"^^xsd:date ;
-                                 rdfs:comment """According to the specification referenced in Appendix A-1, index [C]
-If the trackside does not provide Track Conditions, the driver will need to be informed about such conditions via alternative methods."""@en ;
+                                 rdfs:comment """If the trackside does not provide Track Conditions, the driver will need to be informed about such conditions via alternative methods."""@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Is the ETCS trackside engineered to transmit Track Conditions"@en ;
+                                 rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ; 
+                                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -4164,6 +4275,7 @@ era:frenchTrainDetectionSystemLimitationApplicable rdf:type owl:DatatypeProperty
                                                    <http://purl.org/dc/terms/created> "2023-04-05"^^xsd:date ;
                                                    rdfs:comment "Part of the section with train detection limitation that indicates if it is applicable. Only for the French network."@en ;
                                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                                   dcterms:relation era:frenchTrainDetectionSystemLimitation ;
                                                    rdfs:label "Section with train detection limitation"@en ;
                                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4192,9 +4304,11 @@ era:gprsForETCS rdf:type owl:DatatypeProperty ;
                 era:rinfIndex "1.1.1.3.3.3.2" ,
                               "1.2.1.1.2.3.2" ;
                 <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
-                <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
+                <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date ;
                 rdfs:comment "Indication if GPRS can be used for ETCS."@en ;
+                rdfs:requires """GSM-R and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                dcterms:source "Sections of EIRENE and ETCS subsets for trackside in TSI"@en ; 
                 rdfs:label "GPRS for ETCS"@en ;
                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4207,9 +4321,10 @@ era:gprsImplementationArea rdf:type owl:DatatypeProperty ;
                            era:rinfIndex "1.1.1.3.3.3.3" ,
                                          "1.2.1.1.2.3.3" ;
                            <http://purl.org/dc/terms/created> "2021-08-09"^^xsd:date ;
-                           <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
-                           rdfs:comment "Indication of the area in which GPRS can be used for ETCS."@en ;
+                           <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date , "2024-04-18"^^xsd:date  ;
+                           rdfs:comment "Indication of the area in which GPRS can be used for ETCS, expressed as a list of GPRS-enabled RBC's."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                           rdfs:requires """GSM-R, ETCS L2 (parameter 1.1.1.3.2.1) and GPRS for ETCS (parameter 1.1.1.3.3.3.2) must be installed for this parameter to be applicable."""@en ;
                            rdfs:label "Area of implementation of GPRS"@en ;
                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -4819,7 +4934,7 @@ Trackside hot axle box detector TSI compliant."""@en ;
 era:idPhoneErtmsRadioBlockCenter rdf:type owl:DatatypeProperty ;
                                  rdfs:domain era:CCSSubsystem ;
                                  rdfs:range xsd:string ;
-				 era:appendixD2Index "3.4.7" ;
+				                         era:appendixD2Index "3.4.7" ;
                                  era:rinfIndex "1.1.1.3.2.17" ,
                                                "1.2.1.1.1.17" ;
                                  <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -5156,17 +5271,17 @@ era:mNvderun rdf:type owl:DatatypeProperty ;
              era:XMLName "CPE_MNVDERUN" ;
              era:appendixD3Index "1.5.10" ;
              era:rinfIndex "1.1.1.3.2.16.10" ,
-                           "1.2.1.1.1.16.10Â " ;
+                           "1.2.1.1.1.16.10" ;
              <http://purl.org/dc/terms/created> "2022-11-07"^^xsd:date ;
              <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ,
                                                  "2023-04-18"^^xsd:date ;
              rdfs:comment """Entry of Driver ID permitted while running. 
 
-According to the specification referenced in Appendix A-1, index [C]. 
-
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
- Subset 26, chapter 7. 7.5.1.75 M_NVDERUN."""@en ;
+Subset 26, chapter 7. 7.5.1.75 M_NVDERUN."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+             dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
              rdfs:label "M_NVDERUN"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5430,16 +5545,17 @@ era:maximumDesignSpeed rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/maximumInterferenceCurrent
 era:maximumInterferenceCurrent rdf:type owl:DatatypeProperty ;
                                rdfs:domain era:TrainDetectionSystem ;
-                               rdfs:range xsd:integer ;
+                               rdfs:range xsd:double ;
                                era:unitOfMeasure <https://qudt.org/vocab/unit/A-PER-M> ;
+                               era:XMLName "CCD_IInterferenceMax" ;
                                era:rinfIndex "1.1.1.3.4.2.1" ,
                                              "1.2.1.1.3.2.1" ;
                                <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-                               rdfs:comment """Maximum interference current limits allowed for track circuits for a defined frequency band (to be expressed in A/m).
-                               TODO: update the range to xsd:double with a unit description"""@en ;
+                               rdfs:comment """Maximum interference current limits allowed for track circuits for a defined frequency band (to be expressed in A/m)."""@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                               rdfs:label "Maximum interference current"@en ;
+                               dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
+                               rdfs:label "maximum interference current"@en ;
                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -5447,11 +5563,14 @@ era:maximumInterferenceCurrent rdf:type owl:DatatypeProperty ;
 era:maximumInterferenceCurrentEvaluation rdf:type owl:DatatypeProperty ;
 								rdfs:domain era:TrainDetectionSystem ;
 								rdfs:range xsd:string ;
+                era:XMLName "CCD_IInterferenceMax" ;
 								era:rinfIndex "1.1.1.3.4.2.1" ,
 											  "1.2.1.1.3.2.1" ;
 								<http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
-								rdfs:comment "If the preferred frequency bands are not used, description of the parameters for evaluation of compliance."@en ;
+								rdfs:comment """"If the preferred frequency bands are not used, (mandatory) description of the parameters for evaluation of compliance.
+                If the preferred frequency bands are used, this parameter is optional."""@en ;
 								rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
 								rdfs:label "Evaluation parameters if maximum interference current is not measured in the preferred bands"@en ;
 								<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5474,11 +5593,13 @@ era:maximumLocomotivesCoupled rdf:type owl:DatatypeProperty ;
 era:maximumMagneticFieldDirectionX rdf:type owl:DatatypeProperty ;
                                    rdfs:domain era:MaximumMagneticField ;
                                    rdfs:range xsd:integer ;
+                                   era:XMLName "CCD_ACMagFieldMax" ;
                                    era:rinfIndex "1.1.1.3.4.2.3" ,
                                                  "1.2.1.1.3.2.3" ;
                                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction X."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                   dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                                    rdfs:label "Maximum magnetic field direction X"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5487,11 +5608,13 @@ era:maximumMagneticFieldDirectionX rdf:type owl:DatatypeProperty ;
 era:maximumMagneticFieldDirectionY rdf:type owl:DatatypeProperty ;
                                    rdfs:domain era:MaximumMagneticField ;
                                    rdfs:range xsd:integer ;
+                                   era:XMLName "CCD_ACMagFieldMax" ;
                                    era:rinfIndex "1.1.1.3.4.2.3" ,
                                                  "1.2.1.1.3.2.3" ;
                                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction Y."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                   dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                                    rdfs:label "Maximum magnetic field direction Y"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5500,11 +5623,13 @@ era:maximumMagneticFieldDirectionY rdf:type owl:DatatypeProperty ;
 era:maximumMagneticFieldDirectionZ rdf:type owl:DatatypeProperty ;
                                    rdfs:domain era:MaximumMagneticField ;
                                    rdfs:range xsd:integer ;
+                                   era:XMLName "CCD_ACMagFieldMax" ;
                                    era:rinfIndex "1.1.1.3.4.2.3" ,
                                                  "1.2.1.1.3.2.3" ;
                                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction Z."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                   dcterms:source "https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf" ;
                                    rdfs:label "Maximum magnetic field direction Z"@en ;
                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -5750,11 +5875,13 @@ era:minVehicleImpedance rdf:type owl:DatatypeProperty ;
                                                   )
                                     ] ;
                         rdfs:range xsd:string ;
+                        era:XMLName "CCD_TCVehicleImpedance" ;
                         era:eratvIndex "4.14.2.17" ;
                         era:rinfIndex "1.1.1.3.4.2.2" ,
                                       "1.2.1.1.3.2.2" ;
                         <http://purl.org/dc/terms/created> "2021-09-01"^^xsd:date ;
                         <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
+                        <http://purl.org/dc/terms/modified> "2024-05-30"^^xsd:date ;
                         rdfs:comment """Impedance as defined in the specification referenced in Appendix A-1, index [D].
 
 Minimum vehicle impedance (between wheels and pantograph) (only for vehicles equipped for 1500V or 3000V DC).
@@ -5764,7 +5891,7 @@ Per Voltage:
 [3000]: [CCCC]+[ZZZZ], idem.
 """@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                        rdfs:label "Vehicle impedance"@en ;
+                        rdfs:label "vehicle impedance"@en ;
                         owl:deprecated "true"^^xsd:boolean ;
                         dcterms:isReplacedBy era:minVehicleImpedance , era:minVehicleImpedanceVoltages, era:minVehicleInputImpedance , era:minVehicleInputCapacitance ;
                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
@@ -6008,7 +6135,8 @@ era:nationalRollingStockFireCategory rdf:type owl:DatatypeProperty ;
 era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty ;
                              rdfs:domain era:CCSSubsystem ;
                              rdfs:range xsd:string ;
-			     era:appendixD3index "1.5.13" ;
+                             era:XMLName "CPE_NVBRAKEMOD" ;
+			                       era:appendixD3index "1.5.13" ;
                              era:rinfIndex "1.1.1.3.2.16.13" ,
                                            "1.2.1.1.1.16.13" ;
                              <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -6017,6 +6145,8 @@ era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty ;
 It copies the content of Packet 3 or of Packet 203 as defined in the specification referenced in Appendix A-1, index [C]."""@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "National Values used for the brake model"@en ;
+                             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                             dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -6462,11 +6592,11 @@ era:qNvdriverAdhes rdf:type owl:DatatypeProperty ;
                    <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
                    rdfs:comment """Boolean determining whether the driver is allowed to modify the adhesion factor used by the ETCS on-board to calculate the braking curves. 
 
-According to the specification referenced in Appendix A-1, index [C]. 
-
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES."""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                   rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                   dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
                    rdfs:label "Q_NVDRIVER_ADHES"@en ;
                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6476,18 +6606,18 @@ era:qNvsbtsmperm rdf:type owl:DatatypeProperty ;
                  rdfs:domain era:CCSSubsystem ;
                  rdfs:range xsd:boolean ;
                  era:XMLName "CPE_QNVSBTSMPERM" ;
-		 era:appendixD3index "1.5.12" ;
+		             era:appendixD3index "1.5.12" ;
                  era:rinfIndex "1.1.1.3.2.16.12" ,
                                "1.2.1.1.1.16.12" ;
                  <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                  <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                  rdfs:comment """Permission to use service brake in target speed monitoring.
-                 
-According to the specification referenced in Appendix A-1, index [C]. 
 
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.124 Q_NVSBTSMPERM."""@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                 rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                 dcterms:source "According to the specification referenced in Appendix A-1, index [C]" ;
                  rdfs:label "Q_NVSBTSMPERM"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -6510,7 +6640,7 @@ era:radioNetworkId rdf:type owl:DatatypeProperty ;
                    rdfs:domain era:CCSSubsystem ;
                    rdfs:range xsd:string ;
                    era:XMLName "CRG_RadioNID" ;
-		   era:appendixD2Index "3.4.4" ;
+		               era:appendixD2Index "3.4.4" ;
                    era:rinfIndex "1.1.1.3.3.13" ,
                                  "1.2.1.1.2.13" ;
                    <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
@@ -6615,26 +6745,33 @@ The raised pantographs distance and speed is  the indication of maximum number o
 era:rbcID rdf:type owl:DatatypeProperty ;
           rdfs:domain era:RadioBlockCenter ;
           rdfs:range xsd:string ;
-		 era:rinfIndex "1.1.1.3.2.17" ,
-					   "1.2.1.1.1.17" ;
-		 era:appendixD2Index "3.4.7" ;
-		 <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ; # sh:regex to be added
-		 rdfs:comment "Unique RBC identification (NID_C+NID_RBC) as defined in the specification referenced in Appendix A-1, index [C]."@en ;
-		 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+          era:XMLName "CPE_IDRBC" ;
+          era:rinfIndex "1.1.1.3.2.17" ,
+                  "1.2.1.1.1.17" ;
+          era:appendixD2Index "3.4.7" ;
+          <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ; # sh:regex to be added
+          rdfs:comment "Unique RBC identification (NID_C+NID_RBC) [NNNN NNNN] as defined in the specification referenced in Appendix A-1, index [C]."@en ;
+          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "ERTMS/ETCS Radio Block Center (RBC) identifier"@en ;
-		 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+          rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+          dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
+          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
 ###  http://data.europa.eu/949/rbcPhone
 era:rbcPhone rdf:type owl:DatatypeProperty ;
-             rdfs:range xsd:string ;
+       rdfs:domain era:RadioBlockCenter ;
+       rdfs:range xsd:string ;
+       era:XMLName "CPE_PHONERBC" ;
 			 era:rinfIndex "1.1.1.3.2.17" ,
 						   "1.2.1.1.1.17" ;
 			 era:appendixD2Index "3.4.7" ;
 			 <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ; # sh:regex to be added
-			 rdfs:comment "Unique RBC calling number (NID_RADIO) as defined in the specification referenced in Appendix A-1, index [C]."@en ;
+			 rdfs:comment "Unique RBC calling number (NID_RADIO) [NNNN NNNN NNNN NNNN] as defined in the specification referenced in Appendix A-1, index [C]."@en ;
 			 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
 			 rdfs:label "ERTMS/ETCS Radio Block Center (RBC) phone number"@en ;
+       rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+       dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
 			 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -7057,11 +7194,11 @@ era:tNvcontact rdf:type owl:DatatypeProperty ;
                                                    "2024-04-18"^^xsd:date ;
                rdfs:comment """Maximum time without a safe message from Radio Block Center before train reacts in seconds. 
 
-According to the specification referenced in Appendix A-1, index [C]. 
-
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
 Subset 26, chapter 7. 7.5.1.148 T_NVCONTACT."""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+               rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+               dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                rdfs:label "T_NVCONTACT"@en ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7078,12 +7215,13 @@ era:tNvovtrp rdf:type owl:DatatypeProperty ;
              <http://purl.org/dc/terms/created> "2022-11-07"^^xsd:date ;
              <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ,
                                                  "2024-04-18"^^xsd:date ;
-             rdfs:comment """Maximum time for overriding the train trip in seconds. 
+             rdfs:comment """Maximum time for overriding the train trip in seconds.
 
-According to the specification referenced in Appendix A-1, index [C]. 
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
- Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP."""@en ;
+Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+             rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+             dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
              rdfs:label "T_NVOVTRP"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7232,7 +7370,7 @@ era:trainControlSwitchOverSpecialConditions rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/trainDetectionSystemSpecificCheck
 era:trainDetectionSystemSpecificCheck rdf:type owl:DatatypeProperty ;
                                       rdfs:domain era:TrainDetectionSystem ;
-                                      rdfs:range xsd:anyURI ;
+                                      rdfs:range xsd:string ;
                                       era:XMLName "CTD_TCCheck" ;
                                       era:rinfIndex "1.1.1.3.7.1.2" ,
                                                     "1.2.1.1.6.1" ;
@@ -7242,7 +7380,9 @@ era:trainDetectionSystemSpecificCheck rdf:type owl:DatatypeProperty ;
                                                                           "2024-04-18"^^xsd:date ;
                                       rdfs:comment "Reference to the technical specification of train detection system, in accordance with the specification referenced in Appendix A-1, index [D]."@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                      rdfs:label "Type of track circuits or axle counters to which specific checks are needed"@en ;
+                                      rdfs:label "Type of track circuits or axle counters to which specific checks are needed. "@en ;
+                                      dcterms:relation era:trainDetectionSystemSpecificCheckDocument ;
+                                      dcterms:requires "String containing the name of the TD system for which checks are mentioned in 1.1.1.3.7.1.3." ;
                                       owl:deprecated "false"^^xsd:boolean ;
                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7471,11 +7611,13 @@ era:vNvallowovtrp rdf:type owl:DatatypeProperty ;
                   era:unitOfMeasure qudt:KiloM-PER-HR ;
                   <http://purl.org/dc/terms/created> "2022-11-07"^^xsd:date ;
                   <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
-                  rdfs:comment """Speed limit allowing the driver to select the 'override' function in km/h.
-According to the specification referenced in Appendix A-1, index [C]. 
+                  rdfs:comment """Speed limit allowing the driver to select the “override” function in km/h.
+
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
- Chapter 7. 7.5.1.161"""@en ;
+Chapter 7. 7.5.1.161"""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                  rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                  dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                   rdfs:label "V_NVALLOWOVTRP"@en ;
                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
@@ -7491,11 +7633,13 @@ era:vNvsupovtrp rdf:type owl:DatatypeProperty ;
                 era:unitOfMeasure qudt:KiloM-PER-HR ;
                 <http://purl.org/dc/terms/created> "2022-11-07"^^xsd:date ;
                 <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
-                rdfs:comment """Override speed limit to be supervised when the 'override' function is active  in km/h.
-According to the specification referenced in Appendix A-1, index [C]. 
+                rdfs:comment """Override speed limit to be supervised when the “override” function is active in km/h.
+
 In https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632
- Subset 26, chapter 7. 7.5.1.163 V_NVSUPOVTRP."""@en ;
+Subset 26, chapter 7. 7.5.1.163 V_NVSUPOVTRP."""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                rdfs:requires "Only applicable when selected value for 1.1.1.3.2.1 is not ‘N’."@en ;
+                dcterms:source "According to the specification referenced in Appendix A-1, index [C]"@en ;
                 rdfs:label "V_NVSUPOVTRP"@en ;
                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -408,6 +408,8 @@ era:atoCommunicationSystem rdf:type owl:ObjectProperty ;
                                          "1.2.1.1.10.3" ;
                            <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                            <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
+        		               dcterms:relation era:etcsBaseline ;
+                           dcterms:requires "Parameter only applicable when ETCS Baseline > 4 MR1 and ATO is implemented" ;
                            rdfs:comment "Supported ATO communication systems from trackside."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "ATO communication system"@en ;
@@ -426,6 +428,8 @@ era:atoGradeAutomation rdf:type owl:ObjectProperty ;
                        <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                        <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                        rdfs:comment "ATO grade of automation installed lineside."@en ;
+    		               dcterms:relation era:etcsBaseline ;
+                       dcterms:requires "Parameter only applicable when ETCS Baseline > 4 MR1 and ATO is implemented" ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "ATO Grade of Automation"@en ;
                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -443,6 +447,8 @@ era:atoSystemVersion rdf:type owl:ObjectProperty ;
                      <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
                      <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                      rdfs:comment "ATO system version according to the specification referenced in TSI CCS (4.2.19)."@en ;
+    		             dcterms:relation era:etcsBaseline ;
+                     dcterms:requires "Parameter only applicable when ETCS Baseline > 4 MR1 and ATO is implemented" ;
                      dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "ATO System version"@en ;
@@ -897,9 +903,11 @@ era:etcsBaseline rdf:type owl:ObjectProperty ;
                  <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
                  <http://purl.org/dc/terms/modified> "2021-08-31"^^xsd:date ,
                                                      "2024-04-18"^^xsd:date ;
-                 rdfs:comment "ETCS baseline installed lineside - TSI CCS (Table A2)"@en ;
+                 rdfs:comment "ETCS baseline installed lineside"@en ;
+                 dcterms:description "The ETCS baseline needs to be provided for each available ETCS Level. See: TSI CCS (Table A2)"@en ;
+                 dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                  rdfs:label "ETCS baseline"@en ;
-		 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+		             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS baseline"@en ;
                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -919,14 +927,16 @@ era:etcsDegradedSituation rdf:type owl:ObjectProperty ;
                                                               "2024-04-18"^^xsd:date ;
                           <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                           rdfs:comment "ERTMS / ETCS application level for degraded situation related to the track side equipment."@en ;
-			  dcterms:description """System for degraded situation. See also TSI OPE 4.2.3.6. Degraded operation.
+			  dcterms:description """System for degraded situation. 
 
 In case of failure of the ETCS Level for normal operation, train movement can be supervised in another ETCS Level. 
 Example: Level 1 as a degraded mode for Level 2.
 
-If parameter 1.1.1.3.2.1 is not used (no ETCS), no degradation is possible, so only ‘none’ level is possible for degraded case."""@en ;
+If parameter 1.1.1.3.2.1 is not used (no ETCS), no degradation is possible, so only ‘none’ level is possible for degraded case.
+
+See also TSI OPE 4.2.3.6. Degraded operation."""@en ;
 	                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present). Degraded level must be lower than actual operating level."@en ;
-		 	  dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> , <http://data.europa.eu/eli/reg_impl/2019/773/2023-09-28> ;
+		 	              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> , <http://data.europa.eu/eli/reg_impl/2019/773/2023-09-28> ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "ETCS level for degraded situation"@en ;
                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -947,7 +957,7 @@ era:etcsEquipmentOnBoardLevel rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/etcsInfill
-era:etcsInfill rdf:type owl:ObjectProperty ;
+era:etcsInfill rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                rdfs:domain [ rdf:type owl:Class ;
                              owl:unionOf ( era:CCSSubsystem
                                            era:VehicleType
@@ -962,7 +972,8 @@ era:etcsInfill rdf:type owl:ObjectProperty ;
                <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                    "2024-04-18"^^xsd:date ;
-               rdfs:comment "Information about installed trackside equipment capable to transmit infill information TSI CCS (4.2.2) by loop or Global System for Mobile communications for Railways (GSM-R) for level 1 installations."@en ;
+               rdfs:comment "Information about installed trackside equipment capable of transmitting infill information by loop or Global System for Mobile communications for Railways (GSM-R) for level 1 installations."@en ;
+               dcterms:description "TSI CCS (4.2.2 & 4.3.3)" ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
 		           dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                rdfs:label "ETCS infill installed line-side"@en ;
@@ -994,10 +1005,8 @@ era:etcsLevelType rdf:type owl:ObjectProperty ;
                   <http://purl.org/dc/terms/created> "2021-08-07"^^xsd:date ;
                   <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date , "2024-04-18"^^xsd:date ;
                   rdfs:comment "European Train Control System (ETCS) application level related to the track side equipment."@en ;
-		              dcterms:relation era:etcsBaseline ;
-		              dcterms:description """See TSI CCS (Subset-026, Chapter 2, 2.6) 
-                  
-The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
+		              dcterms:relation era:etcsBaseline , era:etcsMVersion , era:etcsSystemCompatibility , era:etcsTransmittedTrackConditions , era:gsmRActiveMobiles , era:etcsDegradedSituation , era:cantDeficiencyBasicSSP , era:rbcPhone , era:rbcID ;
+		              dcterms:description """The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
 	
 Level definitions are principally related to the track side equipment used, to the way the track side information reaches the on-board units and to which functions are processed in the track side and in the on-board equipment respectively."""@en ;
 		  dcterms:requires """If ETCS is on the trackside (one or more levels are selected), all other ETCS parameters (from 1.1.1.3.2.2 to 1.1.1.3.2.10) are applicable.
@@ -1005,7 +1014,9 @@ Level definitions are principally related to the track side equipment used, to t
 The ETCS value NTC is only relevant when the line is dual equipped with ETCS (i.e., balises are placed in the track) and Class B system, and both systems are in operation at the same time. 
 In those cases, this parameter should be filled relevant ETCS Level and repeated with the value “NTC”.
 	
-If the line is only equipped with Class B, this should be reflected in Parameter 1.1.1.3.5.3, and this parameter etcsLevelType should not be used. """@en ; 
+If the line is only equipped with Class B, this should be reflected in Parameter 1.1.1.3.5.3, and this parameter etcsLevelType should not be used. 
+
+See: TSI CCS (Subset-026, Chapter 2, 2.6)"""@en ; 
 		              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "ETCS level"@en ;
@@ -1049,12 +1060,25 @@ era:etcsSystemCompatibility rdf:type owl:ObjectProperty ;
                             <http://purl.org/dc/terms/created> "2020-08-31"^^xsd:date ;
                             <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
                             rdfs:comment "ETCS requirements used for demonstrating technical compatibility."@en ;
-                            dcterms:source <https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf> ;
-                            dcterms:definition """The Infrastructure Manager is responsible for defining the ESC type(s). All sections of the Union network which require the same set of checks for the demonstration of ESC shall have the same ESC type.
+                            dcterms:source <https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf> , 
+                                           <https://eur-lex.europa.eu/eli/reg_impl/2019/776/oj> ;
+                            dcterms:definition """The Values "Not defined" or "ESC-EU-0" should not be combined with other values.
 
-The list of ESC Types is published and maintained by the European Union Agency for Railways in the technical document ‘ESC/RSC technical document, TD/011REC1028’. See Appendix A, Table A 1, 4.2.17 a. The Agency shall assess the checks unless they have been assessed by a NoBo as required in Table 6.3 row 10. The assessment by the Agency shall be done within 2 months of receipt thereof, unless a longer period is agreed between the Agency and the Infrastructure Manager but not exceeding 4 months in total. The technical document will be updated within 10 working days after positive assessment.
+For application in CCS Onboard:
+The vehicles are considered compatible with the infrastructure for this parameter, if their parameter value matches any of the values declared on the trackside. 
+
+For application in CCS Trackside:
+The Infrastructure Manager is responsible for defining the ESC type(s). All sections of the Union network which require the same set of checks for the demonstration of ESC shall have the same ESC type.
+
+See: TSI CCS, Appendix A, Table A 1, 4.2.17 a.
+The list of ESC Types is published and maintained by the European Union Agency for Railways in the technical document ‘ESC/RSC technical document, TD/011REC1028’. 
+The Agency shall assess the checks unless they have been assessed by a NoBo as required in Table 6.3 row 10. 
+The assessment by the Agency shall be done within 2 months of receipt thereof, unless a longer period is agreed between the Agency and the Infrastructure Manager but not exceeding 4 months in total. 
+The technical document will be updated within 10 working days after positive assessment.
 
 The ESC Types shall only be used when published with status ‘Valid’ in the Agency Technical document referred above."""@en ; 
+                            rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
+                            dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "ETCS system compatibility"@en ;
                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -1074,7 +1098,7 @@ era:etcsTransmittedTrackConditions rdf:type owl:ObjectProperty , owl:FunctionalP
                                                                        "2023-04-18"^^xsd:date ;
                                    rdfs:comment """Transmittable track conditions by the CCSSubsystem, as per CCS TSI.
 
-See TSI CCS (Subset-026, Chapter 5, section 5.18.1.1)"""@en ;
+See: TSI CCS (Subset-026, Chapter 5, section 5.18.1.1)"""@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Track conditions which can be transmitted"@en ;
 		 	           rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
@@ -1541,7 +1565,8 @@ era:legacyRadioSystem rdf:type owl:ObjectProperty ;
                       <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                           "2024-04-18"^^xsd:date ;
                       <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
-                      rdfs:comment "Indication of radio legacy systems installed. The list is in line with ERA/TD/2011-09/INT (v1.13), Table 4. "@en ;
+                      rdfs:comment "Indication of radio legacy systems installed."@en ;
+                      dcterms:description "The list is in line with ERA/TD/2011-09/INT (v1.13), Table 4."@en ;
                       dcterms:source <https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf> ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Other radio systems installed (Radio Legacy Systems)"@en ;
@@ -1743,7 +1768,7 @@ era:mNvcontact rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                                                    "2024-04-18"^^xsd:date ;
                rdfs:comment """On-Board system reaction when T_NVCONTACT expires.
 
-See TSI CCS (Subset-026, chapter 7. 7.5.1.74 M_NVCONTACT)"""@en ;
+See: TSI CCS (Subset-026, chapter 7. 7.5.1.74 M_NVCONTACT)"""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
 	       rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
@@ -2482,7 +2507,7 @@ era:siding rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/signalOrientation
-era:signalOrientation rdf:type owl:ObjectProperty ;
+era:signalOrientation rdf:type owl:ObjectProperty , owl:FunctionalProperty ;
                       rdfs:domain era:Signal ;
                       rdfs:range <http://www.w3.org/2004/02/skos/core#Concept> ;
                       era:XMLName "SIG_LocDir" ;
@@ -2513,7 +2538,8 @@ era:signalType rdf:type owl:ObjectProperty ;
                <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
                                                    "2024-04-18"^^xsd:date ;
                <http://purl.org/dc/terms/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
-               rdfs:comment "Signalling information for Route Book compilation. Indicates what function the signal (on the track or in OP) executes in relation to the track/switches."@en ;
+               rdfs:comment "Signalling information for Route Book compilation."@en ;
+               dcterms:description "Indicates what function the signal (on the track or in OP) executes in relation to the track/switches."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "Type of signal"@en ;
                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
@@ -3605,7 +3631,7 @@ era:compositeBrakeBlockRetrofitted rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/conditionalRegenerativeBrake
-era:conditionalRegenerativeBrake rdf:type owl:DatatypeProperty ;
+era:conditionalRegenerativeBrake rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                                  rdfs:domain era:ContactLineSystem ;
                                  rdfs:range xsd:boolean ;
                                  era:XMLName "ECS_RegenerativeBraking" ;
@@ -3653,7 +3679,7 @@ era:conditionsChargingElectricEnergyStorage rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/conditionsSwitchClassBSystems
 era:conditionsSwitchClassBSystems rdf:type owl:DatatypeProperty ;
                                   rdfs:domain era:CCSSubsystem ;
-                                  rdfs:range xsd:anyURI ;
+                                  rdfs:range xsd:string ;
                                   era:XMLName "CTS_SwitchProtectAB" ;
                                   era:appendixD2Index "3.4.3" ;
                                   era:rinfIndex "1.1.1.3.8.3" ,
@@ -3671,7 +3697,7 @@ era:conditionsSwitchClassBSystems rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/conditionsSwitchTrainProtectionSystems
 era:conditionsSwitchTrainProtectionSystems rdf:type owl:DatatypeProperty ;
                                            rdfs:domain era:CCSSubsystem ;
-                                           rdfs:range xsd:anyURI ;
+                                           rdfs:range xsd:string ;
                                            era:XMLName "CTS_SwitchProtectConditions" ;
                                            era:appendixD2Index "3.4.2" ;
                                            era:rinfIndex "1.1.1.3.8.1.1" ,
@@ -4212,10 +4238,10 @@ era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty , owl:Fun
                                          era:rinfIndex "1.1.1.3.2.13" ,
                                                        "1.2.1.1.1.13" ;
                                          <http://purl.org/dc/terms/created> "2022-11-04"^^xsd:date ;
-                                 	 <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
+                                 	       <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                          rdfs:comment "If the trackside does not implement any solution to cover defective LXs (which are normally protected by means of a technical system), then drivers will be required to comply with instructions received from other sources."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-	    				 rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
+	    				                           rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                          rdfs:label "ETCS trackside implements level crossing procedure or an equivalent solution"@en ;
                                          dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                                          dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -4223,7 +4249,7 @@ era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty , owl:Fun
 
 
 ###  http://data.europa.eu/949/etcsInfillLineAccess
-era:etcsInfillLineAccess rdf:type owl:DatatypeProperty ;
+era:etcsInfillLineAccess rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                          rdfs:domain era:CCSSubsystem ;
                          rdfs:range xsd:boolean ;
                          era:XMLName "CPE_Infill" ;
@@ -4232,6 +4258,11 @@ era:etcsInfillLineAccess rdf:type owl:DatatypeProperty ;
                          <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                          <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ;
                          rdfs:comment "Indication whether infill is required to access the line for safety reasons."@en ;
+                         dcterms:description """As indicated in CCS TSI section 7.2.9.1, an ETCS Level 1 trackside application may require that the on-board is equipped with the corresponding in-fill data transmission (Euroloop or radio) if the release speed is set to zero for safety reasons.
+                         
+See: TSI CCS 7.2.9.1 & 4.2.3 """@en ;
+                         dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
+		                     dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "ETCS infill necessary for line access"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -4264,7 +4295,16 @@ era:etcsNationalPacket44 rdf:type owl:DatatypeProperty ;
                          <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                          <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                              "2024-04-18"^^xsd:date ;
-                         rdfs:comment "Indication whether data for national packet 44 applications is transmitted between track and train. Value can be `false` or a link to the implemented functions."@en ;
+                         rdfs:comment "Indication whether data for national packet 44 applications is transmitted between track and train."@en ;
+                         dcterms:description """Value can be `false` or a link to the implemented functions.
+
+Packets 44 are the means to transmit data for national applications between train and track and vice versa, using the data transmission facilities included within the ETCS. 
+NID_XUSER values managed by ERA in a document about ETCS variables available on ERA website. 
+
+See: TSI CCS (7.4.3 & 6.2.4.2)""" @en ;
+                         dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
+		                     dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
+	     			             rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "ETCS national packet 44 application implemented"@en ;
                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -4292,6 +4332,7 @@ era:etcsOptionalFunctions rdf:type owl:DatatypeProperty ;
                           <http://purl.org/dc/terms/modified> "2023-03-14"^^xsd:date ;
                           rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. Optional ETCS functions which might improve operation on the line."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+		                      dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ; 
                           rdfs:label "ETCS optional functions"@en ;
                           owl:deprecated "true"^^xsd:boolean ;
                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
@@ -4327,7 +4368,7 @@ era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty , owl:FunctionalP
                                                                      "2024-04-18"^^xsd:date ;
                                  rdfs:comment """If the trackside does not provide Track Conditions, the driver will need to be informed about such conditions via alternative methods."""@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-	     			 rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
+	     			                     rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                  rdfs:label "Is the ETCS trackside engineered to transmit Track Conditions"@en ;
                                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ; 
                                  dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -4666,11 +4707,14 @@ era:hasETCSRestrictionsConditions rdf:type owl:DatatypeProperty ;
                                   <http://purl.org/dc/terms/created> "2021-08-08"^^xsd:date ;
                                   <http://purl.org/dc/terms/modified> "2024-01-08"^^xsd:date ,
                                                                       "2024-04-18"^^xsd:date ;
-                                  rdfs:comment """Indication whether restrictions or conditions due to partial compliance with the TSI CCS exist. If not `false`, a link to the conditions must be provided.
+                                  rdfs:comment "Indication whether restrictions or conditions due to partial compliance with the TSI CCS exist."@en ;
+                                  dcterms:description: """If not `false`, a link to the conditions must be provided. The RU has to contact the IM to be informed about these conditions.
                                   
 These conditions and restrictions of use are considered in section 6.4 of the CCS TSI. They should be described using the template available on Agency website (Certification 
-and deviations – Guidelines for using the ERA template) with the following link: https://www.era.europa.eu/system/files/2022-11/restrictions_and_added_functions_en_1.doc."""@en ;
+and deviations – Guidelines for using the ERA template) with the following link."""@en ;
+                                  rdfs:seeAlso <https://www.era.europa.eu/system/files/2022-11/restrictions_and_added_functions_en_1.doc> ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                                   dcterms:source <https://www.era.europa.eu/content/certification-issues> ;
                                   rdfs:label "Existence of operating restrictions or conditions"@en ;
                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -5156,7 +5200,7 @@ the functions of the infrastructure manager on a network or part of a network ma
 ###  http://data.europa.eu/949/instructionsSwitchRadioSystems
 era:instructionsSwitchRadioSystems rdf:type owl:DatatypeProperty ;
                                    rdfs:domain era:CCSSubsystem ;
-                                   rdfs:range xsd:anyURI ;
+                                   rdfs:range xsd:string ;
                                    era:XMLName "CTS_SwitchRadioConditions" ;
                                    era:appendixD2Index "3.4.4" ;
                                    era:rinfIndex "1.1.1.3.8.2.1" ,
@@ -5259,7 +5303,7 @@ era:length rdf:type owl:DatatypeProperty ;
 - a platform (For its usable length, use era:lengthOfPlatform), 
 - a siding (For its usable length, use era:lengthOfSiding), and 
 - length of other areas such as 
-  - a non-stopping area, 
+  - a non-stopping area (accuracy +- 10m), 
   - a walkway, 
   - an evacuation and rescue point.
 
@@ -5441,7 +5485,7 @@ era:mNvderun rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
 See: TSI CCS (Subset 26, chapter 7. 7.5.1.75 M_NVDERUN)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
-	     rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
+	           rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
              rdfs:label "M_NVDERUN"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -6796,7 +6840,7 @@ era:qNvdriverAdhes rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                    <http://purl.org/dc/terms/created> "2024-04-18"^^xsd:date ;
                    rdfs:comment """Boolean determining whether the driver is allowed to modify the adhesion factor used by the ETCS on-board to calculate the braking curves. 
 
-See TSI CCS (Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES)"""@en ;
+See: TSI CCS (Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES)"""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
                    dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -6817,7 +6861,7 @@ era:qNvsbtsmperm rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                  <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                  rdfs:comment """Permission to use service brake in target speed monitoring.
 
-See TSI CCS (Subset-026, chapter 7. 7.5.1.124 Q_NVSBTSMPERM)"""@en ;
+See: TSI CCS (Subset-026, chapter 7. 7.5.1.124 Q_NVSBTSMPERM)"""@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
 	         rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                  dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
@@ -7019,11 +7063,13 @@ era:referencePassByNoiseLevel rdf:type owl:DatatypeProperty ;
 era:relativeDistanceDangerPoint rdf:type owl:DatatypeProperty ;
                                 rdfs:domain era:Signal ;
                                 rdfs:range xsd:integer ;
+                                era:unitOfMeasure <https://qudt.org/vocab/unit/M> ;
                                 era:appendixD2Index "2.2.3" ,
                                                     "2.3.3" ;
                                 era:rinfIndex "1.1.1.3.14.4" ,
                                               "1.2.1.0.8.4" ;
                                 <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
+                                <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
                                 rdfs:comment "Distance in meters to the danger point."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Relative distance of the danger point"@en ;
@@ -7104,7 +7150,7 @@ era:sidingId rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/signalId
-era:signalId rdf:type owl:DatatypeProperty ;
+era:signalId rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
              rdfs:subPropertyOf <http://purl.org/dc/terms/identifier> ;
              rdfs:domain era:Signal ;
              rdfs:range xsd:string ;
@@ -7114,9 +7160,9 @@ era:signalId rdf:type owl:DatatypeProperty ;
                            "1.2.1.0.8.1" ;
              <http://purl.org/dc/terms/created> "2023-03-14"^^xsd:date ;
              <http://purl.org/dc/terms/modified> "2024-04-18"^^xsd:date ;
-             rdfs:comment "Identifier of the signal (on the track or in OP), as in the operational and maintenance provisions."@en ;
+             rdfs:comment "Operational identifier of the signal (on the track or in OP), as in the operational and maintenance provisions."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-             rdfs:label "Operational name of signal"@en ;
+             rdfs:label "Name of signal"@en ;
              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
 
 
@@ -7446,7 +7492,7 @@ era:tNvovtrp rdf:type owl:DatatypeProperty, owl:FunctionalProperty ;
 
 Precision: [NNN], with N a decimal number (0÷9)
 
-See TSI CCS (Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP)"""@en ;
+See: TSI CCS (Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              dcterms:requires "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en ;
              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -7620,7 +7666,7 @@ era:trainDetectionSystemSpecificCheck rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/trainIntegrityOnBoardRequired
-era:trainIntegrityOnBoardRequired rdf:type owl:DatatypeProperty ;
+era:trainIntegrityOnBoardRequired rdf:type owl:DatatypeProperty , owl:FunctionalProperty ;
                                   rdfs:domain era:CCSSubsystem ;
                                   rdfs:range [ rdf:type rdfs:Datatype ;
                                                owl:oneOf [ rdf:type rdf:List ;
@@ -7643,6 +7689,7 @@ era:trainIntegrityOnBoardRequired rdf:type owl:DatatypeProperty ;
                                   <http://purl.org/dc/terms/modified> "2021-09-12"^^xsd:date ,
                                                                       "2024-04-18"^^xsd:date ;
                                   rdfs:comment "Indication whether train confirmation from on-board is required to access the line for safety reasons. In hybrid operation, the confirmation can be optional."@en ;
+                                  dcterms:requires "Parameter only applicable when ETCS Baseline > 4 MR1 with operation requiring train integrity." ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Train integrity confirmation from on-board (not from driver) necessary for line access"@en ;
                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
@@ -8668,7 +8715,7 @@ era:PrimaryLocation rdf:type owl:Class ;
 Primary locations are for example: stations, yards, halts, handover points, border points, open access terminals. 
 Primary locations are identified by single and unique Primary Location codes. Primary location code is allocated based on processes defined by national entity. Primary location codes are used in any kind of TAF/TAP communication.
 
-See Handbook 9.3.3 / page 60"""@en ;
+See: Handbook 9.3.3 / page 60"""@en ;
                     rdfs:seeAlso <http://taf-jsg.info/wp-content/uploads/2024/01/20231018-JGS-Handbook-3.4-with-XSD-3.4.0.0.pdf> .
 
 


### PR DESCRIPTION
Please note I also used:
- `dcterms:source` for the "Reference", i.e the EULEX or ERA document describing the basis of the parameter
- `rdfs:requires` for the "Applicable" - conditions
- `dcterms:relation` to link to another parameter if there is a dependency
- `dcterms:description` for the "Explanations" or any data not in Defintion/Data presentation.

The `dcterms`-prefix was therefore also added.