### PR TITLE
Revision 13-08-2024 of the ontology.ttl

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -1,27 +1,33 @@
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 @prefix era: <http://data.europa.eu/949/> .
-@prefix era: <http://data.europa.eu/949/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix org: <http://www.w3.org/ns/org#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix wgs: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix qudt: <http://qudt.org/vocab/unit/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 <http://data.europa.eu/949/> rdf:type owl:Ontology ;
-                              <http://creativecommons.org/ns#license> <https://creativecommons.org/licenses/by/4.0/> ;
+                              cc:license <https://creativecommons.org/licenses/by/4.0/> ;
                               dcterms:contributor [ foaf:name "Maarten Duhoux" ;
-                                                    <http://www.w3.org/ns/org#memberOf> <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+                                                    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
                                                   ] ,
                                                   "Designated RINF Topical Working Groups"@en ;
                               dcterms:creator [ foaf:name "Ghislain Atemezing" ;
                                                 rdfs:seeAlso <https://orcid.org/0000-0003-1562-6922> ;
-                                                <http://www.w3.org/ns/org#memberOf> <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+                                                org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
                                               ] ,
                                               [ foaf:name "Dragos Patru" ;
-                                                <http://www.w3.org/ns/org#memberOf> <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+                                                org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
                                               ] ;
                               dcterms:issued "2024-04-18"^^xsd:date ;
                               dcterms:modified "2024-04-18"^^xsd:date ,
@@ -29,8 +35,9 @@
                                                "2024-06-03"^^xsd:date ,
                                                "2024-06-05"^^xsd:date ,
                                                "2024-07-05"^^xsd:date ,
-											   "2024-08-02"^^xsd:date ,
-											   "2024-08-12"^^xsd:date ;
+                                               "2024-08-02"^^xsd:date ,
+                                               "2024-08-12"^^xsd:date ,
+                                               "2024-08-13"^^xsd:date ;
                               dcterms:publisher "European Union Agency for Railways" ;
                               dcterms:title "ERA Ontology"@en ;
                               rdfs:comment """This is the human and machine readable Ontology governed by the European Union Agency for Railways (https://www.era.europa.eu/). It represents the concepts and relationships linked to the sectorial legal framework and the use cases under the AgencyÂ´s remit, as described in the Commission Implementing Regulation (EU) [to be updated after publication] on the common specifications for the register of railway infrastructure [to be updated after publication].
@@ -43,6 +50,13 @@ The Ontology also includes the routebook concepts described in appendix D2 \"Ele
                               owl:versionInfo "v3.1.0"@en ;
                               owl:versionURI <https://github.com/Interoperable-data/ERA_vocabulary/releases/releases/v3.1.0> ;
                               skos:changeNote """
+Revision 13-08-2024:
+- clarified the comment and label for ORG pattern as per issue #74.
+- renamed prefix qudt: to unit: to avoid confusion as per issue #47. 
+- merged annexD2Index with appendixD2index as per issue #50. 
+- added range and/or domain for annotation properties as per issue #56. 
+- fixed label and comment for the properies era:ETCSLevel and era:ETCSLevelType as per issue #60. 
+
 Revision 12-08-2024:
 - removed owl:incompatibleWith in a property as per issue #71.
 - Reduced some long labels + split off notes from definition (see issue #45)
@@ -95,44 +109,42 @@ Revision 18-04-2024:
 #################################################################
 
 ###  http://creativecommons.org/ns#license
-<http://creativecommons.org/ns#license> rdf:type owl:AnnotationProperty .
+cc:license rdf:type owl:AnnotationProperty .
 
 
 ###  http://data.europa.eu/949/XMLName
 era:XMLName rdf:type owl:AnnotationProperty ;
             dcterms:created "2023-05-26"^^xsd:date ;
+            dcterms:modified "2024-08-13"^^xsd:date ;
             rdfs:comment "Corresponding XML name as indicated in the RINF application guide: https://www.era.europa.eu/sites/default/files/registers/docs/rinf_application_guide_for_register_en.pdf"@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-            rdfs:label "XML name"@en .
-
-
-###  http://data.europa.eu/949/annexD2Index
-era:annexD2Index rdf:type owl:AnnotationProperty .
+            rdfs:label "XML name"@en ;
+            rdfs:range xsd:string .
 
 
 ###  http://data.europa.eu/949/appendixD2Index
 era:appendixD2Index rdf:type owl:AnnotationProperty ;
+                    dcterms:created "2022-11-04"^^xsd:date ;
+                    dcterms:modified "2024-08-13"^^xsd:date ;
                     rdfs:comment "The index of a vocabulary term in Appendix D2 Elements the infrastructure manager has to provide to the railway undertaking for the Route Book from the document Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision 2012/757/EU."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Appendix D2 index"@en ;
-                    skos:definition "The index of a vocabulary term in Appendix D2 Elements the infrastructure manager has to provide to the railway undertaking for the Route Book from the document Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision 2012/757/EU."@en .
+                    skos:definition "The index of a vocabulary term in Appendix D2 Elements the infrastructure manager has to provide to the railway undertaking for the Route Book from the document Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision 2012/757/EU."@en ;
+                    rdfs:range xsd:string .
 
-
-###  http://data.europa.eu/949/appendixD2index
-era:appendixD2index rdf:type owl:AnnotationProperty .
 
 
 ###  http://data.europa.eu/949/appendixD3Index
 era:appendixD3Index rdf:type owl:AnnotationProperty ;
                     dcterms:created "2022-11-04"^^xsd:date ;
+                    dcterms:modified "2024-08-13"^^xsd:date ;
                     rdfs:comment "The index of a vocabulary term in Appendix D3 ERTMS trackside engineering information relevant to operation that the infrastructure manager shall provide to the railway undertaking."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Appendix D3 index"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" ;
+                    rdfs:range xsd:string .
 
 
-###  http://data.europa.eu/949/appendixD3index
-era:appendixD3index rdf:type owl:AnnotationProperty .
 
 
 ###  http://data.europa.eu/949/canonicalURI
@@ -152,11 +164,13 @@ Additionally, SoLs point to the canonical URIs of their start OP and end OP."""@
 ###  http://data.europa.eu/949/eratvIndex
 era:eratvIndex rdf:type owl:AnnotationProperty ;
                dcterms:created "2020-11-03"^^xsd:date ;
-               dcterms:modified "2020-11-03"^^xsd:date ;
+               dcterms:modified "2020-11-03"^^xsd:date ,
+                                "2024-08-13"^^xsd:date ;
                rdfs:comment "Index code used in the original definition of a parameter in ERATV."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "ERATV index"@en ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+               vs:term_status "stable" ;
+               rdfs:range xsd:string .
 
 
 ###  http://data.europa.eu/949/hashSource
@@ -172,29 +186,36 @@ era:hashSource rdf:type owl:AnnotationProperty ;
 ###  http://data.europa.eu/949/inSkosConceptScheme
 era:inSkosConceptScheme rdf:type owl:AnnotationProperty ;
                         dcterms:created "2022-11-17"^^xsd:date ;
+                        dcterms:modified "2024-08-13"^^xsd:date ;
                         rdfs:comment "Property that links an object SKOS property to a the URI of the corresponding SKOS Concept Scheme."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "in SKOS Concept Scheme"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
-                        rdfs:range xsd:anyURI .
+                        vs:term_status "stable" ;
+                        rdfs:range skos:ConceptScheme ;
+                        rdfs:domain owl:ObjectProperty .
 
 
 ###  http://data.europa.eu/949/rinfIndex
 era:rinfIndex rdf:type owl:AnnotationProperty ;
               dcterms:created "2020-11-03"^^xsd:date ;
               dcterms:modified "2020-11-03"^^xsd:date ;
+              dcterms:modifief "2024-08-13"^^xsd:date ;
               rdfs:comment "Index code used in the original definition of a parameter in RINF."@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "RINF index"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+              vs:term_status "stable" ;
+              rdfs:range xsd:string .
 
 
 ###  http://data.europa.eu/949/unitOfMeasure
 era:unitOfMeasure rdf:type owl:AnnotationProperty ;
                   dcterms:created "2024-05-16"^^xsd:date ;
+                  dcterms:modified "2024-08-13"^^xsd:date ;
                   rdfs:comment "Magnitude of a quantity, defined and adopted by convention or by law, that is used as a standard for measurement of the same kind of quantity."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                  rdfs:label "Unit of measure"@en .
+                  rdfs:label "Unit of measure"@en ;
+                  rdfs:range unit: ;
+                  rdfs:domain owl:DatatypeProperty .
 
 
 ###  http://data.europa.eu/949/usedInRCCCalculations
@@ -208,27 +229,27 @@ https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj#:~:text=Commission%20Implemen
 
 
 ###  http://purl.org/dc/elements/1.1/contributor
-<http://purl.org/dc/elements/1.1/contributor> rdf:type owl:AnnotationProperty .
+dc:contributor rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/elements/1.1/creator
-<http://purl.org/dc/elements/1.1/creator> rdf:type owl:AnnotationProperty .
+dc:creator rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/elements/1.1/date
-<http://purl.org/dc/elements/1.1/date> rdf:type owl:AnnotationProperty .
+dc:date rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/elements/1.1/description
-<http://purl.org/dc/elements/1.1/description> rdf:type owl:AnnotationProperty .
+dc:description rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/elements/1.1/source
-<http://purl.org/dc/elements/1.1/source> rdf:type owl:AnnotationProperty .
+dc:source rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/elements/1.1/title
-<http://purl.org/dc/elements/1.1/title> rdf:type owl:AnnotationProperty .
+dc:title rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/terms/author
@@ -267,12 +288,20 @@ dcterms:issued rdf:type owl:AnnotationProperty .
 dcterms:modified rdf:type owl:AnnotationProperty .
 
 
+###  http://purl.org/dc/terms/modifief
+dcterms:modifief rdf:type owl:AnnotationProperty .
+
+
 ###  http://purl.org/dc/terms/publisher
 dcterms:publisher rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/terms/relation
 dcterms:relation rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/replaces
+dcterms:replaces rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.org/dc/terms/source
@@ -288,35 +317,35 @@ owl:versionURI rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#alt
-<http://www.w3.org/2003/01/geo/wgs84_pos#alt> rdf:type owl:AnnotationProperty ;
-                                              rdfs:comment """The WGS84 altitude of a SpatialThing (decimal meters 
+wgs:alt rdf:type owl:AnnotationProperty ;
+        rdfs:comment """The WGS84 altitude of a SpatialThing (decimal meters 
 above the local reference ellipsoid).""" ;
-                                              rdfs:label "altitude" ;
-                                              rdfs:domain <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> .
+        rdfs:label "altitude" ;
+        rdfs:domain wgs:SpatialThing .
 
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#lat
-<http://www.w3.org/2003/01/geo/wgs84_pos#lat> rdf:type owl:AnnotationProperty ;
-                                              rdfs:comment "The WGS84 latitude of a SpatialThing (decimal degrees)." ;
-                                              rdfs:label "latitude" ;
-                                              rdfs:domain <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> .
+wgs:lat rdf:type owl:AnnotationProperty ;
+        rdfs:comment "The WGS84 latitude of a SpatialThing (decimal degrees)." ;
+        rdfs:label "latitude" ;
+        rdfs:domain wgs:SpatialThing .
 
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#location
-<http://www.w3.org/2003/01/geo/wgs84_pos#location> rdf:type owl:AnnotationProperty ;
-                                                   rdfs:subPropertyOf foaf:based_near ;
-                                                   rdfs:range <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> .
+wgs:location rdf:type owl:AnnotationProperty ;
+             rdfs:subPropertyOf foaf:based_near ;
+             rdfs:range wgs:SpatialThing .
 
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#long
-<http://www.w3.org/2003/01/geo/wgs84_pos#long> rdf:type owl:AnnotationProperty ;
-                                               rdfs:comment "The WGS84 longitude of a SpatialThing (decimal degrees)." ;
-                                               rdfs:label "longitude" ;
-                                               rdfs:domain <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> .
+wgs:long rdf:type owl:AnnotationProperty ;
+         rdfs:comment "The WGS84 longitude of a SpatialThing (decimal degrees)." ;
+         rdfs:label "longitude" ;
+         rdfs:domain wgs:SpatialThing .
 
 
 ###  http://www.w3.org/2003/06/sw-vocab-status/ns#term_status
-<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> rdf:type owl:AnnotationProperty .
+vs:term_status rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#altLabel
@@ -331,6 +360,14 @@ skos:changeNote rdf:type owl:AnnotationProperty .
 skos:definition rdf:type owl:AnnotationProperty .
 
 
+###  http://www.w3.org/2004/02/skos/core#editorialNote
+skos:editorialNote rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
 ###  http://www.w3.org/2004/02/skos/core#prefLabel
 skos:prefLabel rdf:type owl:AnnotationProperty .
 
@@ -340,7 +377,7 @@ skos:scopeNote rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/ns/org#memberOf
-<http://www.w3.org/ns/org#memberOf> rdf:type owl:AnnotationProperty .
+org:memberOf rdf:type owl:AnnotationProperty .
 
 
 ###  http://xmlns.com/foaf/0.1/based_near
@@ -352,7 +389,7 @@ foaf:based_near rdf:type owl:AnnotationProperty .
 #################################################################
 
 ###  http://www.opengis.net/ont/geosparql#wktLiteral
-<http://www.opengis.net/ont/geosparql#wktLiteral> rdf:type rdfs:Datatype .
+geo:wktLiteral rdf:type rdfs:Datatype .
 
 
 ###  http://www.w3.org/2001/XMLSchema#date
@@ -379,7 +416,7 @@ era:TSIMagneticFields rdf:type owl:ObjectProperty ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "existence and TSI compliance of rules for magnetic fields emitted by a vehicle"@en ;
                       owl:deprecated "true"^^xsd:boolean ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/TSITractionHarmonics
@@ -397,7 +434,7 @@ era:TSITractionHarmonics rdf:type owl:ObjectProperty ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "existence and TSI compliance of limits in harmonics in the traction current of vehicles"@en ;
                          owl:deprecated "true"^^xsd:boolean ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/additionalBrakingInformationDocument
@@ -413,7 +450,7 @@ era:additionalBrakingInformationDocument rdf:type owl:ObjectProperty ;
                                          rdfs:comment "Electronic document available in two EU languages from the IM stored by the Agency providing additional information as defined in point (2) of point 4.2.2.6.2 of TSI OPE."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Documents available by the IM relating to braking performance"@en ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                         vs:term_status "stable" ;
                                          skos:changeNote "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
 
@@ -421,14 +458,18 @@ era:additionalBrakingInformationDocument rdf:type owl:ObjectProperty ;
 era:allocationCompany rdf:type owl:ObjectProperty ;
                       rdfs:domain era:SubsidiaryLocation ;
                       rdfs:range era:Body ;
-                      rdfs:label "allocation company"@en ;
-                      rdfs:comment "the organisation in charge to allocate the code for the subsidiary location"@en .
+                      dcterms:created "2024-05-24"^^xsd:date ;
+                      rdfs:comment "the organisation in charge to allocate the code for the subsidiary location"@en ;
+                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                      rdfs:label "allocation company"@en .
 
 
 ###  http://data.europa.eu/949/applicability
 era:applicability rdf:type owl:ObjectProperty ;
                   rdfs:domain era:Applicability ;
                   rdfs:range era:TechnicalCharacteristics ;
+                  dcterms:created "2024-05-24"^^xsd:date ;
+                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "applicability"@en .
 
 
@@ -447,7 +488,7 @@ era:atoCommunicationSystem rdf:type owl:ObjectProperty ;
                            rdfs:comment "Supported ATO communication systems from trackside."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "ATO communication system"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" ;
+                           vs:term_status "unstable" ;
                            skos:scopeNote "Parameter only applicable when ETCS Baseline > 4 MR1 and ATO is implemented"@en .
 
 
@@ -466,7 +507,7 @@ era:atoGradeAutomation rdf:type owl:ObjectProperty ;
                        rdfs:comment "ATO grade of automation installed lineside."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "ATO Grade of Automation"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                       vs:term_status "stable" ;
                        skos:scopeNote "Parameter only applicable when ETCS Baseline > 4 MR1 and ATO is implemented"@en .
 
 
@@ -486,7 +527,7 @@ era:atoSystemVersion rdf:type owl:ObjectProperty ;
                      rdfs:comment "ATO system version according to the specification referenced in TSI CCS (4.2.19)."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "ATO System version"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                     vs:term_status "stable" ;
                      skos:scopeNote "Parameter only applicable when ETCS Baseline > 4 MR1 and ATO is implemented"@en .
 
 
@@ -500,7 +541,7 @@ era:authorizedCountry rdf:type owl:ObjectProperty ;
                       rdfs:comment "Indicates the country(ies) in where a vehicle type has been authorized to operate."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "authorized country"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/axleBearingConditionMonitoring
@@ -514,7 +555,7 @@ era:axleBearingConditionMonitoring rdf:type owl:ObjectProperty ;
                                    rdfs:comment "Axle bearing condition monitoring."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "axle bearing condition monitoring"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/belongsTo
@@ -533,7 +574,7 @@ era:borderPointOf rdf:type owl:ObjectProperty ;
                   rdfs:comment "TODO: review. Relates the information that each country maintains on a border point, to the operational point that represents the general information on the border point."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "border point of"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/cantDeficiencyBasicSSP
@@ -557,7 +598,7 @@ a) The “Cant Deficiency” SSP categories: the cant deficiency value assigned 
 """@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "cant deficiency used for the basic SSP"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                           vs:term_status "stable" ;
                            skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -580,7 +621,7 @@ era:category rdf:type owl:ObjectProperty ;
              rdfs:comment "Vehicle category."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "Vehicle category"@en ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/certificate
@@ -594,7 +635,7 @@ era:certificate rdf:type owl:ObjectProperty ;
 Notified Bodies, supporting the EC Declaration(s) of Verification for the subsystems in scope of the type's authorisation by an authorizing entity."""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Certificate"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/companyCodeCategory
@@ -605,7 +646,7 @@ era:companyCodeCategory rdf:type owl:ObjectProperty ;
                         rdfs:comment "TODO review if used or necessary: Category of a Railway company. Can be Infrastructure, Freight or Passenger."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Company code category"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/compatibilityProcedureDocument
@@ -623,7 +664,7 @@ Or
 - relevant information for carrying out the checks for specific structures."""@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Document with the procedure(s) for static and dynamic route compatibility checks"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                   vs:term_status "stable" ;
                                    skos:changeNote "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
 
@@ -644,7 +685,7 @@ era:conditionsUseReflectivePlates rdf:type owl:ObjectProperty ;
                                   rdfs:comment "Details of any conditions for using the reflective plates on freight corridors. Specific case for Portugal and Spain until 1.1.2025 and Belgium and France until 1.1.2026."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "conditions for use of reflective plates"@en ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                                  vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/contactLineSystem
@@ -656,7 +697,7 @@ era:contactLineSystem rdf:type owl:ObjectProperty ;
                       rdfs:comment "Contact line system present in the section of line."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "contact line system"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/contactLineSystemType
@@ -672,7 +713,7 @@ era:contactLineSystemType rdf:type owl:ObjectProperty ;
                           rdfs:comment "Indication of the type of the contact line system."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "type of contact line system"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/contactStripMaterial
@@ -693,7 +734,7 @@ era:contactStripMaterial rdf:type owl:ObjectProperty ;
                          rdfs:comment "Indication of which contact strip materials are permitted to be used."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "permitted contact strip material"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/dataGSMRNetwork
@@ -707,7 +748,7 @@ era:dataGSMRNetwork rdf:type owl:ObjectProperty ;
                     rdfs:comment "Data SIM Card GSM-R Home Network."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Data GSM-R network"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/dataRadioCompatible
@@ -733,7 +774,7 @@ Information on RSC data requirements per country:
 https://www.era.europa.eu/era-folder/radio-system-compatibility-rsc-voice-and-data-documents"""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Radio system compatibility data"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                        vs:term_status "stable" ;
                         skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -747,17 +788,17 @@ era:definesSubset rdf:type owl:ObjectProperty ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Defines subset"@en ;
                   owl:deprecated "true"^^xsd:boolean ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/direction
 era:direction rdf:type owl:ObjectProperty ;
               rdfs:domain era:Orientation ;
-              rdfs:range skos:Concept;
-			  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-			  era:inSkosConceptScheme <http://data.europa.eu/949/concepts/orientations/Directions> ;
-			  dcterms:created "2024-04-23"^^xsd:date ;
+              rdfs:range skos:Concept ;
+              era:inSkosConceptScheme <http://data.europa.eu/949/concepts/orientations/Directions> ;
+              dcterms:created "2024-04-23"^^xsd:date ;
               rdfs:comment "The direction of the orientation of a railway element, in relation to the carrier object"@en ;
+              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               skos:definition "direction"@en .
 
 
@@ -775,10 +816,10 @@ era:eddyCurrentBraking rdf:type owl:ObjectProperty ;
                        dcterms:modified "2022-09-06"^^xsd:date ;
                        dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                        rdfs:comment "Indication of limitations on the use of eddy current brakes."@en ;
-                       skos:editorialNote "This property has been modified to be a RINF parameter (its eratvIndex is deleted). It is treated as a SKOS by RINF and as a boolean by ERATV. A new ERATV datatype property has been defined, eddyCurrentBrakingFitted with boolean values."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Use of eddy current brakes"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" ;
+                       skos:editorialNote "This property has been modified to be a RINF parameter (its eratvIndex is deleted). It is treated as a SKOS by RINF and as a boolean by ERATV. A new ERATV datatype property has been defined, eddyCurrentBrakingFitted with boolean values."@en .
 
 
 ###  http://data.europa.eu/949/eddyCurrentBrakingConditionsDocument
@@ -796,7 +837,7 @@ era:eddyCurrentBrakingConditionsDocument rdf:type owl:ObjectProperty ;
                                          rdfs:comment "Electronic document available in two EU languages from the IM stored by the Agency with conditions for the use of eddy current brakes identified in 1.1.1.1.6.2."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Document with the conditions for the use of eddy current brakes"@en ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                         vs:term_status "stable" ;
                                          skos:changeNote "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
 
@@ -811,7 +852,7 @@ Indicates the object that corresponds to a section of line, an operational point
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "Element A"@en ;
              owl:deprecated "true"^^xsd:boolean ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+             vs:term_status "stable" ;
              skos:altLabel "Internal connection"@en .
 
 
@@ -826,7 +867,7 @@ Indicates the object that corresponds to a section of line, an operational point
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "Element B"@en ;
              owl:deprecated "true"^^xsd:boolean ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+             vs:term_status "stable" ;
              skos:altLabel "Internal connection"@en .
 
 
@@ -838,7 +879,7 @@ era:elementPart rdf:type owl:ObjectProperty ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Element part"@en ;
                 owl:deprecated "true"^^xsd:boolean ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/elementPartOf
@@ -860,17 +901,17 @@ era:endCouplingType rdf:type owl:ObjectProperty ;
                     rdfs:comment "Type of end coupling (indicating tensile and compressive forces)."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "End coupling type"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/endLocation
 era:endLocation rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf <http://www.opengis.net/ont/geosparql#hasGeometry> ,
-                                   <http://www.w3.org/2003/01/geo/wgs84_pos#location> ;
+                rdfs:subPropertyOf geo:hasGeometry ,
+                                   wgs:location ;
                 rdfs:domain era:Tunnel ;
                 rdfs:range [ rdf:type owl:Class ;
-                             owl:unionOf ( <http://www.opengis.net/ont/geosparql#Geometry>
-                                           <http://www.w3.org/2003/01/geo/wgs84_pos#Point>
+                             owl:unionOf ( geo:Geometry
+                                           wgs:Point
                                          )
                            ] ;
                 era:XMLName "SOLTunnelEnd" ;
@@ -881,7 +922,7 @@ era:endLocation rdf:type owl:ObjectProperty ;
 The End of tunnel is the Geographical coordinates in decimal degrees and km of the line at the end of a tunnel."""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "End of tunnel location"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/energySupplySystem
@@ -905,7 +946,7 @@ era:energySupplySystem rdf:type owl:ObjectProperty ;
 and frequency)."""@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "energy supply system"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/errorCorrectionsOnboard
@@ -920,7 +961,7 @@ era:errorCorrectionsOnboard rdf:type owl:ObjectProperty ;
                             rdfs:comment "List of unacceptable errors impacting the IM network that are required to be solved in the on-board according to the TSI CCS point 7.2.10.3 specification maintenance point (ETCS, GSM-R and/or ATO). An additional parameter (era:errorCorrectionsOnboardExplanation) must document if a non-implemented CR has been accepted by the IM."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Error corrections required for the on-board ETCS, GSM-R and/or ATO function"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsBaseline
@@ -945,7 +986,7 @@ era:etcsBaseline rdf:type owl:ObjectProperty ;
                  rdfs:comment "ETCS baseline installed lineside"@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS baseline"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                 vs:term_status "stable" ;
                  skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -975,7 +1016,7 @@ See also TSI OPE 4.2.3.6. Degraded operation."""@en ;
                           rdfs:comment "ERTMS / ETCS application level for degraded situation related to the track side equipment."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "ETCS level for degraded situation"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                          vs:term_status "stable" ;
                           skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present). Degraded level must be lower than actual operating level."@en .
 
 
@@ -990,7 +1031,7 @@ era:etcsEquipmentOnBoardLevel rdf:type owl:ObjectProperty ;
                               rdfs:comment "ETCS equipment on-board and its level."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "ETCS equipment level"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsInfill
@@ -1015,7 +1056,7 @@ era:etcsInfill rdf:type owl:ObjectProperty ,
                rdfs:comment "Information about installed trackside equipment capable of transmitting infill information by loop or Global System for Mobile communications for Railways (GSM-R) for level 1 installations."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "ETCS infill installed line-side"@en ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsLevel
@@ -1024,11 +1065,13 @@ era:etcsLevel rdf:type owl:ObjectProperty ;
               rdfs:range era:ETCSLevel ;
               era:rinfIndex "1.2.1.1.1.1" ;
               dcterms:created "2021-08-07"^^xsd:date ;
-              dcterms:modified "2021-09-12"^^xsd:date ;
-              rdfs:comment "European Train Control System (ETCS) application level related to the track side equipment."@en ;
+              dcterms:modified "2021-09-12"^^xsd:date ,
+                               "2024-08-13"^^xsd:date ;
+              rdfs:comment "European Train Control System (ETCS) application level related to the track side equipment."@en ,
+                           "Indicates the level for which the ETCS relates to"@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-              rdfs:label "ETCS"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+              rdfs:label "ETCS Level"@en ;
+              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsLevelType
@@ -1045,7 +1088,8 @@ era:etcsLevelType rdf:type owl:ObjectProperty ;
 	
 Level definitions are principally related to the track side equipment used, to the way the track side information reaches the on-board units and to which functions are processed in the track side and in the on-board equipment respectively."""@en ;
                   dcterms:modified "2024-01-08"^^xsd:date ,
-                                   "2024-04-18"^^xsd:date ;
+                                   "2024-04-18"^^xsd:date ,
+                                   "2024-08-13"^^xsd:date ;
                   dcterms:relation era:cantDeficiencyBasicSSP ,
                                    era:etcsBaseline ,
                                    era:etcsDegradedSituation ,
@@ -1056,10 +1100,10 @@ Level definitions are principally related to the track side equipment used, to t
                                    era:rbcID ,
                                    era:rbcPhone ;
                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
-                  rdfs:comment "European Train Control System (ETCS) application level related to the track side equipment."@en ;
+                  rdfs:comment "Indicates the type associated as a SKOS concept from the era:ETCSLevel related to the track side equipment."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                  rdfs:label "ETCS level"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                  rdfs:label "ETCS level type"@en ;
+                  vs:term_status "stable" ;
                   skos:scopeNote """If ETCS is on the trackside (one or more levels are selected), all other ETCS parameters (from 1.1.1.3.2.2 to 1.1.1.3.2.10) are applicable.
 	
 The ETCS value NTC is only relevant when the line is dual equipped with ETCS (i.e., balises are placed in the track) and Class B system, and both systems are in operation at the same time. 
@@ -1088,7 +1132,7 @@ era:etcsMVersion rdf:type owl:ObjectProperty ,
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS M_version"@en ;
                  rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                 vs:term_status "stable" ;
                  skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -1129,7 +1173,7 @@ The ESC Types shall only be used when published with status ‘Valid’ in the A
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "ETCS system compatibility"@en ;
                             rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                            vs:term_status "stable" ;
                             skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -1153,7 +1197,7 @@ See: TSI CCS (Subset-026, Chapter 5, section 5.18.1.1)"""@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Track conditions which can be transmitted"@en ;
                                    rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" ;
+                                   vs:term_status "unstable" ;
                                    skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -1168,7 +1212,7 @@ era:fireSafetyCategory rdf:type owl:ObjectProperty ;
                        rdfs:comment "Fire safety category for tunnels."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Fire safety category"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/freightCorridor
@@ -1184,7 +1228,7 @@ era:freightCorridor rdf:type owl:ObjectProperty ;
                     rdfs:comment "Indication whether the line is designated to a Railway Freight Corridor."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Part of a Railway Freight Corridor"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/frenchTrainDetectionSystemLimitation
@@ -1204,7 +1248,7 @@ era:frenchTrainDetectionSystemLimitation rdf:type owl:ObjectProperty ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Section with train detection limitation, only for the French network"@en ;
                                          owl:deprecated "true"^^xsd:boolean ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/frenchTrainDetectionSystemLimitationNumber
@@ -1233,7 +1277,7 @@ Sections with:
 [8]	45-second delay for specific announcement reset devices"""@en ;
                                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                                rdfs:label "Section with train detection limitation number, only for French network"@en ;
-                                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/frequencyBandsForDetection
@@ -1258,7 +1302,7 @@ Multiple selection from a predefined list:
                                rdfs:comment "Bands of the frequency management of the train detection systems as defined in the TSI CCS (Annex I, Appendix A, Table A.2 -Index 77), and in the specific cases or technical documents referred to in Article 13 of TSI CCS when they are available."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "frequency bands for detection"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                               vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/from
@@ -1289,7 +1333,7 @@ era:gaugingProfile rdf:type owl:ObjectProperty ;
 In accordance with point 7.3.2.2 of LOC&PAS TSI, sections of lines of the United Kingdom of Great Britain network may not have gauge reference profile."""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "gauging"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/gaugingTransversalDocument
@@ -1305,7 +1349,7 @@ era:gaugingTransversalDocument rdf:type owl:ObjectProperty ;
                                rdfs:comment "Electronic document available from the IM stored by the Agency with the transversal section of the particular points requiring specific checks due to deviations from gauging referred to in parameter \"Gauging\". Where relevant, guidance for the check with the particular point may be attached to the document with the transversal section."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Document with the transversal section of the particular points requiring specific checks"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                               vs:term_status "stable" ;
                                skos:changeNote "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
 
@@ -1329,7 +1373,7 @@ Please select ”1” or “2”, taking into account that TSI compliant trains 
                       rdfs:comment "Number of simultaneous communication session on board for ETCS level 2 required for a smooth running of the train. This relates to the radio block centre (RBC) handling of communication sessions. Not safety critical and no matter of interoperability."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Number of active GSM-R mobiles (EDOR) or simultaneous communication session on-board for ETCS Level 2 needed to perform radio block centre handovers without having an operational disruption"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                      vs:term_status "stable" ;
                       skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -1349,7 +1393,7 @@ The document(s) itself has(have) to be upload by the NRE via the “reference do
                        rdfs:comment "Any additional information on network characteristics or corresponding document available from the IM and stored by the Agency, e.g.; interference level, leading to the recommendation of additional on-board protection."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Additional information on network characteristics"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                       vs:term_status "stable" ;
                        skos:changeNote "Change from datatype property to object property in order to point to the class Document (reference document)"@en ;
                        skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable"@en .
 
@@ -1391,7 +1435,7 @@ In case there is a balise used to announce the change of the network, or if ther
                           rdfs:comment "Use of optional GSM-R functions which might improve operation on the line. They are for information only and not for network access criteria."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Optional GSM-R functions"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                          vs:term_status "stable" ;
                           skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable"@en .
 
 
@@ -1406,7 +1450,7 @@ era:gsmRRadioDataCommunication rdf:type owl:ObjectProperty ;
                                rdfs:comment "GSM-R Radio Data communication on board and its Baseline."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "GSM-R radio data communication"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/gsmRVersion
@@ -1433,7 +1477,7 @@ era:gsmRVersion rdf:type owl:ObjectProperty ;
 Since more than one version may be installed in different areas, this property can have multiple values."""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "GSM-R version"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                vs:term_status "stable" ;
                 skos:scopeNote "GSM-R must be installed for this parameter to be applicable. If this property is not used, all GSM-R related properties should not be used either."@en .
 
 
@@ -1451,7 +1495,7 @@ era:gsmrConstraintsOperateOnlyInCircuitSwitch rdf:type owl:ObjectProperty ;
                                               rdfs:comment "These constraints, where applicable, are meant to manage the limited number of circuit-switched radio connections that can be handled simultaneously by a Radio Block Center."@en ;
                                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                               rdfs:label "Specific constraints imposed by the GSM-R network operator on ETCS on-board units only able to operate in circuit-switch"@en ;
-                                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                              vs:term_status "stable" ;
                                               skos:scopeNote """GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable.
 Multiple values are allowed."""@en .
 
@@ -1474,7 +1518,7 @@ For voice services, roaming for CS is applicable.  For ETCS, as long as roaming 
                         rdfs:comment "List of GSM-R networks which are covered by a roaming agreement."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "GSM-R networks covered by a roaming agreement"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                        vs:term_status "stable" ;
                         skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -1488,7 +1532,7 @@ era:hasAbstraction rdf:type owl:ObjectProperty ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Has abstraction"@en ;
                    owl:deprecated "true"^^xsd:boolean ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasImplementation
@@ -1501,15 +1545,17 @@ era:hasImplementation rdf:type owl:ObjectProperty ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Has implementation"@en ;
                       owl:deprecated "true"^^xsd:boolean ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasOrganisationRole
-era:hasOrganisationRole rdf:type owl:ObjectProperty ;
+era:hasOrganisationRole rdf:type owl:ObjectProperty ,
+                                 owl:FunctionalProperty ;
                         rdfs:domain era:OrganisationRole ;
                         rdfs:range skos:Concept ;
                         dcterms:created "2024-06-03"^^xsd:date ;
-                        rdfs:comment "The role of the body"@en ;
+                        rdfs:comment "The role plays in an n-ary relationship between a Body and a specific concept in the concept scheme of organisation roles"@en ;
+                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "has organisation role"@en .
 
 
@@ -1563,7 +1609,7 @@ If the direction of measurement is:
                                              "This property was previously a datatype property with domain Track and range string. As its values are a list of three predefined values, it is now a SKOS."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "direction of measurement of trackside HABD"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/inCountry
@@ -1576,7 +1622,7 @@ era:inCountry rdf:type owl:ObjectProperty ;
               rdfs:comment "TODO review: Indicates the country in which an entity resides."@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "In country"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/infrastructureMgr
@@ -1588,7 +1634,7 @@ era:infrastructureMgr rdf:type owl:ObjectProperty ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Infrastructure manager"@en ;
                       owl:deprecated "true"^^xsd:boolean ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/isPartOf
@@ -1623,7 +1669,7 @@ era:legacyRadioSystem rdf:type owl:ObjectProperty ;
                       rdfs:comment "Indication of radio legacy systems installed."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Other radio systems installed (Radio Legacy Systems)"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/lineCategory
@@ -1639,7 +1685,7 @@ era:lineCategory rdf:type owl:ObjectProperty ;
                  rdfs:comment "Classification of a line according to the TSI INF."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "category of line"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/lineNationalId
@@ -1659,7 +1705,7 @@ era:lineNationalId rdf:type owl:ObjectProperty ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "National line identification"@en ;
                    owl:deprecated "true"^^xsd:boolean ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/lineReference
@@ -1671,7 +1717,7 @@ era:lineReference rdf:type owl:ObjectProperty ;
                   rdfs:comment "Indicates a relationship with a national railway line at a specific kilometer point."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Railway location of an infrastructure object"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/lineReferenceTunnelEnd
@@ -1686,7 +1732,7 @@ era:lineReferenceTunnelEnd rdf:type owl:ObjectProperty ;
 The End of tunnel is the Geographical coordinates in decimal degrees and km of the line at the end of a tunnel."""@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "End of tunnel kilometer"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/lineReferenceTunnelStart
@@ -1701,7 +1747,7 @@ era:lineReferenceTunnelStart rdf:type owl:ObjectProperty ;
 The Start of tunnel is the Geographical coordinates in decimal degrees and km of the line at the end of a tunnel."""@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Start of tunnel kilometer"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/linesideDistanceIndicationAppearance
@@ -1716,7 +1762,7 @@ era:linesideDistanceIndicationAppearance rdf:type owl:ObjectProperty ;
                                          rdfs:comment "Indication of types of appearance of track lineside distance indications."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Lineside distance indication appearance"@en ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                                         vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/linesideDistanceIndicationPositioning
@@ -1730,7 +1776,7 @@ era:linesideDistanceIndicationPositioning rdf:type owl:ObjectProperty ;
                                           rdfs:comment "Indication of the side along the track where the lineside indication is positioned (left or right)."@en ;
                                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                           rdfs:label "Lineside distance indication positioning"@en ;
-                                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                                          vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/loadCapability
@@ -1750,7 +1796,7 @@ era:loadCapability rdf:type owl:ObjectProperty ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Load Capability"@en ;
                    owl:deprecated "true"^^xsd:boolean ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/loadCapabilityLineCategory
@@ -1766,7 +1812,7 @@ era:loadCapabilityLineCategory rdf:type owl:ObjectProperty ;
 The load capability is a value selected from the list of load models representing: line category which is amended by value of speed [km/h] permitted for a specific load model. The list of values may also be Route Availability which is amended by value of speed [miles/h] permitted for a specific load model."""@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Load capability line category"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/localRulesOrRestrictionsDoc
@@ -1786,7 +1832,7 @@ era:localRulesOrRestrictionsDoc rdf:type owl:ObjectProperty ;
                                 rdfs:comment "Electronic document available from the IM stored by the Agency providing additional information."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Documents regarding the rules or restrictions of a strictly local nature available by the IM"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                vs:term_status "stable" ;
                                 skos:changeNote "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
 
@@ -1794,6 +1840,8 @@ era:localRulesOrRestrictionsDoc rdf:type owl:ObjectProperty ;
 era:location rdf:type owl:ObjectProperty ;
              rdfs:domain era:TopologicalObject ;
              rdfs:range era:BaseLocation ;
+             dcterms:created "2024-05-24"^^xsd:date ;
+             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "location"@en .
 
 
@@ -1801,9 +1849,9 @@ era:location rdf:type owl:ObjectProperty ;
 era:lrsMethod rdf:type owl:ObjectProperty ;
               rdfs:domain era:Position ;
               rdfs:range skos:Concept ;
+              era:inSkosConceptScheme <http://data.europa.eu/949/concepts/lines/ReferenceSystems> ;
+              dcterms:created "2024-04-18"^^xsd:date ;
               rdfs:comment "The preferred line referencing system. TODO: provide example"@en ;
-			  dcterms:created "2024-04-18"^^xsd:date ;
-			  era:inSkosConceptScheme <http://data.europa.eu/949/concepts/lines/ReferenceSystems> ;
               rdfs:label "line referencing system"@en .
 
 
@@ -1827,7 +1875,7 @@ See: TSI CCS (Subset-026, chapter 7. 7.5.1.74 M_NVCONTACT)"""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "M_NVCONTACT"@en ;
                rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" ;
+               vs:term_status "unstable" ;
                skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -1845,10 +1893,10 @@ era:magneticBraking rdf:type owl:ObjectProperty ;
                     dcterms:modified "2022-09-12"^^xsd:date ;
                     dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                     rdfs:comment "Indication of limitations on the use of magnetic brakes."@en ;
-                    skos:scopeNote "This property has been modified to be a RINF parameter (its eratvIndex is deleted). It is treated as a SKOS by RINF and as a boolean by ERATV. A new ERATV datatype property has been defined, magneticBrakingFitted with boolean values."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Use of magnetic brakes"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" ;
+                    skos:scopeNote "This property has been modified to be a RINF parameter (its eratvIndex is deleted). It is treated as a SKOS by RINF and as a boolean by ERATV. A new ERATV datatype property has been defined, magneticBrakingFitted with boolean values."@en .
 
 
 ###  http://data.europa.eu/949/magneticBrakingConditionsDocument
@@ -1866,7 +1914,7 @@ era:magneticBrakingConditionsDocument rdf:type owl:ObjectProperty ;
                                       rdfs:comment "Electronic document available in two EU languages from the IM stored by the Agency with conditions for the use of magnetic brakes identified in 1.1.1.1.6.3."@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Document with the conditions for the use of magnetic brakes"@en ;
-                                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                      vs:term_status "stable" ;
                                       skos:changeNote "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
 
@@ -1880,7 +1928,7 @@ era:manufacturer rdf:type owl:ObjectProperty ;
                  rdfs:comment "Vehicle manufacturer company."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "manufactured by"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/manufacturingCountry
@@ -1897,7 +1945,7 @@ era:manufacturingCountry rdf:type owl:ObjectProperty ;
                          rdfs:comment "Indicates the country in which a vehicle or vehicle type is manufactured."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Manufacturing country"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maxSandingOutput
@@ -1914,7 +1962,7 @@ Deprecated according to the ammendment to the Regulation (EU) 2019/777."""@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Maximum amount of sand"@en ;
                      owl:deprecated "true"^^xsd:boolean ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/minAxleLoadVehicleCategory
@@ -1931,7 +1979,7 @@ Deprecated according to the ammendment to the Regulation (EU) 2019/777."""@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Minimum axle load vehicle category"@en ;
                                owl:deprecated "true"^^xsd:boolean ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/minVehicleImpedance
@@ -1959,8 +2007,8 @@ era:minVehicleImpedanceVoltages rdf:type owl:ObjectProperty ;
                                 rdfs:comment "Indication of the voltage system valid for the minimal impedance value (track circuits)."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "minimum Vehicle Impedance (Voltage applicable)"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
-                                skos:scopeNote "The parameter minVehicleImpedanceVoltages is applicable for track circuits."@en  .
+                                vs:term_status "stable" ;
+                                skos:scopeNote "The parameter minVehicleImpedanceVoltages is applicable for track circuits."@en .
 
 
 ###  http://data.europa.eu/949/nationalLine
@@ -1986,7 +2034,7 @@ era:navigability rdf:type owl:ObjectProperty ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Navigability"@en ;
                  owl:deprecated "true"^^xsd:boolean ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                 vs:term_status "stable" ;
                  skos:altLabel "Internal connection"@en .
 
 
@@ -1999,7 +2047,7 @@ The reason for deprecating this property is that it is defined as \"References a
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "Net element"@en ;
                owl:deprecated "true"^^xsd:boolean ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/notApplicable
@@ -2009,7 +2057,7 @@ era:notApplicable rdf:type owl:ObjectProperty ;
                   rdfs:comment "Reference to a property that is not applicable."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Not applicable"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                  vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/notYetAvailable
@@ -2019,13 +2067,15 @@ era:notYetAvailable rdf:type owl:ObjectProperty ;
                     rdfs:comment "Reference to a property that is not provided."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Not provided"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                    vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/onGrid
 era:onGrid rdf:type owl:ObjectProperty ;
            rdfs:domain era:Signal ;
            rdfs:range era:SignalsGrid ;
+           dcterms:created "2024-05-24"^^xsd:date ;
+           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "on signal grid"@en .
 
 
@@ -2042,7 +2092,7 @@ era:opEnd rdf:type owl:ObjectProperty ;
           rdfs:comment "Operational point at the end of section of line (kilometres increasing from start OP to the end OP)."@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "Operational point at end of section of line"@en ;
-          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/opInfoPerCountry
@@ -2053,7 +2103,7 @@ era:opInfoPerCountry rdf:type owl:ObjectProperty ;
                      rdfs:comment "TODO: review, it is in use. Relates an operational point that represents the general information of a border point to the information that each country maintains for the border point."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Border point information per country"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/opStart
@@ -2069,7 +2119,7 @@ era:opStart rdf:type owl:ObjectProperty ;
             rdfs:comment "Operational point at the start of section of line (kilometres increasing from start OP to the end OP)."@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             rdfs:label "Operational point at start of section of line"@en ;
-            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/opType
@@ -2087,7 +2137,7 @@ era:opType rdf:type owl:ObjectProperty ;
            rdfs:comment "Type of facility in relation to the dominating operational functions."@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "Type of operational point"@en ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/operatingLanguage
@@ -2102,7 +2152,7 @@ era:operatingLanguage rdf:type owl:ObjectProperty ;
                       rdfs:comment "The language or languages used in daily operation by infrastructure manager and published in its Network Statement, for the communication of operational or safety related messages between the staff of the infrastructure manager and the railway undertaking."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Operating language"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                      vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/operationalRegimeType
@@ -2116,7 +2166,7 @@ era:operationalRegimeType rdf:type owl:ObjectProperty ;
                           rdfs:comment "Double track type."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Operational regime"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                          vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/operationalRestriction
@@ -2129,7 +2179,7 @@ era:operationalRestriction rdf:type owl:ObjectProperty ;
                            rdfs:comment "Indicates an operational restriction of vehicle or wagon. Parking brake type (if the vehicle is fitted with it)."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Operational restriction"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/organisation
@@ -2139,17 +2189,17 @@ era:organisation rdf:type owl:ObjectProperty ;
                  dcterms:created "2024-06-03"^^xsd:date ;
                  rdfs:comment "The organisation managing the infrastructure objet (infrastructure manager)"@en ;
                  rdfs:label "organisation"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/orientation
 era:orientation rdf:type owl:ObjectProperty ;
                 rdfs:domain era:Orientation ;
-                rdfs:range skos:Concept;
-				rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-				dcterms:created "2024-04-18"^^xsd:date ;
-				era:inSkosConceptScheme <http://data.europa.eu/949/concepts/orientations/Directions> ; 
+                rdfs:range skos:Concept ;
+                era:inSkosConceptScheme <http://data.europa.eu/949/concepts/orientations/Directions> ;
+                dcterms:created "2024-04-18"^^xsd:date ;
                 rdfs:comment "The orientation of the object in relation to the carrier object. Possible values: Normal, Opposite, Both"@en ;
+                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "orientation"@en .
 
 
@@ -2166,7 +2216,7 @@ era:osmClass rdf:type owl:ObjectProperty ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "Open street map class"@en ;
              owl:deprecated "true"^^xsd:boolean ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+             vs:term_status "stable" ;
              skos:definition "Additional concept class according to OpenStreetMap."@en .
 
 
@@ -2184,12 +2234,12 @@ era:otherCantDeficiencyBasicSSP rdf:type owl:ObjectProperty ,
                                 dcterms:modified "2024-04-18"^^xsd:date ;
                                 dcterms:relation era:cantDeficiencyBasicSSP ;
                                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
-                                rdfs:comment """Essential information for drivers of trains with a worse (lower) tolerated cant deficiency than those for which the ETCS trackside provides SSP (Static Speed Profiles) in conjunction with parameter \"Cant Deficiency used for the basic SSP\""".  
+                                rdfs:comment """Essential information for drivers of trains with a worse (lower) tolerated cant deficiency than those for which the ETCS trackside provides SSP (Static Speed Profiles) in conjunction with parameter \"Cant Deficiency used for the basic SSP\"\"\".  
 								 Subset-026 (3.11.3.2.1.1) definition: b) The “other specific” SSP categories: it groups all other specific 
 								SSP categories corresponding to the other international train categories. """@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Other Cant Deficiency train categories basic  SSP"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" ;
+                                vs:term_status "unstable" ;
                                 skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -2206,7 +2256,7 @@ era:otherPantographHead rdf:type owl:ObjectProperty ;
                         rdfs:comment "Indication of pantograph heads which are allowed to be used."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "accepted other pantograph heads"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/otherTrainProtection
@@ -2229,7 +2279,7 @@ era:otherTrainProtection rdf:type owl:ObjectProperty ,
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Other train protection, control and warning systems for degraded situation"@en ;
                          rdfs:seeAlso <https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf> ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                         vs:term_status "stable" ;
                          skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -2258,7 +2308,7 @@ era:parkingBrakeType rdf:type owl:ObjectProperty ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Parking brake type"@en ;
                      owl:deprecated "true"^^xsd:boolean ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "deprecated" .
+                     vs:term_status "deprecated" .
 
 
 ###  http://data.europa.eu/949/passesThroughTunnel
@@ -2271,7 +2321,7 @@ era:passesThroughTunnel rdf:type owl:ObjectProperty ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Passes through tunnel"@en ;
                         owl:deprecated "true"^^xsd:boolean ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "deprected" .
+                        vs:term_status "deprected" .
 
 
 ###  http://data.europa.eu/949/platformEdge
@@ -2283,7 +2333,7 @@ era:platformEdge rdf:type owl:ObjectProperty ;
                  rdfs:comment "TODO: review. Reference to a related platform edge."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Platform edge"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/platformHeight
@@ -2301,7 +2351,7 @@ era:platformHeight rdf:type owl:ObjectProperty ;
                    rdfs:comment "Distance between the upper surface of platform and running surface of the neighbouring track. It is the nominal value expressed in millimetres."@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "height of platform"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/positionOnA
@@ -2316,7 +2366,7 @@ era:positionOnA rdf:type owl:ObjectProperty ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Position on A"@en ;
                 owl:deprecated "true"^^xsd:boolean ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                vs:term_status "stable" ;
                 skos:altLabel "Internal connection"@en .
 
 
@@ -2332,7 +2382,7 @@ era:positionOnB rdf:type owl:ObjectProperty ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Position on B"@en ;
                 owl:deprecated "true"^^xsd:boolean ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                vs:term_status "stable" ;
                 skos:altLabel "Internal connection"@en .
 
 
@@ -2345,7 +2395,7 @@ era:previousVehicleType rdf:type owl:ObjectProperty ;
                         rdfs:comment "Denotes a the previous VehicleType."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Previous vehicle type"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/primaryLocation
@@ -2367,7 +2417,7 @@ era:profileNumberSemiTrailers rdf:type owl:ObjectProperty ;
                               rdfs:comment "Coding for combined transport for semi-trailers (for all freight and mixed-traffic lines) in accordance with the specification referenced in Appendix A-1, index [B]."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "Standard combined transport profile number for semi-trailers"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/profileNumberSwapBodies
@@ -2382,7 +2432,7 @@ era:profileNumberSwapBodies rdf:type owl:ObjectProperty ;
                             rdfs:comment "Coding for combined transport with swap bodies (for all freight and mixed-traffic lines) in accordance with the specification referenced in Appendix A-1, index [B]"@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Standard combined transport profile number for swap bodies"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/protectionLegacySystem
@@ -2406,7 +2456,7 @@ era:protectionLegacySystem rdf:type owl:ObjectProperty ;
                            rdfs:comment "Indication of which class B system is installed. The list is in line with ERA/TD/2011-09/INT (v1.13), Table 3. "@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Train protection legacy system"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/qNvemrrls
@@ -2427,7 +2477,7 @@ Qualifier defining whether the application of the emergency brake for reasons ot
 According to the specification referenced in TSI CCS (Subset-026, chapter 7, 7.5.1.123 Q_NVEMRRLS)"""@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "Q_NVEMRRLS"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+              vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/quieterRoutesExemptedCountry
@@ -2440,7 +2490,7 @@ era:quieterRoutesExemptedCountry rdf:type owl:ObjectProperty ;
                                  rdfs:comment "Country where a vehicle may operate without noise restrictions."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Quieter route exempted country"@en ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/railInclination
@@ -2461,7 +2511,7 @@ era:railInclination rdf:type owl:ObjectProperty ;
                     rdfs:comment "An angle defining the inclination of the head of a rail relative to the running surface."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Rail inclination"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/reasonsEtcsRadioBlockCenterReject
@@ -2484,7 +2534,7 @@ See: Subset 26, Chapter 5 5.4 Procedure start of mission."""@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Reasons for which an ETCS Radio Block Center can reject a train"@en ;
                                       rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" ;
+                                      vs:term_status "unstable" ;
                                       skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -2500,8 +2550,9 @@ era:referent rdf:type owl:ObjectProperty ;
 era:role rdf:type owl:ObjectProperty ;
          rdfs:domain era:Body ;
          rdfs:range era:OrganisationRole ;
-		 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
          dcterms:created "2024-06-03"^^xsd:date ;
+         rdfs:comment "Indicates the n-ary relationship from the Body"@en ;
+         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
          rdfs:label "role"@en .
 
 
@@ -2523,7 +2574,7 @@ era:rollingStockFireCategory rdf:type owl:ObjectProperty ;
 Passenger train fire category in accordance with point 4.1.4 of TSI LOC&PAS."""@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "fire category of rolling stock required"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/safeConsistLengthInformationNecessary
@@ -2542,7 +2593,7 @@ era:safeConsistLengthInformationNecessary rdf:type owl:ObjectProperty ,
                                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                           rdfs:label "Safe consist length information from on-board necessary for access the line and SIL"@en ;
                                           rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                          vs:term_status "stable" ;
                                           skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -2550,11 +2601,10 @@ era:safeConsistLengthInformationNecessary rdf:type owl:ObjectProperty ,
 era:side rdf:type owl:ObjectProperty ;
          rdfs:domain era:Orientation ;
          rdfs:range skos:Concept ;
-         rdfs:label "on side"@en ;
-		 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-		 dcterms:created "2024-04-18"^^xsd:date  ;
-		 era:inSkosConceptScheme <http://data.europa.eu/949/concepts/orientations/Sides> ;
-		 .
+         era:inSkosConceptScheme <http://data.europa.eu/949/concepts/orientations/Sides> ;
+         dcterms:created "2024-04-18"^^xsd:date ;
+         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+         rdfs:label "on side"@en .
 
 
 ###  http://data.europa.eu/949/siding
@@ -2566,7 +2616,7 @@ era:siding rdf:type owl:ObjectProperty ;
            rdfs:comment "Reference to a related siding."@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "Siding"@en ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/signalOrientation
@@ -2585,7 +2635,7 @@ era:signalOrientation rdf:type owl:ObjectProperty ,
                       rdfs:comment "Indication if the signal (on the track or in OP) is applicable for operation on normal, opposite track direction or if it contains bidirectionally valid information (radio-based system only)."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Signal orientation"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                      vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/signalType
@@ -2606,7 +2656,7 @@ era:signalType rdf:type owl:ObjectProperty ;
                rdfs:comment "Signalling information for Route Book compilation."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "Type of signal"@en ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+               vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/signallingSystemType
@@ -2621,7 +2671,7 @@ The reason for deprecation is that this property has the same RINF index than \"
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Signalling system type"@en ;
                          owl:deprecated "true"^^xsd:boolean ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                         vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/snowIceHailConditions
@@ -2635,7 +2685,7 @@ era:snowIceHailConditions rdf:type owl:ObjectProperty ;
                           rdfs:comment "Snow, ice and hail conditions."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Snow ice hail conditions"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/solNature
@@ -2650,7 +2700,7 @@ era:solNature rdf:type owl:ObjectProperty ;
               rdfs:comment "Kind of section of line expressing size of presented data which depends on fact whether it connects OPs generated by division of a big node into several OPs or not."@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "Nature of Section of Line"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/specialAreaType
@@ -2671,7 +2721,7 @@ era:specialAreaType rdf:type owl:ObjectProperty ;
                     rdfs:comment "Indicates the special area or location types such as safe areas and restricted area types."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Special area type"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                    vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/specialTunnelArea
@@ -2684,7 +2734,7 @@ era:specialTunnelArea rdf:type owl:ObjectProperty ;
                       rdfs:comment "Relates a tunnel with a special area or location."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Special tunnel area"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/standardCombinedTransporRollerUnits
@@ -2697,7 +2747,7 @@ era:standardCombinedTransporRollerUnits rdf:type owl:ObjectProperty ;
 """@en ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "Standard combined transport profile number for roller units"@en ;
-                                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                                        vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/standardCombinedTransportContainers
@@ -2710,17 +2760,17 @@ era:standardCombinedTransportContainers rdf:type owl:ObjectProperty ;
 """@en ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "Standard combined transport profile number for containers"@en ;
-                                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                                        vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/startLocation
 era:startLocation rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf <http://www.opengis.net/ont/geosparql#hasGeometry> ,
-                                     <http://www.w3.org/2003/01/geo/wgs84_pos#location> ;
+                  rdfs:subPropertyOf geo:hasGeometry ,
+                                     wgs:location ;
                   rdfs:domain era:Tunnel ;
                   rdfs:range [ rdf:type owl:Class ;
-                               owl:unionOf ( <http://www.opengis.net/ont/geosparql#Geometry>
-                                             <http://www.w3.org/2003/01/geo/wgs84_pos#Point>
+                               owl:unionOf ( geo:Geometry
+                                             wgs:Point
                                            )
                              ] ;
                   era:XMLName "SOLTunnelStart" ;
@@ -2731,7 +2781,7 @@ era:startLocation rdf:type owl:ObjectProperty ;
 The Start of tunnel is the Geographical coordinates in decimal degrees and km of the line at the beginning of a tunnel."""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Start of tunnel location"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/state
@@ -2742,8 +2792,9 @@ era:state rdf:type owl:ObjectProperty ;
           dcterms:created "2022-06-15"^^xsd:date ;
           dcterms:modified "2022-06-15"^^xsd:date ;
           rdfs:comment "Denoting the state of the certificate Can be in one of the following: Amended, New, Suspended, Withdrawn."@en ;
+          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "State"@en ;
-          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/subCategory
@@ -2757,7 +2808,7 @@ era:subCategory rdf:type owl:ObjectProperty ;
                 rdfs:comment "Vehicle subcategory."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Vehicle subcategory"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/subsidiaryLocation
@@ -2771,6 +2822,8 @@ era:subsidiaryLocation rdf:type owl:ObjectProperty ;
 era:subsidiaryLocationType rdf:type owl:ObjectProperty ;
                            rdfs:domain era:SubsidiaryLocation ;
                            rdfs:range skos:Concept ;
+                           dcterms:created "2024-05-24"^^xsd:date ;
+                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "subsidiary location type"@en .
 
 
@@ -2785,7 +2838,7 @@ era:supportedPlatformHeight rdf:type owl:ObjectProperty ;
                             rdfs:comment "Platform height for which the vehicle is designed."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Supported platform height"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tdsFrenchTrainDetectionSystemLimitation
@@ -2802,7 +2855,7 @@ era:tdsFrenchTrainDetectionSystemLimitation rdf:type owl:ObjectProperty ;
 Specific for route compatibility check on French network."""@en ;
                                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                             rdfs:label "Section with train detection limitation, only for the French network"@en ;
-                                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tdsMaximumMagneticField
@@ -2821,7 +2874,7 @@ The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a 
 It should be provided in 3 directions."""@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Maximum magnetic field"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tdsMinAxleLoadVehicleCategory
@@ -2836,7 +2889,7 @@ era:tdsMinAxleLoadVehicleCategory rdf:type owl:ObjectProperty ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Train detection system min axle load vehicle category"@en ;
                                   owl:deprecated "true"^^xsd:boolean ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/temperatureRange
@@ -2851,7 +2904,7 @@ era:temperatureRange rdf:type owl:ObjectProperty ;
                      rdfs:comment "Temperature range for unrestricted access to the line according European standard."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Temperature range"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tenClassification
@@ -2870,7 +2923,7 @@ era:tenClassification rdf:type owl:ObjectProperty ;
                       rdfs:comment "Indicates the part of the trans-European network the (track, platform, siding) belongs to."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Trans-European Network (TEN) classification"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/thermalCapacityTSIReference
@@ -2884,7 +2937,7 @@ era:thermalCapacityTSIReference rdf:type owl:ObjectProperty ;
                                 rdfs:comment "Reference case of a TSI thermal capacity."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Thermal capacity TSI reference"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/to
@@ -2917,7 +2970,7 @@ era:track rdf:type owl:ObjectProperty ;
           rdfs:comment "Reference to a related railway track."@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "Track"@en ;
-          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trackDirection
@@ -2936,7 +2989,7 @@ era:trackDirection rdf:type owl:ObjectProperty ;
 - both directions: (B)"""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Normal running direction"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trackLoadCapability
@@ -2950,7 +3003,7 @@ era:trackLoadCapability rdf:type owl:ObjectProperty ;
                         rdfs:comment "Relates the track with the class LoadCapability. A combination of the line category and speed at the weakest point of the track."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Track load capability"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trackPhaseInfo
@@ -2963,7 +3016,7 @@ era:trackPhaseInfo rdf:type owl:ObjectProperty ;
                    rdfs:comment "Relates the Track with PhaseInfo. Indication of required several information on phase separation."@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Track phase info"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trackRaisedPantographsDistanceAndSpeed
@@ -2977,7 +3030,7 @@ era:trackRaisedPantographsDistanceAndSpeed rdf:type owl:ObjectProperty ;
                                            rdfs:comment "Relates the track with the class RaisePantporaphsDistanceAndSpeed. Indication of maximum number of raised pantographs per train allowed and minimum spacing centre line to centre line of adjacent pantograph heads, expressed in metres, at the given speed."@en ;
                                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                            rdfs:label "Track raised pantograph distance and speed"@en ;
-                                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trackSystemSeparationInfo
@@ -2990,7 +3043,7 @@ era:trackSystemSeparationInfo rdf:type owl:ObjectProperty ;
                               rdfs:comment "Relates the Track with the SystemSeparationInfo. Indication of required several information on system separation."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "Track system separation info"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trainDetectionSystem
@@ -3002,7 +3055,7 @@ era:trainDetectionSystem rdf:type owl:ObjectProperty ;
                          rdfs:comment "Train detection systems installed in the section of line."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Train detection system"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trainDetectionSystemSpecificCheckDocument
@@ -3021,7 +3074,7 @@ era:trainDetectionSystemSpecificCheckDocument rdf:type owl:ObjectProperty ;
                                               rdfs:comment "Electronic document from the IM stored by the Agency with precise values in accordance with TSI CCS (Article 13 and Annex I, Appendix A, Table A.2, Index 77), for the specific check to be performed for train detection systems identified in parameter \"\"Type of track circuits or axle counters to which specific checks are needed\"."@en ;
                                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                               rdfs:label "Document with the procedure(s) related to the type of train detection systems declared in 1.1.1.3.7.1.2 or 1.2.1.1.6.1"@en ;
-                                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                              vs:term_status "stable" ;
                                               skos:changeNote "Change from datatype property to object property in order to point to the class Document (reference document)"@en ;
                                               skos:scopeNote "The document itself has to be upload by the NRE via the “reference document management” functionality. The reference of the document is provided for the parameter using the characterstring format."@en .
 
@@ -3048,7 +3101,7 @@ The option of ‘wheel detector’ has to be also selected for: wheel sensor for
                              rdfs:comment "Indication of types of train detection systems installed. "@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Type of train detection system"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                             vs:term_status "stable" ;
                              skos:scopeNote "Not all parameters are applicable to all types of train detection systems; it depends on the applicability condition."@en .
 
 
@@ -3065,7 +3118,7 @@ era:tsiCompliantCompositeBrakeBlocks rdf:type owl:ObjectProperty ;
                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                      rdfs:label "TSI compliance of rules on the use of composite brake blocks"@en ;
                                      owl:deprecated "true"^^xsd:boolean ;
-                                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliantFerromagneticWheel
@@ -3081,7 +3134,7 @@ era:tsiCompliantFerromagneticWheel rdf:type owl:ObjectProperty ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "TSI compliance of Ferromagnetic characteristics of wheel material required"@en ;
                                    owl:deprecated "true"^^xsd:boolean ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliantMaxDistConsecutiveAxles
@@ -3097,7 +3150,7 @@ era:tsiCompliantMaxDistConsecutiveAxles rdf:type owl:ObjectProperty ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "TSI compliance of maximum permitted distance between two consecutive axles"@en ;
                                         owl:deprecated "true"^^xsd:boolean ;
-                                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliantMaxImpedanceWheelset
@@ -3113,7 +3166,7 @@ era:tsiCompliantMaxImpedanceWheelset rdf:type owl:ObjectProperty ;
                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                      rdfs:label "TSI compliance of maximum permitted impedance between opposite wheels of a wheelset"@en ;
                                      owl:deprecated "true"^^xsd:boolean ;
-                                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliantMetalConstruction
@@ -3129,7 +3182,7 @@ era:tsiCompliantMetalConstruction rdf:type owl:ObjectProperty ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "TSI compliance of rules for vehicle metal construction"@en ;
                                   owl:deprecated "true"^^xsd:boolean ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliantMetalFreeSpace
@@ -3145,7 +3198,7 @@ era:tsiCompliantMetalFreeSpace rdf:type owl:ObjectProperty ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "TSI compliance of rules for metal-free space around wheels"@en ;
                                owl:deprecated "true"^^xsd:boolean ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliantRSTShuntImpedance
@@ -3161,7 +3214,7 @@ era:tsiCompliantRSTShuntImpedance rdf:type owl:ObjectProperty ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "TSI compliance of rules on combination of RST characteristics influencing shunting impedance"@en ;
                                   owl:deprecated "true"^^xsd:boolean ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliantSandCharacteristics
@@ -3177,7 +3230,7 @@ era:tsiCompliantSandCharacteristics rdf:type owl:ObjectProperty ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "TSI Compliance of rules on sand characteristics"@en ;
                                     owl:deprecated "true"^^xsd:boolean ;
-                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliantSanding
@@ -3192,7 +3245,7 @@ era:tsiCompliantSanding rdf:type owl:ObjectProperty ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "TSI compliance of sanding"@en ;
                         owl:deprecated "true"^^xsd:boolean ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                        vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliantShuntDevices
@@ -3208,7 +3261,7 @@ era:tsiCompliantShuntDevices rdf:type owl:ObjectProperty ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "TSI compliance of rules on shunt assisting devices"@en ;
                              owl:deprecated "true"^^xsd:boolean ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiPantographHead
@@ -3224,7 +3277,7 @@ era:tsiPantographHead rdf:type owl:ObjectProperty ;
                       rdfs:comment "Indication of TSI compliant pantograph heads which are allowed to be used. The allowed values for this property belong to the SKOS Concept Scheme http://data.europa.eu/949/concepts/compliant-pantograph-heads/CompliantPantographHeads."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "accepted TSI compliant pantograph heads"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tunnelDocRef
@@ -3239,7 +3292,7 @@ era:tunnelDocRef rdf:type owl:ObjectProperty ;
                  rdfs:comment "Electronic document available from the IM stored by the Agency with precise description of the clearance gauge and geometry of the tunnel."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Document available from the IM with precise description of the tunnel"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                 vs:term_status "stable" ;
                  skos:changeNote "Change from datatype property to object property in order to point to the class Document (reference document)"@en .
 
 
@@ -3253,7 +3306,7 @@ era:typeVersionId rdf:type owl:ObjectProperty ;
 The allowed values for this property belong to the SKOS Concept Scheme http://data.europa.eu/949/concepts/type-version-ids/TypeVersionIds."""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Type version id"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/validity
@@ -3277,7 +3330,7 @@ era:vehicleKeeper rdf:type owl:ObjectProperty ;
                   rdfs:comment "Indicates the organization that owns/operated a vehicle or wagon."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "vehicle keeper"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/vehicleType
@@ -3289,7 +3342,7 @@ era:vehicleType rdf:type owl:ObjectProperty ;
                 rdfs:comment "Indicates the vehicle type of a specific vehicle or wagon."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Vehicle type"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/vehicleTypeMaximumSpeedAndCantDeficiency
@@ -3301,7 +3354,7 @@ era:vehicleTypeMaximumSpeedAndCantDeficiency rdf:type owl:ObjectProperty ;
                                              rdfs:comment "Relates the vehicle type with its values of maximum speed and cant deficiency."@en ;
                                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                              rdfs:label "Vehicle type maximum speed and cant deficiency"@en ;
-                                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/voiceGSMRNetwork
@@ -3315,7 +3368,7 @@ era:voiceGSMRNetwork rdf:type owl:ObjectProperty ;
                      rdfs:comment "Voice SIM Card GSM-R Home Network. The allowed values for this property belong to the SKOS Concept Scheme http://data.europa.eu/949/concepts/gsmr-networks/GSMRNetworks"@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Voice GSM-R network"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/voiceRadioCompatible
@@ -3344,7 +3397,7 @@ Information on RSC voice requirements per country:
 https://www.era.europa.eu/era-folder/radio-system-compatibility-rsc-voice-and-data-documents"""@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Radio system compatibility voice"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                         vs:term_status "stable" ;
                          skos:scopeNote """GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable.
 In case of RSC-EU-0 or None, no other values are allowed."""@en .
 
@@ -3369,7 +3422,7 @@ era:wheelSetGauge rdf:type owl:ObjectProperty ;
 The allowed values for this property belong to the SKOS Concept Scheme http://data.europa.eu/949/concepts/nominal-track-gauges/NominalTrackGauges"""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Nominal track gauge"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/wheelSetGaugeChangeoverFacility
@@ -3383,40 +3436,40 @@ era:wheelSetGaugeChangeoverFacility rdf:type owl:ObjectProperty ;
                                     rdfs:comment "Wheelset gauge changeover facility. The allowed values for this property belong to the SKOS Concept Scheme http://data.europa.eu/949/concepts/gauge-changeover-facilities/GaugeChangeoverFacilities"@en ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "Wheelset gauge changeover facility"@en ;
-                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                    vs:term_status "stable" .
 
 
 ###  http://www.opengis.net/ont/geosparql#hasGeometry
-<http://www.opengis.net/ont/geosparql#hasGeometry> rdf:type owl:ObjectProperty ;
-                                                   rdfs:domain <http://www.opengis.net/ont/geosparql#Feature> ;
-                                                   rdfs:range <http://www.opengis.net/ont/geosparql#Geometry> ;
-                                                   era:XMLName "OPGeographicLocation" ;
-                                                   era:rinfIndex "1.1.0.0.1.1" ,
-                                                                 "1.1.1.0.1.1" ,
-                                                                 "1.1.1.3.14.5" ,
-                                                                 "1.2.0.0.0.5" ,
-                                                                 "1.2.1.0.8.5" ;
-                                                   era:usedInRCCCalculations "true"^^xsd:boolean ;
-                                                   <http://purl.org/dc/elements/1.1/contributor> "Matthew Perry" ;
-                                                   <http://purl.org/dc/elements/1.1/creator> "OGC GeoSPARQL 1.0 Standard Working Group" ;
-                                                   <http://purl.org/dc/elements/1.1/date> "2011-06-16"^^xsd:date ;
-                                                   <http://purl.org/dc/elements/1.1/description> """
+geo:hasGeometry rdf:type owl:ObjectProperty ;
+                rdfs:domain geo:Feature ;
+                rdfs:range geo:Geometry ;
+                era:XMLName "OPGeographicLocation" ;
+                era:rinfIndex "1.1.0.0.1.1" ,
+                              "1.1.1.0.1.1" ,
+                              "1.1.1.3.14.5" ,
+                              "1.2.0.0.0.5" ,
+                              "1.2.1.0.8.5" ;
+                era:usedInRCCCalculations "true"^^xsd:boolean ;
+                dc:contributor "Matthew Perry" ;
+                dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+                dc:date "2011-06-16"^^xsd:date ;
+                dc:description """
       A spatial representation for a given feature.
     """@en ;
-                                                   rdfs:comment """
+                rdfs:comment """
       A spatial representation for a given feature.
     """@en ;
-                                                   rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> ,
-                                                                    <http://www.opengis.net/spec/geosparql/1.0> ;
-                                                   rdfs:label "hasGeometry"@en ;
-                                                   skos:definition """
+                rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> ,
+                                 <http://www.opengis.net/spec/geosparql/1.0> ;
+                rdfs:label "hasGeometry"@en ;
+                skos:definition """
       A spatial representation for a given feature.
     """@en ;
-                                                   skos:prefLabel "hasGeometry"@en .
+                skos:prefLabel "hasGeometry"@en .
 
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#location
-<http://www.w3.org/2003/01/geo/wgs84_pos#location> rdf:type owl:ObjectProperty .
+wgs:location rdf:type owl:ObjectProperty .
 
 
 #################################################################
@@ -3434,7 +3487,7 @@ era:accelerationLevelCrossing rdf:type owl:DatatypeProperty ;
                               rdfs:comment "Existence of limit for acceleration of train if stopping or recovering speed close to a level crossing expressed in a specific reference acceleration curve."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "Acceleration allowed near level crossing"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/alternativeName
@@ -3448,7 +3501,7 @@ era:alternativeName rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Alternative name of a vehicle type."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Vehicle Type - Alternative name"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/altitudeRange
@@ -3461,7 +3514,7 @@ era:altitudeRange rdf:type owl:DatatypeProperty ;
                   rdfs:comment "Altitude range."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Altitude range"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/altitudeRangeDetail
@@ -3474,7 +3527,7 @@ era:altitudeRangeDetail rdf:type owl:DatatypeProperty ;
                         rdfs:comment "Altitude range value for 'X' if value 'AX' is selected in altitude range."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Altitude range detail"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/areaBoardingAid
@@ -3483,13 +3536,13 @@ era:areaBoardingAid rdf:type owl:DatatypeProperty ;
                     rdfs:range xsd:integer ;
                     era:XMLName "IPL_AreaBoardingAid" ;
                     era:rinfIndex "1.2.1.0.6.7" ;
-                    era:unitOfMeasure qudt:MilliM ;
+                    era:unitOfMeasure unit:MilliM ;
                     dcterms:created "2021-08-02"^^xsd:date ;
                     dcterms:modified "2023-01-20"^^xsd:date ;
                     rdfs:comment "Information of the train access level for which the boarding aid can be used. Data is presented as the vertical difference that is overcome by the platform boarding aid in millimetres. The value “0” means that the platform is not equipped with a platform boarding aid."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Range of use of the platform boarding aid"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/assistanceStartingTrain
@@ -3503,7 +3556,7 @@ era:assistanceStartingTrain rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Indication of existence of equipment or staff supporting the train crew in starting the train."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Existence of platform assistance for starting train"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/atoErrorCorrectionsOnboard
@@ -3517,7 +3570,7 @@ era:atoErrorCorrectionsOnboard rdf:type owl:DatatypeProperty ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "(Deprecated) ATO error corrections required for the on-board. Use: errorCorrectionsOnboard"@en ;
                                owl:deprecated "true"^^xsd:boolean ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "deprecated" .
+                               vs:term_status "deprecated" .
 
 
 ###  http://data.europa.eu/949/automaticDroppingDeviceRequired
@@ -3532,7 +3585,7 @@ era:automaticDroppingDeviceRequired rdf:type owl:DatatypeProperty ;
                                     rdfs:comment "Indication of whether an automatic dropping device (ADD) required on the vehicle."@en ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "Automatic dropping device required"@en ;
-                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/axleSpacing
@@ -3545,7 +3598,7 @@ era:axleSpacing rdf:type owl:DatatypeProperty ;
                 rdfs:comment "Position of the axles along the unit. a: Distance between axles; b: Distance from end axle to the end of the nearest coupling plane; c: distance between two inside axles."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Axle spacing"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/bigMetalMass
@@ -3564,7 +3617,7 @@ era:bigMetalMass rdf:type owl:DatatypeProperty ,
                  rdfs:comment "Indication of existence of metal mass in the vicinity of the location, susceptible of perturbating the reading of balises by the on-board system."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Big Metal Mass"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                 vs:term_status "stable" ;
                  skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -3578,7 +3631,7 @@ era:boardingAids rdf:type owl:DatatypeProperty ;
                  rdfs:comment "Description of any integrated boarding aids (if provided)."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Boarding aids"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/brakeWeightPercentage
@@ -3591,7 +3644,7 @@ era:brakeWeightPercentage rdf:type owl:DatatypeProperty ;
                           rdfs:comment "Brake weight percentage (lambda) or Braked mass."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Brake weight percentage"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/bridge
@@ -3600,7 +3653,7 @@ era:bridge rdf:type owl:DatatypeProperty ;
            rdfs:range xsd:boolean ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "Is bridge"@en ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+           vs:term_status "stable" ;
            skos:definition "Whether or not a track is associated with a bridge."@en .
 
 
@@ -3614,7 +3667,7 @@ era:cantDefficiency rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Cant deficiency (maximum uncompensated lateral acceleration) for which the vehicle has been assessed. For dual gauge vehicles values for each gauge have to be indicated."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Cant defficiency"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/cantDeficiency
@@ -3623,14 +3676,14 @@ era:cantDeficiency rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:integer ;
                    era:XMLName "ITP_CantDeficiency" ;
                    era:rinfIndex "1.1.1.1.4.2" ;
-                   era:unitOfMeasure qudt:MilliM ;
+                   era:unitOfMeasure unit:MilliM ;
                    era:usedInRCCCalculations "true"^^xsd:boolean ;
                    dcterms:created "2020-08-24"^^xsd:date ;
                    dcterms:modified "2021-09-10"^^xsd:date ;
                    rdfs:comment "Maximum cant deficiency expressed in millimetres defined as difference between the applied cant and a higher equilibrium cant the line has been designed for."@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Cant deficiency"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/catenaryMaxRatedCurrent
@@ -3643,7 +3696,7 @@ era:catenaryMaxRatedCurrent rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Maximum rated current from the catenary (to be indicated for each electrical energy supply system the vehicle is equipped for), given in A."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Catenary max rated current"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/complianceInfTsi
@@ -3657,7 +3710,7 @@ era:complianceInfTsi rdf:type owl:DatatypeProperty ;
                      rdfs:comment "Compliance of the tunnel with TSI INF at the maximum permitted speed."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Compliance of the tunnel with TSI INF"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/compositeBrakeBlockRetrofitted
@@ -3669,7 +3722,7 @@ era:compositeBrakeBlockRetrofitted rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "Indicates if a vehicle's composite brake block is retrofitted"@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Composite brake block retrofitted"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/conditionalRegenerativeBrake
@@ -3686,7 +3739,7 @@ era:conditionalRegenerativeBrake rdf:type owl:DatatypeProperty ,
                                  rdfs:comment "Indication whether regenerative braking is permitted, not permitted, or permitted under specific conditions."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Permission for regenerative braking"@en ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/conditionsAppliedRegenerativeBraking
@@ -3704,7 +3757,7 @@ era:conditionsAppliedRegenerativeBraking rdf:type owl:DatatypeProperty ;
                                          rdfs:comment "Name and/or reference of the document specifying the conditions applying in regards to regenerative braking."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Conditions applying in regards to regenerative braking"@en ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                         vs:term_status "stable" ;
                                          skos:scopeNote "When `not electrified` is chosen in parameter 1.1.1.2.2.1.1, then this parameter is not applicable."@en .
 
 
@@ -3717,7 +3770,7 @@ era:conditionsChargingElectricEnergyStorage rdf:type owl:DatatypeProperty ;
                                             rdfs:comment "Conditions set by IMs according to a standardised document."@en ;
                                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                             rdfs:label "Permitted conditions for charging electric energy storage for traction purposes at standstill"@en ;
-                                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/conditionsSwitchClassBSystems
@@ -3735,7 +3788,7 @@ era:conditionsSwitchClassBSystems rdf:type owl:DatatypeProperty ;
                                   rdfs:comment "Name and/or reference of the document specifying the Special technical conditions required to switch over between ERTMS/ETCS and Class B systems."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Special technical conditions required to switch over between ERTMS/ETCS and Class B systems"@en ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/conditionsSwitchTrainProtectionSystems
@@ -3751,7 +3804,7 @@ era:conditionsSwitchTrainProtectionSystems rdf:type owl:DatatypeProperty ;
                                            rdfs:comment "Conditions to switch over between different class B train protection, control and warning systems."@en ;
                                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                            rdfs:label "Special conditions to switch over between different class B train protection, control and warning systems"@en ;
-                                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/conditionsTrainFormation
@@ -3764,7 +3817,7 @@ era:conditionsTrainFormation rdf:type owl:DatatypeProperty ;
                              rdfs:comment "Conditions of use regarding train formation."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Conditions train formation"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/contactStripMaterialMetallicContent
@@ -3778,7 +3831,7 @@ era:contactStripMaterialMetallicContent rdf:type owl:DatatypeProperty ;
                                         rdfs:comment "In case that the value of the property era:contactStripMaterial is \"impregnated carbon\", it is the metallic content in % (this value must be added). This is the maximum percentage allowed."@en ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "Contact strip material metallic content"@en ;
-                                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/containerHandlingFlag
@@ -3786,6 +3839,7 @@ era:containerHandlingFlag rdf:type owl:DatatypeProperty ;
                           rdfs:domain era:PrimaryLocation ;
                           rdfs:range xsd:boolean ;
                           dcterms:created "2024-06-03"^^xsd:date ;
+                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "container handling flag"@en .
 
 
@@ -3795,13 +3849,13 @@ era:crossSectionArea rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:integer ;
                      era:XMLName "ITU_CrossSectionArea" ;
                      era:rinfIndex "1.1.1.1.8.8" ;
-                     era:unitOfMeasure qudt:M2 ;
+                     era:unitOfMeasure unit:M2 ;
                      dcterms:created "2021-08-03"^^xsd:date ;
                      dcterms:modified "2021-08-03"^^xsd:date ;
                      rdfs:comment "Smallest cross section area in square metres of the tunnel."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Cross section area"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/currentLimitationRequired
@@ -3816,7 +3870,7 @@ era:currentLimitationRequired rdf:type owl:DatatypeProperty ;
                               rdfs:comment "Indication of whether an on board current or power limitation function on vehicles is required."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "Current or power limitation on board required"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/currentlyValid
@@ -3828,7 +3882,7 @@ era:currentlyValid rdf:type owl:DatatypeProperty ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Currently valid"@en ;
                    owl:deprecated "true"^^xsd:boolean ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/dNvovtrp
@@ -3840,7 +3894,7 @@ era:dNvovtrp rdf:type owl:DatatypeProperty ,
              era:appendixD3Index "1.5.5" ;
              era:rinfIndex "1.1.1.3.2.16.5" ,
                            "1.2.1.1.1.16.5" ;
-             era:unitOfMeasure qudt:M ;
+             era:unitOfMeasure unit:M ;
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2024-01-08"^^xsd:date ,
                               "2024-04-18"^^xsd:date ;
@@ -3852,7 +3906,7 @@ Precision: [NNNNNN.N] with N a decimal number (0÷9)
 In Subset 26, chapter 7. 7.5.1.15 D_NVOVTRP."""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "D_NVOVTRP"@en ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+             vs:term_status "stable" ;
              skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -3865,7 +3919,7 @@ era:dNvpotrp rdf:type owl:DatatypeProperty ,
              era:appendixD3Index "1.5.7" ;
              era:rinfIndex "1.1.1.3.2.16.7" ,
                            "1.2.1.1.1.16.7" ;
-             era:unitOfMeasure qudt:M ;
+             era:unitOfMeasure unit:M ;
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2023-03-14"^^xsd:date ,
                               "2024-04-18"^^xsd:date ;
@@ -3878,7 +3932,7 @@ See: TSI CCS (Subset 26, chapter 7. 7.5.1.16 D_NVPOTRP)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "D_NVPOTRP"@en ;
              rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+             vs:term_status "stable" ;
              skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -3891,7 +3945,7 @@ era:dNvroll rdf:type owl:DatatypeProperty ,
             era:appendixD3Index "1.5.1" ;
             era:rinfIndex "1.1.1.3.2.16.1" ,
                           "1.2.1.1.1.16.1" ;
-            era:unitOfMeasure qudt:M ;
+            era:unitOfMeasure unit:M ;
             dcterms:created "2022-11-07"^^xsd:date ;
             dcterms:modified "2023-03-14"^^xsd:date ,
                              "2024-04-18"^^xsd:date ;
@@ -3904,7 +3958,7 @@ See: TSI CCS (Subset 26, chapter 7. 7.5.1.17 D_NVROLL)"""@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             rdfs:label "D_NVROLL"@en ;
             rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+            vs:term_status "stable" ;
             skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -3918,7 +3972,7 @@ era:dangerousGoodsTankCode rdf:type owl:DatatypeProperty ;
                            rdfs:comment "Dangerous goods for which the vehicle is suitable (tank code)."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Dangerous goods tank code"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/demonstrationENE
@@ -3931,7 +3985,7 @@ era:demonstrationENE rdf:type owl:DatatypeProperty ;
                      dcterms:modified "2024-01-08"^^xsd:date ;
                      rdfs:comment "Unique number for EI declarations following the same format requirements as specified for EC declarations in Annex VII of Commission Implementing Regulation (EU) 2019/250." ;
                      rdfs:label "EI declaration of demonstration (as defined Recommendation 2014/881/EU) for track relating to compliance with the requirements from TSIs applicable to energy subsystem"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/demonstrationINF
@@ -3948,7 +4002,7 @@ era:demonstrationINF rdf:type owl:DatatypeProperty ;
 In https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019R0777&from=EN"""@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "EI declaration of demonstration (as defined Commission 2014/881/EU) for track relating to compliance with the requirements from TSIs applicable to infrastructure subsystem"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/demonstrationSRT
@@ -3964,7 +4018,7 @@ era:demonstrationSRT rdf:type owl:DatatypeProperty ;
                      rdfs:comment "Unique number for EI declarations following the same format requirements as specified for EC declarations in Annex VII of Commission Implementing Regulation (EU) 2019/250."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "EI declaration of demonstration (as defined in Recommendation 2014/881/EU) relating to compliance with the requirements from TSIs applicable to railway tunnel"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/designMassExceptionalPayload
@@ -3977,7 +4031,7 @@ era:designMassExceptionalPayload rdf:type owl:DatatypeProperty ;
                                  rdfs:comment "Design mass under exceptional payload."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Design mass under exceptional payload"@en ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/designMassNormalPayload
@@ -3990,7 +4044,7 @@ era:designMassNormalPayload rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Design mass under normal payload."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Design mass under normal payload"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/designMassWorkingOrder
@@ -4003,7 +4057,7 @@ era:designMassWorkingOrder rdf:type owl:DatatypeProperty ;
                            rdfs:comment "Design mass in working order."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Design mass in working order"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/dieselThermalAllowed
@@ -4017,19 +4071,19 @@ era:dieselThermalAllowed rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Indication whether it is allowed to use diesel or other thermal traction in the tunnel."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Diesel or other thermal traction allowed"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/digitalSchematicOverview
 era:digitalSchematicOverview rdf:type owl:DatatypeProperty ;
                              rdfs:domain era:OperationalPoint ;
-                             rdfs:range <http://www.opengis.net/ont/geosparql#wktLiteral> ;
+                             rdfs:range geo:wktLiteral ;
                              era:rinfIndex "1.2.0.0.0.7.2" ;
                              dcterms:created "2023-03-14"^^xsd:date ;
                              rdfs:comment "TODO review: Diagrammatic representation of the operational point in Well Known Text polyline"@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Digital schematic overview"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/distSignToPhaseEnd
@@ -4045,7 +4099,7 @@ era:distSignToPhaseEnd rdf:type owl:DatatypeProperty ;
 Distance between the signboard authorizing the driver to ‘raise pantograph’ or ‘close the circuit breaker’ after passing the phase separation and the end of the phase separation section."""@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Distance between signboard and phase separation ending"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/documentRestrictionPositionContactLineSeparation
@@ -4057,7 +4111,7 @@ era:documentRestrictionPositionContactLineSeparation rdf:type owl:DatatypeProper
                                                      rdfs:comment "Name and/or reference of the document specifying the restriction(s) related to the position of Multiple Traction unit(s) to comply with contact line separation."@en ;
                                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                                      rdfs:label "Document with restriction related to the position of Multiple Traction unit(s) to comply with contact line separation"@en ;
-                                                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/documentRestrictionPowerConsumption
@@ -4069,7 +4123,7 @@ era:documentRestrictionPowerConsumption rdf:type owl:DatatypeProperty ;
                                         rdfs:comment "Name and/or reference of the document specifying the restriction(s) related to power consumption of specific electric traction unit(s)."@en ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "Document with restriction related to power consumption of specific electric traction unit(s)"@en ;
-                                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/documentUrl
@@ -4080,7 +4134,7 @@ era:documentUrl rdf:type owl:DatatypeProperty ;
                 rdfs:comment "URL that is used to download a document, e.g. url for a reference document in RINF."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Document URL"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/drivingCabs
@@ -4093,7 +4147,7 @@ era:drivingCabs rdf:type owl:DatatypeProperty ;
                 rdfs:comment "Number of driving cabs. For wagons the number of driving cabs is to be set to zero (0)."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Driving cabs"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/eddyCurrentBrakePrevention
@@ -4106,7 +4160,7 @@ era:eddyCurrentBrakePrevention rdf:type owl:DatatypeProperty ;
                                rdfs:comment "Possibility of preventing the use of the eddy current track brake (only if fitted with eddy current brake)"@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Eddy current brake prevention"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/eddyCurrentBrakingFitted
@@ -4118,7 +4172,7 @@ era:eddyCurrentBrakingFitted rdf:type owl:DatatypeProperty ;
                              rdfs:comment "Eddy current track brake fitted. New property defined to distinghish it from eddyCurrentBraking which is a RINF SKOS property."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Eddy current braking fitted"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/emergencyBrake
@@ -4131,7 +4185,7 @@ era:emergencyBrake rdf:type owl:DatatypeProperty ;
                    rdfs:comment "Stopping distance and deceleration profile for each load condition per design maximum speed."@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Emergency braking"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/endIntrinsicCoordinate
@@ -4143,7 +4197,7 @@ era:endIntrinsicCoordinate rdf:type owl:DatatypeProperty ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "End intrinsic coordinate"@en ;
                            owl:deprecated "true"^^xsd:boolean ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/energyMeterInstalled
@@ -4156,7 +4210,7 @@ era:energyMeterInstalled rdf:type owl:DatatypeProperty ;
                          rdfs:comment "TSI conform energy meter for billing purposes installed on board."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Energy meter installed"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/energySupplyMaxPower
@@ -4169,7 +4223,7 @@ era:energySupplyMaxPower rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Maximum power (to be indicated for each energy supply system the vehicle is equipped for), given in kW."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Energy supply max power"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/energySupplySystemTSICompliant
@@ -4184,7 +4238,7 @@ era:energySupplySystemTSICompliant rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "Indication if the traction supply system (nominal voltage and frequency) is fully compliant with TSI."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Energy supply system TSI compliant"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/errorCorrectionsOnboardExplanation
@@ -4198,7 +4252,7 @@ era:errorCorrectionsOnboardExplanation rdf:type owl:DatatypeProperty ;
                                        rdfs:comment "Explanation on why a mandatory onboard CR required to be solved in the on-board (ETCS, GSM-R and/or ATO) was accepted by the IM."@en ;
                                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                        rdfs:label "Reasons for Error corrections required, but accepted by the IM for the on-board ETCS, GSM-R and/or ATO function"@en ;
-                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/ertmsErrorCorrectionsOnBoard
@@ -4211,7 +4265,7 @@ era:ertmsErrorCorrectionsOnBoard rdf:type owl:DatatypeProperty ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "(Deprecated) ERTMS error corrections required for the on-board. Use: errorCorrectionsOnboard"@en ;
                                  owl:deprecated "true"^^xsd:boolean ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsDataCommApp
@@ -4224,7 +4278,7 @@ era:etcsDataCommApp rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Data communication application for ETCS implementation."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "ETCS data communication application"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsErrorCorrectionsOnboard
@@ -4239,7 +4293,7 @@ era:etcsErrorCorrectionsOnboard rdf:type owl:DatatypeProperty ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "(Deprecated) ETCS error corrections required for the on-board. Use: errorCorrectionsOnboard"@en ;
                                 owl:deprecated "true"^^xsd:boolean ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsImplementsLevelCrossingProcedure
@@ -4258,7 +4312,7 @@ era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty ,
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "ETCS trackside implements level crossing procedure or an equivalent solution"@en ;
                                          rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                         vs:term_status "stable" ;
                                          skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -4279,7 +4333,7 @@ See: TSI CCS 7.2.9.1 & 4.2.3 """@en ;
                          rdfs:comment "Indication whether infill is required to access the line for safety reasons."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "ETCS infill necessary for line access"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                         vs:term_status "stable" ;
                          skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -4293,7 +4347,7 @@ era:etcsNationalApplications rdf:type owl:DatatypeProperty ;
                              rdfs:comment "ETCS national applications implemented (NID_XUSER of Packet 44)."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "ETCS national applications"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsNationalPacket44
@@ -4321,7 +4375,7 @@ See: TSI CCS (7.4.3 & 6.2.4.2)"""@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "ETCS national packet 44 application implemented"@en ;
                          rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                         vs:term_status "stable" ;
                          skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -4335,7 +4389,7 @@ era:etcsOnBoardImplementation rdf:type owl:DatatypeProperty ;
                               rdfs:comment "ETCS on-board implementation."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "ETCS on-board implementation"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsOptionalFunctions
@@ -4350,7 +4404,7 @@ era:etcsOptionalFunctions rdf:type owl:DatatypeProperty ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "ETCS optional functions"@en ;
                           owl:deprecated "true"^^xsd:boolean ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                          vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/etcsSystemFunctionalitiesNextFiveYears
@@ -4366,7 +4420,7 @@ era:etcsSystemFunctionalitiesNextFiveYears rdf:type owl:DatatypeProperty ;
                                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                            rdfs:label "ETCS system version 2.2 or 3.0 functionalities to be required in the next 5 years. Deprecated with TWG RINF CCS 2024."@en ;
                                            owl:deprecated "true"^^xsd:boolean ;
-                                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/etcsTransmitsTrackConditions
@@ -4386,7 +4440,7 @@ era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty ,
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Is the ETCS trackside engineered to transmit Track Conditions"@en ;
                                  rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                 vs:term_status "stable" ;
                                  skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -4400,7 +4454,7 @@ era:ferromagneticWheelMaterial rdf:type owl:DatatypeProperty ;
                                rdfs:comment "Wheel material is ferromagnetic."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Ferromagnetic wheel material"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/fixedSeats
@@ -4413,7 +4467,7 @@ era:fixedSeats rdf:type owl:DatatypeProperty ;
                rdfs:comment "Number of fixed seats."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "Fixed seats"@en ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/flangeLubeForbidden
@@ -4427,7 +4481,7 @@ era:flangeLubeForbidden rdf:type owl:DatatypeProperty ;
                         rdfs:comment "Indication whether the use of on-board device for flange lubrication is forbidden."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Use of flange lubrication forbidden"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/flangeLubeRules
@@ -4442,7 +4496,7 @@ era:flangeLubeRules rdf:type owl:DatatypeProperty ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Existence of rules on on-board flange lubrication"@en ;
                     owl:deprecated "true"^^xsd:boolean ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/flangeLubricationFitted
@@ -4455,7 +4509,7 @@ era:flangeLubricationFitted rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Indicates if the vehicle type is fitted for flange lubrication."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Flange lubrication fitted"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/freightFlag
@@ -4463,6 +4517,7 @@ era:freightFlag rdf:type owl:DatatypeProperty ;
                 rdfs:domain era:PrimaryLocation ;
                 rdfs:range xsd:boolean ;
                 dcterms:created "2024-06-03"^^xsd:date ;
+                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "freight flag"@en .
 
 
@@ -4479,7 +4534,7 @@ era:frenchTrainDetectionSystemLimitationApplicable rdf:type owl:DatatypeProperty
                                                    rdfs:comment "Part of the section with train detection limitation that indicates if it is applicable. Only for the French network."@en ;
                                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                                    rdfs:label "Section with train detection limitation"@en ;
-                                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/gaugingCheckLocation
@@ -4495,7 +4550,7 @@ era:gaugingCheckLocation rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Location of particular points requiring specific checks due to deviations from gauging referred to in parameter \"Gauging\"."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Railway location of particular points requiring specific checks"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/gprsForETCS
@@ -4515,7 +4570,7 @@ era:gprsForETCS rdf:type owl:DatatypeProperty ,
                 rdfs:comment "Indication if GPRS can be used for ETCS."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "GPRS for ETCS"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                vs:term_status "stable" ;
                 skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -4534,7 +4589,7 @@ era:gprsImplementationArea rdf:type owl:DatatypeProperty ;
                            rdfs:comment "Indication of the area in which GPRS can be used for ETCS, expressed as a list of GPRS-enabled RBC's."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Area of implementation of GPRS"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                           vs:term_status "stable" ;
                            skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1), ETCS L2 (parameter 1.1.1.3.2.1) and GPRS for ETCS (parameter 1.1.1.3.3.3.2) must be installed for this parameter to be applicable."@en .
 
 
@@ -4551,7 +4606,7 @@ era:gradient rdf:type owl:DatatypeProperty ;
              rdfs:comment "Maximum value of the gradient for stabling tracks expressed in millimetres per metre."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "Gradient for stabling tracks"@en ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/gradientProfile
@@ -4568,7 +4623,7 @@ era:gradientProfile rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Sequence of gradient values and locations of change in gradient."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Gradient profile"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/gsmRNoCoverage
@@ -4587,7 +4642,7 @@ Another possible use is the declaration of a temporary situation where, although
                    rdfs:comment "Indication if there is no GSMR coverage."@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "No GSMR coverage"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                   vs:term_status "stable" ;
                    skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -4601,7 +4656,7 @@ era:gsmRSetsInDrivingCab rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Number of GSM-R mobile sets in driving cab for data transmission."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "GSM-R sets in driving cab"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/gsmrErrorCorrectionsOnboard
@@ -4616,7 +4671,7 @@ The reason for deprecation is that this parameter does not appear in the latest 
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "(Deprecated) GSM-R error corrections required for the on-board"@en ;
                                 owl:deprecated "true"^^xsd:boolean ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/gsmrForcedDeregistrationFunctionalNumber
@@ -4634,7 +4689,7 @@ era:gsmrForcedDeregistrationFunctionalNumber rdf:type owl:DatatypeProperty ,
                                              rdfs:comment "This feature will determine the applicable operational rules for drivers and signallers when dealing with cab radios registered under wrong numbers."@en ;
                                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                              rdfs:label "Is the GSM-R network configured to allow forced de-registration of a functional number by another driver?"@en ;
-                                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                             vs:term_status "stable" ;
                                              skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -4658,7 +4713,7 @@ era:hasAdditionalBrakingInformation rdf:type owl:DatatypeProperty ;
                                     rdfs:comment "Availability by the IM of additional information as defined in point (2) of point 4.2.2.6.2 of TSI OPE."@en ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "Availability by the IM of additional information"@en ;
-                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasAutomaticDroppingDevice
@@ -4671,7 +4726,7 @@ era:hasAutomaticDroppingDevice rdf:type owl:DatatypeProperty ;
                                rdfs:comment "Automatic dropping device (ADD) fitted (to be indicated for each energy supply system the vehicle is equipped for)."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Has automatic dropping device"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasBallast
@@ -4685,7 +4740,7 @@ era:hasBallast rdf:type owl:DatatypeProperty ;
                rdfs:comment "Specifies whether track construction is with sleepers embedded in ballast or not."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "Existence of ballast"@en ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasCantDefficiencyCompensation
@@ -4698,7 +4753,7 @@ era:hasCantDefficiencyCompensation rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "Vehicle equipped with a cant deficiency compensation system (tilting vehicle)."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Has cant defficiency compensation"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasCurrentLimitation
@@ -4711,7 +4766,7 @@ era:hasCurrentLimitation rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Electric units equipped with power or current limitation function."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Has current limitation"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasETCSRestrictionsConditions
@@ -4737,7 +4792,7 @@ and deviations – Guidelines for using the ERA template) with the following lin
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Existence of operating restrictions or conditions"@en ;
                                   rdfs:seeAlso <https://www.era.europa.eu/system/files/2022-11/restrictions_and_added_functions_en_1.doc> ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                  vs:term_status "stable" ;
                                   skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -4752,7 +4807,7 @@ era:hasElectricShoreSupply rdf:type owl:DatatypeProperty ;
                            rdfs:comment "Indication whether an installation for electric shore supply exists (fixed installation for servicing trains)."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Existence of electric shore supply"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasEmergencyPlan
@@ -4768,7 +4823,7 @@ era:hasEmergencyPlan rdf:type owl:DatatypeProperty ;
                      rdfs:comment "Indication whether emergency plan exists."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Existence of emergency plan"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasEvacuationAndRescuePoints
@@ -4785,7 +4840,7 @@ era:hasEvacuationAndRescuePoints rdf:type owl:DatatypeProperty ;
                                  rdfs:comment "Indication of existence of evacuation and rescue points."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Existence of evacuation and rescue points"@en ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasExternalCleaning
@@ -4799,7 +4854,7 @@ era:hasExternalCleaning rdf:type owl:DatatypeProperty ;
                         rdfs:comment "Indication whether exists an installation for external cleaning facility (fixed installation for servicing trains) as defined in TSI INF."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Existence of external cleaning facilities"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasHotAxleBoxDetector
@@ -4814,7 +4869,7 @@ era:hasHotAxleBoxDetector rdf:type owl:DatatypeProperty ;
                           rdfs:comment "Existence of trackside HABD."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Existence of trackside hot axle box detector (HABD)"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasLevelCrossings
@@ -4828,7 +4883,7 @@ era:hasLevelCrossings rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Indication whether level crossings (including pedestrian track crossing) exist on the section of line."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Existence of level crossings"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasLubricationDevicePrevention
@@ -4841,7 +4896,7 @@ era:hasLubricationDevicePrevention rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "Possibility of preventing the use of the lubrication device (only if fitted with flange lubrication)."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Has lubrication device prevention"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasOtherTrainProtection
@@ -4855,7 +4910,7 @@ era:hasOtherTrainProtection rdf:type owl:DatatypeProperty ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Existence of other train protection, control and warning systems installed"@en ;
                             owl:deprecated "true"^^xsd:boolean ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                            vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/hasParkingBrake
@@ -4868,7 +4923,7 @@ era:hasParkingBrake rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Indicates if a vehicle type has parking brake."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Has parking brake"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasPlatformCurvature
@@ -4883,7 +4938,7 @@ era:hasPlatformCurvature rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Indication of the existence of the curvature of the platform."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Curvature of the platform"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasRefuelling
@@ -4897,7 +4952,7 @@ era:hasRefuelling rdf:type owl:DatatypeProperty ;
                   rdfs:comment "Indication whether exists an installation for refuelling (fixed installation for servicing trains) as defined in TSI INF."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Existence of refuelling"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasRegenerativeBrake
@@ -4910,7 +4965,7 @@ era:hasRegenerativeBrake rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Indication whether regenerative braking is permitted or not."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Permission for regenerative braking"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasSandRestocking
@@ -4924,7 +4979,7 @@ era:hasSandRestocking rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Indication whether an installation for sand restocking exists (fixed installation for servicing trains)."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Existence of sand restocking"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasSandingPrevention
@@ -4937,7 +4992,7 @@ era:hasSandingPrevention rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Possibility of preventing the use of sanding."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Has sanding prevention"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasSchematicOverviewOPDigitalForm
@@ -4950,7 +5005,7 @@ era:hasSchematicOverviewOPDigitalForm rdf:type owl:DatatypeProperty ;
                                       rdfs:comment "The existence of a schematic overview of the operational point in digital form."@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Schematic overview of the operational point in digital form"@en ;
-                                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasSevereWeatherConditions
@@ -4965,7 +5020,7 @@ era:hasSevereWeatherConditions rdf:type owl:DatatypeProperty ;
                                rdfs:comment "Climatic conditions on the line are severe according to European standard."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Existence of severe climatic conditions"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasShuntingRestrictions
@@ -4978,7 +5033,7 @@ era:hasShuntingRestrictions rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Indicates the presence of shunting restrictions."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Has shunting restrictions"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasSystemSeparation
@@ -4992,7 +5047,7 @@ era:hasSystemSeparation rdf:type owl:DatatypeProperty ;
                         rdfs:comment "Indication of existence of system separation."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "System separation"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasTSITrainDetection
@@ -5009,7 +5064,7 @@ era:hasTSITrainDetection rdf:type owl:DatatypeProperty ,
                          rdfs:comment "Indication if there is any train detection system installed and fully compliant with the TSI CCS (Annex I, Appendix A, Table A.2 -Index 77)."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Existence of train detection system fully compliant with the TSI"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasToiletDischarge
@@ -5023,7 +5078,7 @@ era:hasToiletDischarge rdf:type owl:DatatypeProperty ;
                        rdfs:comment "Indication whether exists an installation for toilet discharge (fixed installation for servicing trains) as defined in TSI INF."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Existence of toilet discharge"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasTrainIntegrityConfirmation
@@ -5036,7 +5091,7 @@ era:hasTrainIntegrityConfirmation rdf:type owl:DatatypeProperty ;
                                   rdfs:comment "Indication of on-board management system about completeness of the train information."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Has train integrity confirmation"@en ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasWalkway
@@ -5053,7 +5108,7 @@ era:hasWalkway rdf:type owl:DatatypeProperty ;
                rdfs:comment "Indication of existence of walkways."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "Existence of walkways"@en ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasWaterRestocking
@@ -5067,7 +5122,7 @@ era:hasWaterRestocking rdf:type owl:DatatypeProperty ;
                        rdfs:comment "Indication whether exists an installation for water restocking (fixed installation for servicing trains) as defined in TSI INF."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Existence of water restocking"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hasWheelSlideProtectionSystem
@@ -5080,7 +5135,7 @@ era:hasWheelSlideProtectionSystem rdf:type owl:DatatypeProperty ;
                                   rdfs:comment "Indicates the presence of a wheel slide protection system."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Has wheel slide protection system"@en ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/highSpeedLoadModelCompliance
@@ -5096,7 +5151,7 @@ era:highSpeedLoadModelCompliance rdf:type owl:DatatypeProperty ;
 Information regarding the procedure to be used to perform the dynamic compatibility check."""@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Compliance of structures with the High Speed Load Model (HSLM)"@en ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hotAxleBoxDetectorGeneration
@@ -5112,7 +5167,7 @@ era:hotAxleBoxDetectorGeneration rdf:type owl:DatatypeProperty ;
 Generation of trackside hot axle box detector."""@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Generation of trackside HABD"@en ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hotAxleBoxDetectorIdentification
@@ -5128,7 +5183,7 @@ era:hotAxleBoxDetectorIdentification rdf:type owl:DatatypeProperty ;
 Applicable if trackside HABD is not TSI compliant, identification of trackside hot axle box detector."""@en ;
                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                      rdfs:label "Identification of trackside HABD"@en ;
-                                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hotAxleBoxDetectorLocation
@@ -5144,7 +5199,7 @@ era:hotAxleBoxDetectorLocation rdf:type owl:DatatypeProperty ;
 Applicable if trackside HABD is not TSI compliant, localisation of trackside hot axle box detector."""@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Railway location of trackside HABD"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/hotAxleBoxDetectorTSICompliant
@@ -5160,7 +5215,7 @@ era:hotAxleBoxDetectorTSICompliant rdf:type owl:DatatypeProperty ;
 Trackside hot axle box detector TSI compliant."""@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Trackside HABD TSI compliant"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/idPhoneErtmsRadioBlockCenter
@@ -5178,7 +5233,7 @@ era:idPhoneErtmsRadioBlockCenter rdf:type owl:DatatypeProperty ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "ID  and phone number of ERTMS/ETCS Radio Block Center"@en ;
                                  owl:deprecated "true"^^xsd:boolean ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/imCode
@@ -5216,7 +5271,7 @@ the functions of the infrastructure manager on a network or part of a network ma
            rdfs:label "Infrastructure manager (IM)'s code"@en ;
            rdfs:seeAlso <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02012L0034-20190101#tocId45> ;
            owl:deprecated "true"^^xsd:boolean ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/instructionsSwitchRadioSystems
@@ -5234,7 +5289,7 @@ era:instructionsSwitchRadioSystems rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "Name and/or reference of the document specifying the Special instructions to switch over between different radio systems."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Special instructions to switch over between different radio systems"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/isQuietRoute
@@ -5248,7 +5303,7 @@ era:isQuietRoute rdf:type owl:DatatypeProperty ;
                  rdfs:comment "Belonging to a 'quieter route' in accordance with Article 5b of TSI NOI."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Belonging to a quieter route"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/kilometer
@@ -5277,7 +5332,7 @@ era:kilometer rdf:type owl:DatatypeProperty ;
               rdfs:comment "Distance measured in kilometers from the origin of a national railway line."@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "kilometer"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/kmPostName
@@ -5313,12 +5368,15 @@ era:length rdf:type owl:DatatypeProperty ;
                          "1.2.2.0.5.10.1" ,
                          "1.2.2.0.5.5" ,
                          "1.2.2.0.5.9.1" ;
-           era:unitOfMeasure qudt:M ;
+           era:unitOfMeasure unit:M ;
            era:usedInRCCCalculations "true"^^xsd:boolean ;
            dcterms:created "2021-04-01"^^xsd:date ;
            dcterms:modified "2024-01-08"^^xsd:date ;
            dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
-           rdfs:comment """Length of an infrastructure object"""@en ;
+           rdfs:comment "Length of an infrastructure object"@en ;
+           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+           rdfs:label "Length"@en ;
+           vs:term_status "stable" ;
            skos:scopeNote """The length can be 
 - a section of line (For operational length, use era:lengthOfSectionOfLine), 
 - a tunnel (For operational length, use era:lengthOfTunnel), 
@@ -5328,10 +5386,7 @@ era:length rdf:type owl:DatatypeProperty ;
   - a non-stopping area (accuracy +- 10m), 
   - a walkway, 
   - an evacuation and rescue point.
-- a vehicle length."""@en ;
-           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-           rdfs:label "Length"@en ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+- a vehicle length."""@en .
 
 
 ###  http://data.europa.eu/949/lengthOfPlatform
@@ -5341,13 +5396,13 @@ era:lengthOfPlatform rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:double ;
                      era:XMLName "IPL_Length" ;
                      era:rinfIndex "1.2.1.0.6.4" ;
-                     era:unitOfMeasure qudt:M ;
+                     era:unitOfMeasure unit:M ;
                      era:usedInRCCCalculations "true"^^xsd:boolean ;
                      dcterms:created "2024-05-16"^^xsd:date ;
                      rdfs:comment "The maximum continuous length (expressed in metres) of that part of platform in front of which a train is intended to remain stationary in normal operating conditions for passengers to board and alight from the train, making appropriate allowance for stopping tolerances."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Usable length of platform"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/lengthOfSectionOfLine
@@ -5357,13 +5412,13 @@ era:lengthOfSectionOfLine rdf:type owl:DatatypeProperty ;
                           rdfs:range xsd:double ;
                           era:XMLName "SOLLength" ;
                           era:rinfIndex "1.1.0.0.0.5" ;
-                          era:unitOfMeasure qudt:KiloM ;
+                          era:unitOfMeasure unit:KiloM ;
                           era:usedInRCCCalculations "true"^^xsd:boolean ;
                           dcterms:created "2024-05-16"^^xsd:date ;
                           rdfs:comment "Length between operational points at start and end of section of line."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Length of section of line"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/lengthOfSiding
@@ -5380,7 +5435,7 @@ era:lengthOfSiding rdf:type owl:DatatypeProperty ;
 where trains can be parked safely."""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Usable length of siding"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/lengthOfTunnel
@@ -5392,13 +5447,13 @@ era:lengthOfTunnel rdf:type owl:DatatypeProperty ;
                    era:rinfIndex "1.1.1.1.8.7" ,
                                  "1.2.1.0.5.5" ,
                                  "1.2.2.0.5.5" ;
-                   era:unitOfMeasure qudt:M ;
+                   era:unitOfMeasure unit:M ;
                    era:usedInRCCCalculations "true"^^xsd:boolean ;
                    dcterms:created "2024-05-16"^^xsd:date ;
                    rdfs:comment "Length of a tunnel in metres from entrance portal to exit portal."@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Length of tunnel"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/letterMarking
@@ -5411,7 +5466,7 @@ era:letterMarking rdf:type owl:DatatypeProperty ;
                   rdfs:comment "letter marking"@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Letter marking"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/linearCoordinate
@@ -5419,13 +5474,13 @@ era:linearCoordinate rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:double ;
                      dcterms:created "2021-04-01"^^xsd:date ;
                      dcterms:modified "2023-11-10"^^xsd:date ;
-                     rdfs:comment """Indicates the position of an object within a linear positioning system. For example, relative to a national railway line"""@en ; 
-                     skos:editorialNote """"The reason for deprecation is that this property is not specified in the latest
-					 legal text nor the RINF application guide. Also, no data has been provided for this property."""@en ;
+                     rdfs:comment "Indicates the position of an object within a linear positioning system. For example, relative to a national railway line"@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Linear coordinate"@en ;
                      owl:deprecated "true"^^xsd:boolean ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" ;
+                     skos:editorialNote """\"The reason for deprecation is that this property is not specified in the latest
+					 legal text nor the RINF application guide. Also, no data has been provided for this property."""@en .
 
 
 ###  http://data.europa.eu/949/linesideDistanceIndicationFrequency
@@ -5440,7 +5495,7 @@ era:linesideDistanceIndicationFrequency rdf:type owl:DatatypeProperty ;
                                         rdfs:comment "Frequency of track lineside distance indications."@en ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "Lineside distance indication frequency"@en ;
-                                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/loadCapabilitySpeed
@@ -5449,16 +5504,16 @@ era:loadCapabilitySpeed rdf:type owl:DatatypeProperty ;
                         rdfs:range xsd:integer ;
                         era:XMLName "IPP_LoadCap" ;
                         era:rinfIndex "1.1.1.1.2.4" ;
-                        era:unitOfMeasure qudt:KiloM-PER-HR ;
+                        era:unitOfMeasure unit:KiloM-PER-HR ;
                         era:usedInRCCCalculations "true"^^xsd:boolean ;
                         dcterms:created "2023-01-20"^^xsd:date ;
-                        rdfs:comment """Part of the load capability of a track that corresponds to the speed of the load model"""@en ;  
-                        skos:scopeNote """ The load capability is a value selected from the list of load models representing: 
-						line category which is amended by value of speed [km/h] permitted for a specific load model. 
-						The list of values may also be Route Availability which is amended by value of speed [miles/h] permitted for a specific load model."""@en ;
+                        rdfs:comment "Part of the load capability of a track that corresponds to the speed of the load model"@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Load capability speed"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" ;
+                        skos:scopeNote """ The load capability is a value selected from the list of load models representing: 
+						line category which is amended by value of speed [km/h] permitted for a specific load model. 
+						The list of values may also be Route Availability which is amended by value of speed [miles/h] permitted for a specific load model."""@en .
 
 
 ###  http://data.europa.eu/949/loadingPlatformHeight
@@ -5471,7 +5526,7 @@ era:loadingPlatformHeight rdf:type owl:DatatypeProperty ;
                           rdfs:comment "Height of loading platform (for flat wagons and combined transport), given in mm."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Loading platform height"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/localRulesOrRestrictions
@@ -5490,7 +5545,7 @@ era:localRulesOrRestrictions rdf:type owl:DatatypeProperty ;
                              rdfs:comment "Existence of rules and restrictions of a strictly local nature."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Existence of rules and restrictions of a strictly local nature"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/mNvderun
@@ -5512,7 +5567,7 @@ See: TSI CCS (Subset 26, chapter 7. 7.5.1.75 M_NVDERUN)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "M_NVDERUN"@en ;
              rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+             vs:term_status "stable" ;
              skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -5526,7 +5581,7 @@ era:magneticBrakePrevention rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Possibility of preventing the use of the magnetic track brake (only if fitted with magnetic brake)"@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Magnetic brake prevention"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/magneticBrakingFitted
@@ -5538,7 +5593,7 @@ era:magneticBrakingFitted rdf:type owl:DatatypeProperty ;
                           rdfs:comment "Magnetic track brake fitted. New property defined to distinguish it from magneticBraking which is a RINF SKOS property."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Magnetic braking fitted"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/massPerWheel
@@ -5551,7 +5606,7 @@ era:massPerWheel rdf:type owl:DatatypeProperty ;
                  rdfs:comment "Mass per wheel, given in kg."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Mass per wheel"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maxCurrentStandstillPantograph
@@ -5567,7 +5622,7 @@ era:maxCurrentStandstillPantograph rdf:type owl:DatatypeProperty ;
                                    era:eratvIndex "4.10.4" ;
                                    era:rinfIndex "1.1.1.2.2.3" ,
                                                  "1.2.2.0.6.1" ;
-                                   era:unitOfMeasure qudt:A ;
+                                   era:unitOfMeasure unit:A ;
                                    era:usedInRCCCalculations "true"^^xsd:boolean ;
                                    dcterms:created "2020-08-25"^^xsd:date ;
                                    dcterms:modified "2021-09-12"^^xsd:date ;
@@ -5575,7 +5630,7 @@ era:maxCurrentStandstillPantograph rdf:type owl:DatatypeProperty ;
                                    rdfs:comment "Indication of the maximum allowable train current at standstill expressed in amperes."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Maximum current at standstill per pantograph"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maxDistConsecutiveAxles
@@ -5589,13 +5644,13 @@ era:maxDistConsecutiveAxles rdf:type owl:DatatypeProperty ;
                             era:XMLName "CTD_MaxDistConsecutiveAxles" ;
                             era:eratvIndex "4.14.2.1" ;
                             era:rinfIndex "1.1.1.3.7.2.2" ;
-                            era:unitOfMeasure qudt:MilliM ;
+                            era:unitOfMeasure unit:MilliM ;
                             dcterms:created "2021-08-08"^^xsd:date ;
                             dcterms:modified "2023-03-14"^^xsd:date ;
                             rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter. Indication of maximum permitted distance between two consecutive axles in case of TSI non-compliance, given in millimetres."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Maximum permitted distance between two consecutive axles in case of TSI non-compliance"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maxDistEndTrainFirstAxle
@@ -5604,14 +5659,14 @@ era:maxDistEndTrainFirstAxle rdf:type owl:DatatypeProperty ;
                              rdfs:range xsd:integer ;
                              era:XMLName "CTD_MaxDistEndTrainFirstAxle" ;
                              era:rinfIndex "1.1.1.3.7.5" ;
-                             era:unitOfMeasure qudt:MilliM ;
+                             era:unitOfMeasure unit:MilliM ;
                              dcterms:created "2021-08-08"^^xsd:date ;
                              dcterms:modified "2023-03-14"^^xsd:date ;
                              rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. Indication of maximum distance between end of train and first axle, given in millimetres, applicable for both sides (front and rear) of a vehicle or train."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Maximum distance between end of train and first axle"@en ;
                              owl:deprecated "true"^^xsd:boolean ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maxFlangeHeight
@@ -5625,13 +5680,13 @@ era:maxFlangeHeight rdf:type owl:DatatypeProperty ;
                     era:XMLName "CTD_MaxFlangeHeight" ;
                     era:eratvIndex "4.14.2.9" ;
                     era:rinfIndex "1.1.1.3.7.10" ;
-                    era:unitOfMeasure qudt:MilliM ;
+                    era:unitOfMeasure unit:MilliM ;
                     dcterms:created "2021-08-08"^^xsd:date ;
                     dcterms:modified "2023-03-14"^^xsd:date ;
                     rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter. Maximum permitted flange height, given in millimiters."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Maximum permitted height of the flange"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maxImpedanceWheelset
@@ -5651,7 +5706,7 @@ era:maxImpedanceWheelset rdf:type owl:DatatypeProperty ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Maximum permitted impedance between opposite wheels of a wheelset when not TSI compliant"@en ;
                          owl:deprecated "true"^^xsd:boolean ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maxLengthVehicleNose
@@ -5664,7 +5719,7 @@ era:maxLengthVehicleNose rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Maximum length of the vehicle nose."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Maximum length vehicle nose"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maxTrainCurrent
@@ -5674,13 +5729,13 @@ era:maxTrainCurrent rdf:type owl:DatatypeProperty ;
                     era:XMLName "ECS_MaxTrainCurrent" ;
                     era:appendixD2Index "3.3.2" ;
                     era:rinfIndex "1.1.1.2.2.2" ;
-                    era:unitOfMeasure qudt:A ;
+                    era:unitOfMeasure unit:A ;
                     dcterms:created "2021-08-06"^^xsd:date ;
                     dcterms:modified "2021-08-06"^^xsd:date ;
                     rdfs:comment "Indication of the maximum allowable train current expressed in amperes."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Maximum train current"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumAltitude
@@ -5688,13 +5743,13 @@ era:maximumAltitude rdf:type owl:DatatypeProperty ;
                     rdfs:domain era:InfraSubsystem ;
                     rdfs:range xsd:double ;
                     era:rinfIndex "1.1.1.1.2.7" ;
-                    era:unitOfMeasure qudt:M ;
+                    era:unitOfMeasure unit:M ;
                     dcterms:created "2021-08-03"^^xsd:date ;
                     dcterms:modified "2022-10-20"^^xsd:date ;
                     rdfs:comment "Highest point of the section of line above sea level in reference to Normal Amsterdam's Peil (NAP)."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Maximum altitude"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumAverageDeceleration
@@ -5707,7 +5762,7 @@ era:maximumAverageDeceleration rdf:type owl:DatatypeProperty ;
                                rdfs:comment "Maximum train deceleration given in m/s²."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Maximum average deceleration"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumBrakeThermalEnergyCapacity
@@ -5720,7 +5775,7 @@ era:maximumBrakeThermalEnergyCapacity rdf:type owl:DatatypeProperty ;
                                       rdfs:comment "Maximum brake thermal energy capacity given in kJ"@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Maximum brake thermal energy capacity"@en ;
-                                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumBrakingDistance
@@ -5729,14 +5784,14 @@ era:maximumBrakingDistance rdf:type owl:DatatypeProperty ;
                            rdfs:range xsd:integer ;
                            era:XMLName "CBP_MaxBrakeDist" ;
                            era:rinfIndex "1.1.1.3.11.1" ;
-                           era:unitOfMeasure qudt:M ;
+                           era:unitOfMeasure unit:M ;
                            era:usedInRCCCalculations "true"^^xsd:boolean ;
                            dcterms:created "2020-08-24"^^xsd:date ;
                            dcterms:modified "2021-09-12"^^xsd:date ;
                            rdfs:comment "The maximum value of the braking distance [in meters] of a train shall be given for the maximum line speed."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Maximum braking distance requested"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumContactWireHeight
@@ -5750,14 +5805,14 @@ era:maximumContactWireHeight rdf:type owl:DatatypeProperty ;
                              era:XMLName "ECS_MaxWireHeight" ;
                              era:eratvIndex "4.10.5" ;
                              era:rinfIndex "1.1.1.2.2.5" ;
-                             era:unitOfMeasure qudt:M ;
+                             era:unitOfMeasure unit:M ;
                              era:usedInRCCCalculations "true"^^xsd:boolean ;
                              dcterms:created "2020-08-25"^^xsd:date ;
                              dcterms:modified "2021-09-11"^^xsd:date ;
                              rdfs:comment "Indication of the maximum contact wire height expressed in metres."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Maximum contact wire height"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumDesignSpeed
@@ -5770,7 +5825,7 @@ era:maximumDesignSpeed rdf:type owl:DatatypeProperty ;
                        rdfs:comment "Maximum design speed."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Maximum design speed"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumInterferenceCurrent
@@ -5787,7 +5842,7 @@ era:maximumInterferenceCurrent rdf:type owl:DatatypeProperty ;
                                rdfs:comment "Maximum interference current limits allowed for track circuits for a defined frequency band (to be expressed in A/m)."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "maximum interference current"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumInterferenceCurrentEvaluation
@@ -5804,7 +5859,7 @@ era:maximumInterferenceCurrentEvaluation rdf:type owl:DatatypeProperty ,
 If the preferred frequency bands are used, this parameter is optional."""@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Evaluation parameters if maximum interference current is not measured in the preferred bands"@en ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumLocomotivesCoupled
@@ -5817,7 +5872,7 @@ era:maximumLocomotivesCoupled rdf:type owl:DatatypeProperty ;
                               rdfs:comment "Maximum number of trainsets or locomotives coupled together in multiple operation."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "Maximum locomotives coupled"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumMagneticFieldDirectionX
@@ -5833,7 +5888,7 @@ era:maximumMagneticFieldDirectionX rdf:type owl:DatatypeProperty ,
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction X."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Maximum magnetic field direction X"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                   vs:term_status "stable" ;
                                    skos:scopeNote "The maximumMagneticFieldDirectionX parameter is applicable for axle counters."@en .
 
 
@@ -5850,7 +5905,7 @@ era:maximumMagneticFieldDirectionY rdf:type owl:DatatypeProperty ,
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction Y."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Maximum magnetic field direction Y"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                   vs:term_status "stable" ;
                                    skos:scopeNote "The maximumMagneticFieldDirectionY parameter is applicable for axle counters."@en .
 
 
@@ -5867,7 +5922,7 @@ era:maximumMagneticFieldDirectionZ rdf:type owl:DatatypeProperty ,
                                    rdfs:comment "The maximum magnetic field limits allowed for axle counters (in dB µA/m) for a defined frequency band. Direction Z."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Maximum magnetic field direction Z"@en ;
-                                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                   vs:term_status "stable" ;
                                    skos:scopeNote "The maximumMagneticFieldDirectionZ parameter is applicable for axle counters."@en .
 
 
@@ -5879,14 +5934,14 @@ era:maximumPermittedSpeed rdf:type owl:DatatypeProperty ,
                           era:XMLName "IPP_MaxSpeed" ;
                           era:appendixD2Index "3.1.4" ;
                           era:rinfIndex "1.1.1.1.2.5" ;
-                          era:unitOfMeasure qudt:KiloM-PER-HR ;
+                          era:unitOfMeasure unit:KiloM-PER-HR ;
                           era:usedInRCCCalculations "true"^^xsd:boolean ;
                           dcterms:created "2020-08-24"^^xsd:date ;
                           dcterms:modified "2023-03-14"^^xsd:date ;
                           rdfs:comment "Nominal maximum operational speed on the line as a result of infrastructure, energy and control, command and signalling subsystem characteristics expressed in kilometres/hour."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Maximum permitted speed"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumServiceBrake
@@ -5899,7 +5954,7 @@ era:maximumServiceBrake rdf:type owl:DatatypeProperty ;
                         rdfs:comment "At maximum service brake: Stopping distance, Maximum deceleration, for the load condition 'design mass under normal payload' at the design maximum speed."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Maximum service break"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumSpeedAndCantDeficiency
@@ -5920,7 +5975,7 @@ Deprecated because of replacement by a class and two integer properties. The rea
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Maximum speed and cant deficiency"@en ;
                                   owl:deprecated "true"^^xsd:boolean ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumSpeedEmpty
@@ -5933,7 +5988,7 @@ era:maximumSpeedEmpty rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Maximum speed when empty."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Maximum speed empty"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumTemperature
@@ -5949,7 +6004,7 @@ era:maximumTemperature rdf:type owl:DatatypeProperty ;
                        rdfs:comment "Maximum temperature allowed for unrestricted operation access, according to European standard."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Temperature range (maximum)"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/maximumTrainDeceleration
@@ -5964,7 +6019,7 @@ era:maximumTrainDeceleration rdf:type owl:DatatypeProperty ;
                              rdfs:comment "Limit for longitudinal track resistance given as a maximum allowed train deceleration and expressed in metres per square second."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Maximum train deceleration"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/meetsRequirementVehicleAuthorisation
@@ -5977,7 +6032,7 @@ era:meetsRequirementVehicleAuthorisation rdf:type owl:DatatypeProperty ;
                                          rdfs:comment "Type meets the requirements necessary for validity of the vehicle authorisation granted by one Member State in other MSs."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Meets requirement vehicle authorisation"@en ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/minAxleLoad
@@ -5991,14 +6046,14 @@ era:minAxleLoad rdf:type owl:DatatypeProperty ;
                 era:XMLName "CTD_MinAxleLoadByVehicleCat" ;
                 era:eratvIndex "4.14.2.10" ;
                 era:rinfIndex "1.1.1.3.7.11.1" ;
-                era:unitOfMeasure qudt:TONNE ;
+                era:unitOfMeasure unit:TONNE ;
                 dcterms:created "2021-08-08"^^xsd:date ;
                 dcterms:modified "2023-03-14"^^xsd:date ;
                 rdfs:comment "Minimum permitted axle load, given in tons."@en ;
-                skos:scopeNote "Should be deprecated according to the ammendment to the Regulation (EU) 2019/777 but remains because it is also a parameter of ERATV."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Minimum permitted axle load"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" ;
+                skos:scopeNote "Should be deprecated according to the ammendment to the Regulation (EU) 2019/777 but remains because it is also a parameter of ERATV."@en .
 
 
 ###  http://data.europa.eu/949/minDistConsecutiveAxles
@@ -6012,14 +6067,14 @@ era:minDistConsecutiveAxles rdf:type owl:DatatypeProperty ;
                             era:XMLName "CTD_MinDistConsecutiveAxles" ;
                             era:eratvIndex "4.14.2.2" ;
                             era:rinfIndex "1.1.1.3.7.3" ;
-                            era:unitOfMeasure qudt:MilliM ;
+                            era:unitOfMeasure unit:MilliM ;
                             dcterms:created "2021-08-08"^^xsd:date ;
                             dcterms:modified "2023-03-14"^^xsd:date ;
                             rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
-                            skos:scopeNote  "Indication of minimum permitted distance between two consecutive axles, given in millimetres."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Minimum permitted distance between two consecutive axles"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" ;
+                            skos:scopeNote "Indication of minimum permitted distance between two consecutive axles, given in millimetres."@en .
 
 
 ###  http://data.europa.eu/949/minDistFirstLastAxle
@@ -6033,14 +6088,14 @@ era:minDistFirstLastAxle rdf:type owl:DatatypeProperty ;
                          era:XMLName "CTD_MinDistFirstLastAxles" ;
                          era:eratvIndex "4.14.2.3" ;
                          era:rinfIndex "1.1.1.3.7.4" ;
-                         era:unitOfMeasure qudt:MilliM ;
+                         era:unitOfMeasure unit:MilliM ;
                          dcterms:created "2021-08-08"^^xsd:date ;
                          dcterms:modified "2023-03-14"^^xsd:date ;
                          rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
-                         skos:scopeNote "Indication of minimum permitted distance between first and last axles, given in millimetres."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Minimum permitted distance between first and last axle"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" ;
+                         skos:scopeNote "Indication of minimum permitted distance between first and last axles, given in millimetres."@en .
 
 
 ###  http://data.europa.eu/949/minFlangeHeight
@@ -6054,14 +6109,14 @@ era:minFlangeHeight rdf:type owl:DatatypeProperty ;
                     era:XMLName "CTD_MinFlangeHeight" ;
                     era:eratvIndex "4.14.2.8" ;
                     era:rinfIndex "1.1.1.3.7.9" ;
-                    era:unitOfMeasure qudt:MilliM ;
+                    era:unitOfMeasure unit:MilliM ;
                     dcterms:created "2021-08-08"^^xsd:date ;
                     dcterms:modified "2021-09-01"^^xsd:date ;
                     rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
-                    skos:scopeNote "Minimum permitted flange height, given in millimiters."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Minimum permitted height of the flange"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" ;
+                    skos:scopeNote "Minimum permitted flange height, given in millimiters."@en .
 
 
 ###  http://data.europa.eu/949/minFlangeThickness
@@ -6075,14 +6130,14 @@ era:minFlangeThickness rdf:type owl:DatatypeProperty ;
                        era:XMLName "CTD_MinFlangeThickness" ;
                        era:eratvIndex "4.14.2.7" ;
                        era:rinfIndex "1.1.1.3.7.8" ;
-                       era:unitOfMeasure qudt:MilliM ;
+                       era:unitOfMeasure unit:MilliM ;
                        dcterms:created "2021-08-08"^^xsd:date ;
                        dcterms:modified "2021-09-01"^^xsd:date ;
                        rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
-                       skos:scopeNote "Minimum permitted flange thickness, given in millimiters."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Minimum permitted thickness of the flange"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" ;
+                       skos:scopeNote "Minimum permitted flange thickness, given in millimiters."@en .
 
 
 ###  http://data.europa.eu/949/minRimWidth
@@ -6096,13 +6151,13 @@ era:minRimWidth rdf:type owl:DatatypeProperty ;
                 era:XMLName "CTD_MinRimWidth" ;
                 era:eratvIndex "4.14.2.5" ;
                 era:rinfIndex "1.1.1.3.7.6" ;
-                era:unitOfMeasure qudt:MilliM ;
+                era:unitOfMeasure unit:MilliM ;
                 dcterms:created "2021-08-08"^^xsd:date ;
                 dcterms:modified "2023-03-14"^^xsd:date ;
                 rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Minimum permitted width of the rim"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/minVehicleInputCapacitance
@@ -6119,7 +6174,7 @@ era:minVehicleInputCapacitance rdf:type owl:DatatypeProperty ;
                                rdfs:comment "For the selected DC voltage: [CCCC], as input capacitance [CCCC](Cin)"@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "minimal vehicle input capacitance"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                               vs:term_status "stable" ;
                                skos:scopeNote "The minVehicleInputCapacitance parameter is applicable for track circuits."@en .
 
 
@@ -6137,7 +6192,7 @@ era:minVehicleInputImpedance rdf:type owl:DatatypeProperty ;
                              rdfs:comment "For the selected DC voltage: [ZZZZ], as input impedance [ZZZZ](Zin)"@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "minimal vehicle input impedance"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                             vs:term_status "stable" ;
                              skos:scopeNote "The minVehicleInputImpedance parameter is applicable for track circuits."@en .
 
 
@@ -6152,14 +6207,14 @@ era:minWheelDiameter rdf:type owl:DatatypeProperty ;
                      era:XMLName "CTD_MinWheelDiameter" ;
                      era:eratvIndex "4.14.2.6" ;
                      era:rinfIndex "1.1.1.3.7.7" ;
-                     era:unitOfMeasure qudt:MilliM ;
+                     era:unitOfMeasure unit:MilliM ;
                      dcterms:created "2021-08-08"^^xsd:date ;
                      dcterms:modified "2023-03-14"^^xsd:date ;
                      rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
-                     skos:scopeNote "Minimum permitted wheel diameter, given in millimiters."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Minimum permitted wheel diameter"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" ;
+                     skos:scopeNote "Minimum permitted wheel diameter, given in millimiters."@en .
 
 
 ###  http://data.europa.eu/949/minimumConcaveVerticalRadius
@@ -6172,7 +6227,7 @@ era:minimumConcaveVerticalRadius rdf:type owl:DatatypeProperty ;
                                  rdfs:comment "Minimum vertical concave curve radius capability."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Minimum concave vertical radius"@en ;
-                                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/minimumContactWireHeight
@@ -6186,14 +6241,14 @@ era:minimumContactWireHeight rdf:type owl:DatatypeProperty ;
                              era:XMLName "ECS_MinWireHeight" ;
                              era:eratvIndex "4.10.5" ;
                              era:rinfIndex "1.1.1.2.2.6" ;
-                             era:unitOfMeasure qudt:M ;
+                             era:unitOfMeasure unit:M ;
                              era:usedInRCCCalculations "true"^^xsd:boolean ;
                              dcterms:created "2020-08-25"^^xsd:date ;
                              dcterms:modified "2021-09-11"^^xsd:date ;
                              rdfs:comment "Indication of the minimum contact wire height expressed in metres."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Minimum contact wire height"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/minimumConvexVerticalRadius
@@ -6206,7 +6261,7 @@ era:minimumConvexVerticalRadius rdf:type owl:DatatypeProperty ;
                                 rdfs:comment "Minimum vertical convex curve radius capability."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Minimum convex vertical radius"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/minimumHorizontalRadius
@@ -6221,14 +6276,14 @@ era:minimumHorizontalRadius rdf:type owl:DatatypeProperty ;
                             era:eratvIndex "4.8.4" ;
                             era:rinfIndex "1.1.1.1.3.7" ,
                                           "1.2.2.0.3.2" ;
-                            era:unitOfMeasure qudt:M ;
+                            era:unitOfMeasure unit:M ;
                             era:usedInRCCCalculations "true"^^xsd:boolean ;
                             dcterms:created "2020-08-24"^^xsd:date ;
                             dcterms:modified "2021-09-10"^^xsd:date ;
                             rdfs:comment "Radius of the smallest horizontal curve of the track in metres."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Minimum radius of horizontal curve"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/minimumTemperature
@@ -6244,7 +6299,7 @@ era:minimumTemperature rdf:type owl:DatatypeProperty ;
                        rdfs:comment "Minimum temperature allowed for unrestricted operation access, according to European standard."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Temperature range (minimum)"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/minimumVerticalRadius
@@ -6253,17 +6308,17 @@ era:minimumVerticalRadius rdf:type owl:DatatypeProperty ;
                           rdfs:range xsd:string ;
                           era:XMLName "ILL_MinRadVertCurve" ;
                           era:rinfIndex "1.2.2.0.3.3" ;
-                          era:unitOfMeasure qudt:M ;
+                          era:unitOfMeasure unit:M ;
                           dcterms:created "2020-08-24"^^xsd:date ;
                           dcterms:isReplacedBy era:minimumVerticalRadiusCrest ,
                                                era:minimumVerticalRadiusHollow ;
                           dcterms:modified "2023-04-05"^^xsd:date ;
-                          rdfs:comment """Radius of the smallest vertical curve expressed in metres."""@en ; 
-                          skos:editorialNote """Deprecated because of replacement by  two integer properties The reason is that the property is composed of two values: The first \"NNN\" is a value of crest, the second \"NNN\" is a value of hollow, both expressed in metres."""@en ;
+                          rdfs:comment "Radius of the smallest vertical curve expressed in metres."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Minimum radius of vertical curve"@en ;
                           owl:deprecated "true"^^xsd:boolean ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" ;
+                          skos:editorialNote "Deprecated because of replacement by  two integer properties The reason is that the property is composed of two values: The first \"NNN\" is a value of crest, the second \"NNN\" is a value of hollow, both expressed in metres."@en .
 
 
 ###  http://data.europa.eu/949/minimumVerticalRadiusCrest
@@ -6272,14 +6327,14 @@ era:minimumVerticalRadiusCrest rdf:type owl:DatatypeProperty ;
                                rdfs:range xsd:integer ;
                                era:XMLName "ILL_MinRadVertCurve" ;
                                era:rinfIndex "1.2.2.0.3.3" ;
-                               era:unitOfMeasure qudt:M ;
+                               era:unitOfMeasure unit:M ;
                                era:usedInRCCCalculations "true"^^xsd:boolean ;
                                dcterms:created "2023-04-05"^^xsd:date ;
-                               rdfs:comment """Part of the minimum radius of vertical curve that indicates the crest"""@en ;  
-                               skos:scopeNote """ The minimum radius of vertical curve is the radius of the smallest vertical curve expressed in metres."""@en ;
+                               rdfs:comment "Part of the minimum radius of vertical curve that indicates the crest"@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Minimum radius of vertical curve crest"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" ;
+                               skos:scopeNote " The minimum radius of vertical curve is the radius of the smallest vertical curve expressed in metres."@en .
 
 
 ###  http://data.europa.eu/949/minimumVerticalRadiusHollow
@@ -6288,14 +6343,14 @@ era:minimumVerticalRadiusHollow rdf:type owl:DatatypeProperty ;
                                 rdfs:range xsd:integer ;
                                 era:XMLName "ILL_MinRadVertCurve" ;
                                 era:rinfIndex "1.2.2.0.3.3" ;
-                                era:unitOfMeasure qudt:M ;
+                                era:unitOfMeasure unit:M ;
                                 era:usedInRCCCalculations "true"^^xsd:boolean ;
                                 dcterms:created "2023-04-05"^^xsd:date ;
-                                rdfs:comment """Part of the minimum radius of vertical curve that indicates the hollow"""@en ;  
-                                skos:scopeNote """The minimum radius of vertical curve is the radius of the smallest vertical curve expressed in metres."""@en ;
+                                rdfs:comment "Part of the minimum radius of vertical curve that indicates the hollow"@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Minimum radius of vertical curve hollow"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" ;
+                                skos:scopeNote "The minimum radius of vertical curve is the radius of the smallest vertical curve expressed in metres."@en .
 
 
 ###  http://data.europa.eu/949/minimumWheelDiameter
@@ -6309,14 +6364,14 @@ era:minimumWheelDiameter rdf:type owl:DatatypeProperty ;
                          era:XMLName "ISC_MinWheelDiaFixObtuseCrossings" ;
                          era:eratvIndex "4.8.2" ;
                          era:rinfIndex "1.1.1.1.5.2" ;
-                         era:unitOfMeasure qudt:MilliM ;
+                         era:unitOfMeasure unit:MilliM ;
                          era:usedInRCCCalculations "true"^^xsd:boolean ;
                          dcterms:created "2020-08-24"^^xsd:date ;
                          dcterms:modified "2021-09-10"^^xsd:date ;
                          rdfs:comment "Maximum unguided length of fixed obtuse crossings is based on a minimum wheel diameter in service expressed in millimetres."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Minimum wheel diameter for fixed obtuse crossings"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/multipleTrainProtectionRequired
@@ -6330,7 +6385,7 @@ era:multipleTrainProtectionRequired rdf:type owl:DatatypeProperty ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "Need for more than one train protection, control and warning system required on board"@en ;
                                     owl:deprecated "true"^^xsd:boolean ;
-                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                                    vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/nationalLineId
@@ -6353,7 +6408,7 @@ era:nationalLoadCapability rdf:type owl:DatatypeProperty ;
                            rdfs:comment "National classification for load capability."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "National classification for load capability"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/nationalRollingStockFireCategory
@@ -6370,7 +6425,7 @@ era:nationalRollingStockFireCategory rdf:type owl:DatatypeProperty ;
                                      rdfs:comment "Categorisation how a passenger train with a fire on board will continue to operate for a defined time period - according to national rules if they exist."@en ;
                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                      rdfs:label "National fire category of rolling stock required"@en ;
-                                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/nationalValuesBrakeModel
@@ -6389,7 +6444,7 @@ era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty ,
 It copies the content of Packet 3 or of Packet 203 as defined in the specification referenced in TSI CCS (Annex I, Appendix A, Table A.2 -Subset-026)."""@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "National Values used for the brake model"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                             vs:term_status "stable" ;
                              skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -6402,7 +6457,7 @@ era:nonCodedRestrictions rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Denotes a non coded restrictions for this particular vehicleType, as a set of sentences."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Non coded restrictions"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/numberElementsRakeFreightWagons
@@ -6415,7 +6470,7 @@ era:numberElementsRakeFreightWagons rdf:type owl:DatatypeProperty ;
                                     rdfs:comment "Number of elements in the rake of freight wagons (only for subcategory 'rake of freight wagons')"@en ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "Number elements rake freight wagons"@en ;
-                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/numberOfPantographsInContactWithOCL
@@ -6428,7 +6483,7 @@ era:numberOfPantographsInContactWithOCL rdf:type owl:DatatypeProperty ;
                                         rdfs:comment "Number of pantographs in contact with the overhead contact line (OCL) (to be indicated for each energy supply system the vehicle is equipped for)."@en ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "Number of pantographs in contact with OCL"@en ;
-                                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/numberOfToilets
@@ -6441,7 +6496,7 @@ era:numberOfToilets rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Number of toilets."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Number of toilets"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/oclType
@@ -6454,7 +6509,7 @@ era:oclType rdf:type owl:DatatypeProperty ;
             rdfs:comment "OCL type."@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             rdfs:label "Ocl type"@en ;
-            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/offset
@@ -6479,7 +6534,7 @@ era:opName rdf:type owl:DatatypeProperty ;
            rdfs:comment "Name normally related to the town or village or to traffic control purpose."@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "Name of operational point"@en ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/opTypeGaugeChangeover
@@ -6494,7 +6549,7 @@ era:opTypeGaugeChangeover rdf:type owl:DatatypeProperty ;
                           rdfs:comment "Type of track gauge changeover facility."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Type of track gauge changeover facility"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/organisationCode
@@ -6517,7 +6572,7 @@ era:parkingBrake rdf:type owl:DatatypeProperty ;
                  rdfs:comment "Indicates whether all vehicles of this type must be equipped with a parking brake."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Parking brake"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/parkingBrakeMandatory
@@ -6530,7 +6585,7 @@ era:parkingBrakeMandatory rdf:type owl:DatatypeProperty ;
                           rdfs:comment "All vehicles of this type must be equipped with a parking brake (parking brake mandatory for vehicles of this type)."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Parking brake mandatory"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/parkingBrakeMaximumGradient
@@ -6543,7 +6598,7 @@ era:parkingBrakeMaximumGradient rdf:type owl:DatatypeProperty ;
                                 rdfs:comment "Maximum gradient on which the unit is kept immobilised by the parking brake alone (if the vehicle is fitted with it)."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Parking brake maximum gradient"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/passByNoiseLevel
@@ -6556,7 +6611,7 @@ era:passByNoiseLevel rdf:type owl:DatatypeProperty ;
                      rdfs:comment "Pass-by noise level given in dB(A)."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Pass-by noise level"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/permissiblePayload
@@ -6569,7 +6624,7 @@ era:permissiblePayload rdf:type owl:DatatypeProperty ;
                        rdfs:comment "Permissible payload for different line categories."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Permissible payload"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/permissionChargingElectricEnergyTractionStandstill
@@ -6581,7 +6636,7 @@ era:permissionChargingElectricEnergyTractionStandstill rdf:type owl:DatatypeProp
                                                        rdfs:comment "Point at which IM authorises charging of electric energy storage for traction purposes at standstill."@en ;
                                                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                                        rdfs:label "Permission for charging electric energy storage for traction purposes at standstill"@en ;
-                                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/permitUseReflectivePlates
@@ -6593,7 +6648,7 @@ era:permitUseReflectivePlates rdf:type owl:DatatypeProperty ;
                               rdfs:comment "Sections where is permitted to use the reflective plates on rail freight corridors, with a view to prioritise the current bottlenecks. Specific case for Belgium, France, Italy, Portugal and Spain until 1.1.2026."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "Permit of use of reflective plates"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/permittedContactForce
@@ -6602,14 +6657,14 @@ era:permittedContactForce rdf:type owl:DatatypeProperty ;
                           rdfs:range xsd:string ;
                           era:XMLName "ERS_ContactForce" ;
                           era:rinfIndex "1.1.1.2.5.2" ;
-                          era:unitOfMeasure qudt:N ;
+                          era:unitOfMeasure unit:N ;
                           era:usedInRCCCalculations "true"^^xsd:boolean ;
                           dcterms:created "2020-08-25"^^xsd:date ;
                           dcterms:modified "2024-01-08"^^xsd:date ;
                           rdfs:comment "Indication of contact force allowed expressed in newton."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Contact force permitted"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/phaseInfo
@@ -6626,13 +6681,13 @@ era:phaseInfo rdf:type owl:DatatypeProperty ;
                                    "http://data.europa.eu/949/phaseInfoKm" ,
                                    "http://data.europa.eu/949/trackPhaseInfo" ;
               dcterms:modified "2023-04-05"^^xsd:date ;
-              rdfs:comment """Indication of required several information on phase separation"""@en ;  
-              skos:editorialNote """ Deprecated because of replacement by three properties. The reason is that the property is composed of three values: length [NNN] - the length of the phase separation in metres; switch off breaker [Y/N], single selection of 'yes' or 'no' to show whether the breaker has to be switched off; and lower pantograph [Y/N], single selection of 'yes' or 'no' to show whether the pantograph has to be lowered,  
-			             Km [NNN.NNN] - the location from the start of the line where the new value is valid."""@en ;
+              rdfs:comment "Indication of required several information on phase separation"@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "Information on phase separation"@en ;
               owl:deprecated "true"^^xsd:boolean ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+              vs:term_status "stable" ;
+              skos:editorialNote """ Deprecated because of replacement by three properties. The reason is that the property is composed of three values: length [NNN] - the length of the phase separation in metres; switch off breaker [Y/N], single selection of 'yes' or 'no' to show whether the breaker has to be switched off; and lower pantograph [Y/N], single selection of 'yes' or 'no' to show whether the pantograph has to be lowered,  
+			             Km [NNN.NNN] - the location from the start of the line where the new value is valid."""@en .
 
 
 ###  http://data.europa.eu/949/phaseInfoChangeSupplySystem
@@ -6642,10 +6697,10 @@ era:phaseInfoChangeSupplySystem rdf:type owl:DatatypeProperty ;
                                 era:XMLName "EOS_InfoPhase" ;
                                 era:rinfIndex "1.1.1.2.4.1.2" ;
                                 dcterms:created "2024-02-05"^^xsd:date ;
-                                rdfs:comment """Part of the phase info of a track that corresponds to the single selection of Y=yes or N=no to show if the energy supply system changes"""@en ; 
-                                skos:scopeNote """ The phase info is the indication of required several information on phase separation."""@en ;
+                                rdfs:comment "Part of the phase info of a track that corresponds to the single selection of Y=yes or N=no to show if the energy supply system changes"@en ;
                                 rdfs:label "Phase info change supply system"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" ;
+                                skos:scopeNote " The phase info is the indication of required several information on phase separation."@en .
 
 
 ###  http://data.europa.eu/949/phaseInfoDistanceType
@@ -6655,11 +6710,11 @@ era:phaseInfoDistanceType rdf:type owl:DatatypeProperty ;
                           era:XMLName "EOS_InfoPhase" ;
                           era:rinfIndex "1.1.1.2.4.1.2" ;
                           dcterms:created "2024-02-05"^^xsd:date ;
-                          rdfs:comment """Part of the phase info of a track that corresponds to the single selection of 'MIN=minimum' or 'MAX=maximum' to show whether the length is a minimum distance between the inner contact strips of the pantographs or a maximum distance between the outer contact strips of the pantographs. Multiple strings for this parameter are accepted."""@en ; 
-                          skos:scopeNote """ The phase info is the indication of required several information on phase separation."""@en ;
+                          rdfs:comment "Part of the phase info of a track that corresponds to the single selection of 'MIN=minimum' or 'MAX=maximum' to show whether the length is a minimum distance between the inner contact strips of the pantographs or a maximum distance between the outer contact strips of the pantographs. Multiple strings for this parameter are accepted."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Phase info distance type"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" ;
+                          skos:scopeNote " The phase info is the indication of required several information on phase separation."@en .
 
 
 ###  http://data.europa.eu/949/phaseInfoKm
@@ -6669,11 +6724,11 @@ era:phaseInfoKm rdf:type owl:DatatypeProperty ;
                 era:XMLName "EOS_InfoPhase" ;
                 era:rinfIndex "1.1.1.2.4.1.2" ;
                 dcterms:creator "2023-04-05"^^xsd:date ;
-                rdfs:comment """Part of the phase info of a track that indicates the location from the start of the line where the new value is valid."""@en ; 
-                skos:scopeNote """ The phase info is the indication of required several information on phase separation."""@en ;
+                rdfs:comment "Part of the phase info of a track that indicates the location from the start of the line where the new value is valid."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Phase info Km"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" ;
+                skos:scopeNote " The phase info is the indication of required several information on phase separation."@en .
 
 
 ###  http://data.europa.eu/949/phaseInfoLength
@@ -6684,11 +6739,11 @@ era:phaseInfoLength rdf:type owl:DatatypeProperty ;
                     era:rinfIndex "1.1.1.2.4.1.2" ;
                     era:unitOfMeasure <https://qudt.org/vocab/unit/M> ;
                     dcterms:created "2023-04-05"^^xsd:date ;
-                    rdfs:comment """Part of the phase info of a track that corresponds to the length of the phase separation in metres."""@en ;  
-                    skos:scopeNote """The phase info is the indication of required several information on phase separation."""@en ;
+                    rdfs:comment "Part of the phase info of a track that corresponds to the length of the phase separation in metres."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Phase info length"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" ;
+                    skos:scopeNote "The phase info is the indication of required several information on phase separation."@en .
 
 
 ###  http://data.europa.eu/949/phaseInfoPantographLowered
@@ -6698,11 +6753,11 @@ era:phaseInfoPantographLowered rdf:type owl:DatatypeProperty ;
                                era:XMLName "EOS_InfoPhase" ;
                                era:rinfIndex "1.1.1.2.4.1.2" ;
                                dcterms:created "2023-04-05"^^xsd:date ;
-                               rdfs:comment """Part of the phase info of a track that shows whether a pantograph has to be lowered."""@en ; 
-                               skos:scopeNote """ The phase info is the indication of required several information on phase separation."""@en ;
+                               rdfs:comment "Part of the phase info of a track that shows whether a pantograph has to be lowered."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Phase info pantograph lowered"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" ;
+                               skos:scopeNote " The phase info is the indication of required several information on phase separation."@en .
 
 
 ###  http://data.europa.eu/949/phaseInfoSwitchOffBreaker
@@ -6712,11 +6767,11 @@ era:phaseInfoSwitchOffBreaker rdf:type owl:DatatypeProperty ;
                               era:XMLName "EOS_InfoPhase" ;
                               era:rinfIndex "1.1.1.2.4.1.2" ;
                               dcterms:created "2023-04-05"^^xsd:date ;
-                              rdfs:comment """Part of the phase info of a track that shows whether the breaker has to be switched off."""@en ; 
-                              skos:scopeNote """ The phase info is the indication of required several information on phase separation."""@en ;
+                              rdfs:comment "Part of the phase info of a track that shows whether the breaker has to be switched off."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "Phase info switch off breaker"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" ;
+                              skos:scopeNote " The phase info is the indication of required several information on phase separation."@en .
 
 
 ###  http://data.europa.eu/949/phaseSeparation
@@ -6730,7 +6785,7 @@ era:phaseSeparation rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Indication of existence of phase separation and required information."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Phase separation"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/platformId
@@ -6746,7 +6801,7 @@ era:platformId rdf:type owl:DatatypeProperty ;
                rdfs:comment "Unique platform identification or platform number within an Operational Point."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "Identification of platform"@en ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/portableBoardingAids
@@ -6759,7 +6814,7 @@ era:portableBoardingAids rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Description of any portable boarding aids if considered in the design of the vehicle for meeting the PRM TSI requirements."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Portable boarding aids"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/preventRegenerativeBrakeUse
@@ -6772,7 +6827,7 @@ era:preventRegenerativeBrakeUse rdf:type owl:DatatypeProperty ;
                                 rdfs:comment "Possibility of preventing the use of the regenerative brake (only if fitted with regenerative brake)."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Prevent regenerative brake use"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/primaryLocationCode
@@ -6784,11 +6839,11 @@ era:primaryLocationCode rdf:type owl:DatatypeProperty ;
                         era:appendixD2Index "2.2.2" ;
                         era:rinfIndex "1.2.0.0.0.3" ;
                         dcterms:created "2024-06-03"^^xsd:date ;
+                        dcterms:replaces era:tafTAPCode ;
                         rdfs:comment "Primary location code developed for information exchange in accordance with the TSIs relating to the telematics applications subsystem."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "primary location code"@en ;
-                        dcterms:replaces era:tafTAPCode ; 
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/primaryLocationName
@@ -6809,7 +6864,7 @@ era:prioritySeats rdf:type owl:DatatypeProperty ;
                   rdfs:comment "Number of priority seats."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Priority seats"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/prmAccessibleToilets
@@ -6822,7 +6877,7 @@ era:prmAccessibleToilets rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Number of PRM accessible toilets."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Prm accessible toilets"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/publicNetworkRoaming
@@ -6840,7 +6895,7 @@ era:publicNetworkRoaming rdf:type owl:DatatypeProperty ,
 In case of Y, provide the name of the public network(s) under parameter \"Details on GSM-R roaming to public networks\"."""@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Existence of GSM-R roaming to public networks"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                         vs:term_status "stable" ;
                          skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -6862,7 +6917,7 @@ era:publicNetworkRoamingDetails rdf:type owl:DatatypeProperty ,
 3. also add if there is any operational restriction for vehicles that cannot roam into any of the available public networks."""@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Details on GSM-R roaming to public networks"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                vs:term_status "stable" ;
                                 skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -6883,7 +6938,7 @@ See: TSI CCS (Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES)"""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Q_NVDRIVER_ADHES"@en ;
                    rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                   vs:term_status "stable" ;
                    skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -6905,7 +6960,7 @@ See: TSI CCS (Subset-026, chapter 7. 7.5.1.124 Q_NVSBTSMPERM)"""@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Q_NVSBTSMPERM"@en ;
                  rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                 vs:term_status "stable" ;
                  skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -6919,7 +6974,7 @@ era:quasiStaticGuidingForce rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Quasi-static guiding force (if exceeds the limit defined in TSI or not defined in the TSI), given in kN."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Quasi static guiding force"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/radioNetworkId
@@ -6938,7 +6993,7 @@ era:radioNetworkId rdf:type owl:DatatypeProperty ;
 Format: [NNNNNN] with N a decimal number (0÷9)(sh:minCount 1)."""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Radio Network ID"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                   vs:term_status "stable" ;
                    skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -6952,7 +7007,7 @@ era:radioSwitchOverSpecialConditions rdf:type owl:DatatypeProperty ;
                                      rdfs:comment "Special conditions implemented on-board to switch over between different radio systems. Given as combination of systems installed on board ('System XX'_'System YY')."@en ;
                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                      rdfs:label "Radio switch over special conditions"@en ;
-                                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/railSystemType
@@ -6965,7 +7020,7 @@ era:railSystemType rdf:type owl:DatatypeProperty ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Rail system type"@en ;
                    owl:deprecated "true"^^xsd:boolean ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/raisedPantographsDistance
@@ -6974,14 +7029,14 @@ era:raisedPantographsDistance rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:integer ;
                               era:XMLName "EPA_NumRaisedSpeed" ;
                               era:rinfIndex "1.1.1.2.3.3" ;
-                              era:unitOfMeasure qudt:M ;
+                              era:unitOfMeasure unit:M ;
                               era:usedInRCCCalculations "true"^^xsd:boolean ;
                               dcterms:created "2023-04-05"^^xsd:date ;
-                              rdfs:comment """Part of the raised pantographs dustance and speed of a track that corresponds to the minimum distance between pantographs, in metres."""@en ; 
-                              skos:scopeNote """ The raised pantographs distance and speed is  the indication of maximum number of raised pantographs per train allowed and minimum spacing centre line to centre line of adjacent pantograph heads, expressed in metres, at the given speed."""@en ;
+                              rdfs:comment "Part of the raised pantographs dustance and speed of a track that corresponds to the minimum distance between pantographs, in metres."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "Raised pantographs distance"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" ;
+                              skos:scopeNote " The raised pantographs distance and speed is  the indication of maximum number of raised pantographs per train allowed and minimum spacing centre line to centre line of adjacent pantograph heads, expressed in metres, at the given speed."@en .
 
 
 ###  http://data.europa.eu/949/raisedPantographsDistanceAndSpeed
@@ -6994,12 +7049,12 @@ era:raisedPantographsDistanceAndSpeed rdf:type owl:DatatypeProperty ;
                                       dcterms:created "2020-08-25"^^xsd:date ;
                                       dcterms:modified "2023-04-05"^^xsd:date ;
                                       dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
-                                      rdfs:comment """Indication of maximum number of raised pantographs per train allowed and minimum spacing centre line to centre line of adjacent pantograph heads, expressed in metres, at the given speed."""@en ; 
-                                      skos:editorialNote """ Deprecated because of replacement by a class and three integer properties The reason is that the property is composed of three values: [N] is number of pantographs; [NNN] is minimum distance between pantographs, in metres; [NNN] is the speed considered in km/h."""@en ;
+                                      rdfs:comment "Indication of maximum number of raised pantographs per train allowed and minimum spacing centre line to centre line of adjacent pantograph heads, expressed in metres, at the given speed."@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "raised pantographs and spacing between them, at the given speed"@en ;
                                       owl:deprecated "true"^^xsd:boolean ;
-                                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                      vs:term_status "stable" ;
+                                      skos:editorialNote " Deprecated because of replacement by a class and three integer properties The reason is that the property is composed of three values: [N] is number of pantographs; [NNN] is minimum distance between pantographs, in metres; [NNN] is the speed considered in km/h."@en .
 
 
 ###  http://data.europa.eu/949/raisedPantographsNumber
@@ -7010,11 +7065,11 @@ era:raisedPantographsNumber rdf:type owl:DatatypeProperty ;
                             era:rinfIndex "1.1.1.2.3.3" ;
                             era:usedInRCCCalculations "true"^^xsd:boolean ;
                             dcterms:created "2023-04-05"^^xsd:date ;
-                            rdfs:comment """Part of the raised pantographs distance and speed of a track that corresponds to the number of pantographs."""@en ;  
-                            skos:scopeNote """ The raised pantographs distance and speed is  the indication of maximum number of raised pantographs per train allowed and minimum spacing centre line to centre line of adjacent pantograph heads, expressed in metres, at the given speed."""@en ;
+                            rdfs:comment "Part of the raised pantographs distance and speed of a track that corresponds to the number of pantographs."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Number of pantographs."@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" ;
+                            skos:scopeNote " The raised pantographs distance and speed is  the indication of maximum number of raised pantographs per train allowed and minimum spacing centre line to centre line of adjacent pantograph heads, expressed in metres, at the given speed."@en .
 
 
 ###  http://data.europa.eu/949/raisedPantographsSpeed
@@ -7026,11 +7081,11 @@ era:raisedPantographsSpeed rdf:type owl:DatatypeProperty ;
                            era:unitOfMeasure <https://qudt.org/vocab/unit/KiloM-PER-HR> ;
                            era:usedInRCCCalculations "true"^^xsd:boolean ;
                            dcterms:created "2023-04-05"^^xsd:date ;
-                           rdfs:comment """Part of the raised pantographs distance and speed of a track that corresponds to the speed considered in km/h."""@en ;  
-                           skos:scopeNote """ The raised pantographs distance and speed is  the indication of maximum number of raised pantographs per train allowed and minimum spacing centre line to centre line of adjacent pantograph heads, expressed in metres, at the given speed"""@en ;
+                           rdfs:comment "Part of the raised pantographs distance and speed of a track that corresponds to the speed considered in km/h."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Raised pantographs speed"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" ;
+                           skos:scopeNote " The raised pantographs distance and speed is  the indication of maximum number of raised pantographs per train allowed and minimum spacing centre line to centre line of adjacent pantograph heads, expressed in metres, at the given speed"@en .
 
 
 ###  http://data.europa.eu/949/rbcID
@@ -7049,7 +7104,7 @@ era:rbcID rdf:type owl:DatatypeProperty ,
 Format: [NNNN NNNN] with N a decimal number (0÷9)"""@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "ERTMS/ETCS Radio Block Center (RBC) identifier"@en ;
-          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+          vs:term_status "stable" ;
           skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -7069,7 +7124,7 @@ era:rbcPhone rdf:type owl:DatatypeProperty ,
 Format: [NNNN NNNN NNNN NNNN] with N a decimal number (0÷9)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "ERTMS/ETCS Radio Block Center (RBC) phone number"@en ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+             vs:term_status "stable" ;
              skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -7084,7 +7139,7 @@ era:redLightsRequired rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Sections where two steady red lights are required in accordance with TSI OPE."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Steady red lights required"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/referencePassByNoiseLevel
@@ -7097,7 +7152,7 @@ era:referencePassByNoiseLevel rdf:type owl:DatatypeProperty ;
                               rdfs:comment "Pass-by noise level was measured under reference conditions."@en ;
                               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                               rdfs:label "Reference pass-by noise level"@en ;
-                              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/relativeDistanceDangerPoint
@@ -7114,7 +7169,7 @@ era:relativeDistanceDangerPoint rdf:type owl:DatatypeProperty ;
                                 rdfs:comment "Distance in meters to the danger point."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Relative distance of the danger point"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/relativePosition
@@ -7122,12 +7177,12 @@ era:relativePosition rdf:type owl:DatatypeProperty ;
                      rdfs:range xsd:double ;
                      dcterms:created "2021-04-01"^^xsd:date ;
                      dcterms:modified "2023-11-10"^^xsd:date ;
-                     rdfs:comment """Indicates the position of an object relative to the linear coordinates of the associated topological object."""@en ; 
-                     skos:editorialNote """ The reason for deprecation is that this property is not specified in the latest legal text nor the RINF application guide. Also, no data has been provided for this property."""@en ;
+                     rdfs:comment "Indicates the position of an object relative to the linear coordinates of the associated topological object."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Relative position"@en ;
                      owl:deprecated "true"^^xsd:boolean ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" ;
+                     skos:editorialNote " The reason for deprecation is that this property is not specified in the latest legal text nor the RINF application guide. Also, no data has been provided for this property."@en .
 
 
 ###  http://data.europa.eu/949/requiredSandingOverride
@@ -7144,7 +7199,7 @@ era:requiredSandingOverride rdf:type owl:DatatypeProperty ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Sanding override by driver required"@en ;
                             owl:deprecated "true"^^xsd:boolean ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/schematicOverviewOP
@@ -7156,7 +7211,7 @@ era:schematicOverviewOP rdf:type owl:DatatypeProperty ;
                         rdfs:comment "Document providing the schematic overview of the  operational point."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Schematic overview of the operational point"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/shortestDistanceBetweenPantographsInContactWithOCL
@@ -7169,7 +7224,7 @@ era:shortestDistanceBetweenPantographsInContactWithOCL rdf:type owl:DatatypeProp
                                                        rdfs:comment "Shortest distance between two pantographs in contact with the OCL (to be indicated for each energy supply system the vehicle is equipped for; to be indicated for single and, if applicable, multiple operation) (only if number of raised pantographs is more than 1)."@en ;
                                                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                                        rdfs:label "Shortest distance between pantographs in contact with OCL"@en ;
-                                                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/sidingId
@@ -7187,7 +7242,7 @@ era:sidingId rdf:type owl:DatatypeProperty ;
              rdfs:comment "Unique siding identification or number within an Operational Point."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "Identification of siding"@en ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/signalId
@@ -7205,7 +7260,7 @@ era:signalId rdf:type owl:DatatypeProperty ;
              rdfs:comment "Operational identifier of the signal (on the track or in OP), as in the operational and maintenance provisions."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "Name of signal"@en ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/sleepingPlaces
@@ -7218,7 +7273,7 @@ era:sleepingPlaces rdf:type owl:DatatypeProperty ;
                    rdfs:comment "Number of sleeping places."@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Sleeping places"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/specificInformation
@@ -7232,7 +7287,7 @@ era:specificInformation rdf:type owl:DatatypeProperty ;
                         rdfs:comment "Any relevant information from the IM relating to the line layout."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Specific information"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/startIntrinsicCoordinate
@@ -7244,7 +7299,7 @@ era:startIntrinsicCoordinate rdf:type owl:DatatypeProperty ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Start intrinsic coordinate"@en ;
                              owl:deprecated "true"^^xsd:boolean ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/startingNoiseLevel
@@ -7257,7 +7312,7 @@ era:startingNoiseLevel rdf:type owl:DatatypeProperty ;
                        rdfs:comment "starting noise level given in dB(A)."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Starting noise level"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/staticAxleLoadExceptionalPayload
@@ -7270,7 +7325,7 @@ era:staticAxleLoadExceptionalPayload rdf:type owl:DatatypeProperty ;
                                      rdfs:comment "Static axle load under exceptional payload."@en ;
                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                      rdfs:label "Static axle load under exceptional payload"@en ;
-                                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/staticAxleLoadNormalPayload
@@ -7283,7 +7338,7 @@ era:staticAxleLoadNormalPayload rdf:type owl:DatatypeProperty ;
                                 rdfs:comment "Static axle load under normal payload."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Static axle load under normal payload"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/staticAxleLoadWorkingOrder
@@ -7296,7 +7351,7 @@ era:staticAxleLoadWorkingOrder rdf:type owl:DatatypeProperty ;
                                rdfs:comment "Static axle load in working order."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Static axle load in working order"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/stationaryNoiseLevel
@@ -7309,7 +7364,7 @@ era:stationaryNoiseLevel rdf:type owl:DatatypeProperty ;
                          rdfs:comment "stationary noise level given in dB(A)."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Stationary noise level"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/structuralCategory
@@ -7322,7 +7377,7 @@ era:structuralCategory rdf:type owl:DatatypeProperty ;
                        rdfs:comment "Structural category."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Structural category"@en ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/structureCheckLocation
@@ -7337,7 +7392,7 @@ era:structureCheckLocation rdf:type owl:DatatypeProperty ;
                            rdfs:comment "Localisation of structures requiring specific checks."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Railway location of structures requiring specific checks"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/subsetName
@@ -7348,7 +7403,7 @@ era:subsetName rdf:type owl:DatatypeProperty ;
                rdfs:comment "A subset of common characteristics is identified with a unique name/id, for example \"ETCSbaseline2\" which will describe all ETCS National values (1.1.1.3.2.16 group) and it will be the same for a part of the network (set of tracks)."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "Name of a subset with common characteristics"@en ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/subsidiaryLocationCode
@@ -7381,7 +7436,7 @@ era:switchProtectControlWarning rdf:type owl:DatatypeProperty ;
                                 rdfs:comment "Indication whether a switch over between different systems whilst running exists."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                 rdfs:label "Existence of switch over between different protection, control and warning systems while running"@en ;
-                                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/switchRadioSystem
@@ -7397,7 +7452,7 @@ era:switchRadioSystem rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Indication whether a switch over between different radio systems and no communication system whilst running exists."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Existence of switch over between different radio systems"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/systemSeparationInfo
@@ -7419,7 +7474,7 @@ Deprecated because of replacement by four properties. The reason is that the pro
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Information on system separation"@en ;
                          owl:deprecated "true"^^xsd:boolean ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/systemSeparationInfoChangeSupplySystem
@@ -7433,7 +7488,7 @@ era:systemSeparationInfoChangeSupplySystem rdf:type owl:DatatypeProperty ;
 The system separation info is the Indication of required several information on system separation."""@en ;
                                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                            rdfs:label "System separation info change supply system"@en ;
-                                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/systemSeparationInfoKm
@@ -7447,7 +7502,7 @@ era:systemSeparationInfoKm rdf:type owl:DatatypeProperty ;
 The system separation info is the Indication of required several information on system separation."""@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "System separation info Km"@en ;
-                           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/systemSeparationInfoLength
@@ -7462,7 +7517,7 @@ era:systemSeparationInfoLength rdf:type owl:DatatypeProperty ;
 The system separation info is the Indication of required several information on system separation."""@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "System separation info length"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/systemSeparationInfoPantographLowered
@@ -7476,7 +7531,7 @@ era:systemSeparationInfoPantographLowered rdf:type owl:DatatypeProperty ;
 The system separation info is the Indication of required several information on system separation."""@en ;
                                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                           rdfs:label "System separation info  pantograph lowered"@en ;
-                                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/systemSeparationInfoSwitchOffBreaker
@@ -7490,7 +7545,7 @@ era:systemSeparationInfoSwitchOffBreaker rdf:type owl:DatatypeProperty ;
 The system separation info is the Indication of required several information on system separation."""@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "System separation info switch off breaker"@en ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tNvcontact
@@ -7502,7 +7557,7 @@ era:tNvcontact rdf:type owl:DatatypeProperty ,
                era:appendixD3Index "1.5.8" ;
                era:rinfIndex "1.1.1.3.2.16.8" ,
                              "1.2.1.1.1.16.8" ;
-               era:unitOfMeasure qudt:SEC ;
+               era:unitOfMeasure unit:SEC ;
                dcterms:created "2022-11-07"^^xsd:date ;
                dcterms:modified "2023-03-14"^^xsd:date ,
                                 "2024-04-18"^^xsd:date ;
@@ -7515,7 +7570,7 @@ See: TSI CCS (Subset 26, chapter 7. 7.5.1.148 T_NVCONTACT)"""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "T_NVCONTACT"@en ;
                rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+               vs:term_status "stable" ;
                skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -7528,7 +7583,7 @@ era:tNvovtrp rdf:type owl:DatatypeProperty ,
              era:appendixD3Index "1.5.6" ;
              era:rinfIndex "1.1.1.3.2.16.6" ,
                            "1.2.1.1.1.16.6" ;
-             era:unitOfMeasure qudt:SEC ;
+             era:unitOfMeasure unit:SEC ;
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2023-03-14"^^xsd:date ,
                               "2024-04-18"^^xsd:date ;
@@ -7541,7 +7596,7 @@ See: TSI CCS (Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "T_NVOVTRP"@en ;
              rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+             vs:term_status "stable" ;
              skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -7554,14 +7609,14 @@ era:tafTAPCode rdf:type owl:DatatypeProperty ;
                era:appendixD2Index "2.2.2" ;
                era:rinfIndex "1.2.0.0.0.3" ;
                dcterms:created "2020-07-29"^^xsd:date ;
+               dcterms:isReplacedBy era:primaryLocationCode ;
                dcterms:modified "2024-01-08"^^xsd:date ,
                                 "2024-06-03"^^xsd:date ;
                rdfs:comment "Not used anymore. It has been replaced by era:primaryLocationCode."@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "OP primary location code"@en ;
                owl:deprecated "true"^^xsd:boolean ;
-			   dcterms:isReplacedBy era:primaryLocationCode ; 
-               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tenGISId
@@ -7575,7 +7630,7 @@ era:tenGISId rdf:type owl:DatatypeProperty ;
              rdfs:comment "Indication of the GIS identity (GIS ID) of the section of TEN-T database to which the track belongs."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "TEN geographic information system identity (GIS ID)"@en ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/thermalCapacityDistance
@@ -7588,7 +7643,7 @@ era:thermalCapacityDistance rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Thermal capacity distance. If no reference case is indicated."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Thermal capacity distance"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/thermalCapacityGradient
@@ -7601,7 +7656,7 @@ era:thermalCapacityGradient rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Thermal capacity gradient. If no reference case is indicated."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Thermal capacity gradient"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/thermalCapacitySpeed
@@ -7614,7 +7669,7 @@ era:thermalCapacitySpeed rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Thermal capacity speed. If no reference case is indicated."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Thermal capacity speed"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/thermalCapacityTime
@@ -7627,7 +7682,7 @@ era:thermalCapacityTime rdf:type owl:DatatypeProperty ;
                         rdfs:comment "Thermal capacity time. If no reference case is indicated."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Thermal capacity time"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tiltingSupported
@@ -7641,7 +7696,7 @@ era:tiltingSupported rdf:type owl:DatatypeProperty ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Indication whether tilting functions are supported by ETCS"@en ;
                      owl:deprecated "true"^^xsd:boolean ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/totalVehicleMass
@@ -7654,7 +7709,7 @@ era:totalVehicleMass rdf:type owl:DatatypeProperty ;
                      rdfs:comment "Total vehicle mass (for each vehicle of the unit), given in kg."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Total vehicle mass"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trackId
@@ -7673,7 +7728,7 @@ era:trackId rdf:type owl:DatatypeProperty ;
             rdfs:comment "Unique track identification or unique track number within an OP or a section of line."@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             rdfs:label "Identification of track"@en ;
-            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trainControlSwitchOverSpecialConditions
@@ -7686,7 +7741,7 @@ era:trainControlSwitchOverSpecialConditions rdf:type owl:DatatypeProperty ;
                                             rdfs:comment "Special conditions implemented on-board to switch over between different train protection control and warning systems. Given as combination of systems installed on board ('System XX'_'System YY')."@en ;
                                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                             rdfs:label "Train control switch over special conditions"@en ;
-                                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/trainDetectionSystemSpecificCheck
@@ -7706,8 +7761,8 @@ era:trainDetectionSystemSpecificCheck rdf:type owl:DatatypeProperty ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Type of track circuits or axle counters to which specific checks are needed. "@en ;
                                       owl:deprecated "false"^^xsd:boolean ;
-                                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
-                                      skos:scopeNote "String containing the name of the TD system for which checks are mentioned in 1.1.1.3.7.1.3."@en.
+                                      vs:term_status "stable" ;
+                                      skos:scopeNote "String containing the name of the TD system for which checks are mentioned in 1.1.1.3.7.1.3."@en .
 
 
 ###  http://data.europa.eu/949/trainIntegrityOnBoardRequired
@@ -7737,7 +7792,7 @@ era:trainIntegrityOnBoardRequired rdf:type owl:DatatypeProperty ,
                                   rdfs:comment "Indication whether train confirmation from on-board is required to access the line for safety reasons. In hybrid operation, the confirmation can be optional."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Train integrity confirmation from on-board (not from driver) necessary for line access"@en ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                                  vs:term_status "stable" ;
                                   skos:scopeNote "Parameter only applicable when ETCS Baseline > 4 MR1 with operation requiring train integrity."@en .
 
 
@@ -7751,7 +7806,7 @@ era:transportableOnFerry rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Indicates the suitability for transport on ferries."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Transportable on ferry"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiCompliant
@@ -7763,7 +7818,7 @@ era:tsiCompliant rdf:type owl:DatatypeProperty ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Tsi compliant"@en ;
                  owl:deprecated "true"^^xsd:boolean ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiMagneticFields
@@ -7778,7 +7833,7 @@ era:tsiMagneticFields rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Indication whether rules exist and are compliant with the TSI."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Existence and TSI compliance of rules for magnetic fields emitted by a vehicle"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiSwitchCrossing
@@ -7792,7 +7847,7 @@ era:tsiSwitchCrossing rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Switches and crossings are maintained to in service limit dimension as specified in TSI."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "TSI compliance of in service values for switches and crossings"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tsiTractionHarmonics
@@ -7806,7 +7861,7 @@ era:tsiTractionHarmonics rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Indication whether rules exist and are compliant with the TSI."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Existence and TSI compliance of limits in harmonics in the traction current of vehicles"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tunnelIdentification
@@ -7827,7 +7882,7 @@ era:tunnelIdentification rdf:type owl:DatatypeProperty ;
                          rdfs:comment "Unique tunnel identification or unique number within Member State."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Tunnel identification"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tunnelKilometerEnd
@@ -7844,7 +7899,7 @@ The End of tunnel is the Geographical coordinates in decimal degrees and km of t
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "End of tunnel kilometer"@en ;
                        owl:deprecated "true"^^xsd:boolean ;
-                       <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                       vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/tunnelKilometerStart
@@ -7856,12 +7911,12 @@ era:tunnelKilometerStart rdf:type owl:DatatypeProperty ;
                          dcterms:created "2023-03-29"^^xsd:date ;
                          dcterms:isReplacedBy era:lineReferenceTunnelStart ;
                          dcterms:modified "2024-02-05" ;
-                         rdfs:comment """Part of the Start of tunnel that indicates the km of the line at the beginning of a tunnel."""@en ; 
-                         skos:scopeNote """ The Start of tunnel is the Geographical coordinates in decimal degrees and km of the line at the beginning of a tunnel. The reason for deprecation is that the property is now a subproperty of lineReference in order to represent the kilometer in relation to a national railway line"""@en ;
+                         rdfs:comment "Part of the Start of tunnel that indicates the km of the line at the beginning of a tunnel."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Start of tunnel kilometer"@en ;
                          owl:deprecated "true"^^xsd:boolean ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" ;
+                         skos:scopeNote " The Start of tunnel is the Geographical coordinates in decimal degrees and km of the line at the beginning of a tunnel. The reason for deprecation is that the property is now a subproperty of lineReference in order to represent the kilometer in relation to a national railway line"@en .
 
 
 ###  http://data.europa.eu/949/typeVersionNumber
@@ -7873,7 +7928,7 @@ era:typeVersionNumber rdf:type owl:DatatypeProperty ;
                       rdfs:comment "Serial number that identifies a vehicle type."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Type version number"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/umax2
@@ -7882,14 +7937,14 @@ era:umax2 rdf:type owl:DatatypeProperty ;
           rdfs:range xsd:integer ;
           era:XMLName "ECS_Umax2" ;
           era:rinfIndex "1.1.1.2.2.1.3" ;
-          era:unitOfMeasure qudt:V ;
+          era:unitOfMeasure unit:V ;
           era:usedInRCCCalculations "true"^^xsd:boolean ;
           dcterms:created "2020-08-24"^^xsd:date ;
           dcterms:modified "2024-01-08"^^xsd:date ;
           rdfs:comment "Highest non-permanent voltage (Umax2) for France on lines not compliant with values defined in the the specification referenced in Appendix A-2, index [1]."@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "Umax2 for the French network"@en ;
-          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/uopid
@@ -7906,7 +7961,7 @@ era:uopid rdf:type owl:DatatypeProperty ;
           rdfs:comment "Code composed of country code and alphanumeric operational point code."@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "Unique OP ID"@en ;
-          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/usesGroup555
@@ -7926,7 +7981,7 @@ era:usesGroup555 rdf:type owl:DatatypeProperty ,
                  rdfs:comment "Indication if group 555 is used."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "GSM-R use of group 555"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                 vs:term_status "stable" ;
                  skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) and ETCS L2 (parameter 1.1.1.3.2.1) must be installed for this parameter to be applicable."@en .
 
 
@@ -7939,7 +7994,7 @@ era:vNvallowovtrp rdf:type owl:DatatypeProperty ,
                   era:appendixD3Index "1.5.3" ;
                   era:rinfIndex "1.1.1.3.2.16.3" ,
                                 "1.2.1.1.1.16.3" ;
-                  era:unitOfMeasure qudt:KiloM-PER-HR ;
+                  era:unitOfMeasure unit:KiloM-PER-HR ;
                   dcterms:created "2022-11-07"^^xsd:date ;
                   dcterms:modified "2023-03-14"^^xsd:date ;
                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -7951,7 +8006,7 @@ See: TSI CCS (Subset-026, Chapter 7. 7.5.1.161)"""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "V_NVALLOWOVTRP"@en ;
                   rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                  vs:term_status "stable" ;
                   skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -7964,7 +8019,7 @@ era:vNvsupovtrp rdf:type owl:DatatypeProperty ,
                 era:appendixD3Index "1.5.4" ;
                 era:rinfIndex "1.1.1.3.2.16.4" ,
                               "1.2.1.1.1.16.4" ;
-                era:unitOfMeasure qudt:KiloM-PER-HR ;
+                era:unitOfMeasure unit:KiloM-PER-HR ;
                 dcterms:created "2022-11-07"^^xsd:date ;
                 dcterms:modified "2023-03-14"^^xsd:date ;
                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -7976,7 +8031,7 @@ See: TSI CCS (Subset-026, chapter 7. 7.5.1.163 V_NVSUPOVTRP)"""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "V_NVSUPOVTRP"@en ;
                 rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                vs:term_status "stable" ;
                 skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
@@ -7989,7 +8044,7 @@ era:validityEndDate rdf:type owl:DatatypeProperty ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Validity end date"@en ;
                     owl:deprecated "true"^^xsd:boolean ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                    vs:term_status "stable" ;
                     skos:editorialNote "To be deprecated with the introduction of temporal entity"@en .
 
 
@@ -8002,7 +8057,7 @@ era:validityStartDate rdf:type owl:DatatypeProperty ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Validity start date"@en ;
                       owl:deprecated "true"^^xsd:boolean ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                      vs:term_status "stable" ;
                       skos:editorialNote "To be deprecated with the introduction of temporal entity"@en .
 
 
@@ -8016,7 +8071,7 @@ era:vehicleContactForce rdf:type owl:DatatypeProperty ;
                         rdfs:comment "Mean contact force."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Vehicle contact force"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/vehicleKinematicGaugeOther
@@ -8028,7 +8083,7 @@ era:vehicleKinematicGaugeOther rdf:type owl:DatatypeProperty ;
                                rdfs:comment "Vehicle kinematic gauge  that corresponds to other gauges assessed using the kinematic method"@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Vehicle kinematic gauge other"@en ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/vehicleMaxSandingOutput
@@ -8041,7 +8096,7 @@ era:vehicleMaxSandingOutput rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Vehicle Maximum sanding output, given in grams per second."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Vehicle max sanding output"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/vehicleNumber
@@ -8053,7 +8108,7 @@ era:vehicleNumber rdf:type owl:DatatypeProperty ;
                   rdfs:comment "Identification number of a vehicle or wagon."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Vehicle number"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/vehiclePantographHead
@@ -8066,7 +8121,7 @@ era:vehiclePantographHead rdf:type owl:DatatypeProperty ;
                           rdfs:comment "Pantograph head geometry (to be indicated for each energy supply system the vehicle is equipped for)."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Vehicle pantograph head"@en ;
-                          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/vehicleSeries
@@ -8078,7 +8133,7 @@ era:vehicleSeries rdf:type owl:DatatypeProperty ;
                   rdfs:comment "Manufacturing series of a vehicle."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Vehicle series"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                  vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/vehicleTypeMaximumCantDeficiency
@@ -8090,7 +8145,7 @@ era:vehicleTypeMaximumCantDeficiency rdf:type owl:DatatypeProperty ;
                                      rdfs:comment "Part of the combination of maximum speed and maximum cant deficiency for which the vehicle was assessed. Corresponds to the maximum cant deficiency."@en ;
                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                      rdfs:label "Vehicle type maximum cant deficiency"@en ;
-                                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/vehicleTypeMaximumSpeed
@@ -8102,7 +8157,7 @@ era:vehicleTypeMaximumSpeed rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Part of the combination of maximum speed and maximum cant deficiency for which the vehicle was assessed. Corresponds to the maximum speed."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Vehicle type maximum speed"@en ;
-                            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/vehicleTypesCompatibleTrafficLoad
@@ -8114,7 +8169,7 @@ era:vehicleTypesCompatibleTrafficLoad rdf:type owl:DatatypeProperty ;
                                       rdfs:comment "TODO: review. The infrastructure managers shall provide through RINF the information to the RU regarding list of vehicle types compatible with the route for which they have already verified compatibility for parameter Traffic load and load carrying capacity of infrastructure and train detection systems, where such information is available."@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "List of vehicle types already identified as compatible with Traffic load and load carrying capacity of infrastructure and train detection systems"@en ;
-                                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                                      vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/vehiclesCompatibleTrafficLoad
@@ -8126,7 +8181,7 @@ era:vehiclesCompatibleTrafficLoad rdf:type owl:DatatypeProperty ;
                                   rdfs:comment "TODO: review. The infrastructure managers shall provide through RINF the information or a document to the RU regarding list of vehicle(s) compatible with the route for which they have already verified compatibility for parameter Traffic load and load carrying capacity of infrastructure and train detection systems, where such information is available."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "List of vehicles already identified as compatible with Traffic load and load carrying capacity of infrastructure and train detection systems"@en ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                                  vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/vehiclesComposingFixedFormation
@@ -8139,7 +8194,7 @@ era:vehiclesComposingFixedFormation rdf:type owl:DatatypeProperty ;
                                     rdfs:comment "Number of vehicles composing the fixed formation (for fixed formation only). Note: the value is mandatory for all vehicle categories. If the vehicle is composed of only one car, the indicated value shall be '1'."@en ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "Vehicles composing fixed formation"@en ;
-                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/verificationCCS
@@ -8153,7 +8208,7 @@ era:verificationCCS rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Unique number for EC declarations in accordance with Commission Implementing Regulation (EU) 2019/250"@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "EC declaration of verification for track relating to compliance with the requirements from TSIs applicable to control, command signalling subsystem"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/verificationENE
@@ -8167,7 +8222,7 @@ era:verificationENE rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Unique number for EC declarations in accordance with Commission Implementing Regulation (EU) 2019/250."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "EC declaration of verification for track relating to compliance with the requirements from TSIs applicable to energy subsystem"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/verificationINF
@@ -8184,7 +8239,7 @@ era:verificationINF rdf:type owl:DatatypeProperty ;
 In https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019R0777&from=EN."""@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "EC declaration of verification for track relating to compliance with the requirements from TSIs applicable to infrastructure subsystem"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/verificationSRT
@@ -8200,7 +8255,7 @@ era:verificationSRT rdf:type owl:DatatypeProperty ;
                     rdfs:comment "Unique number for EC declarations in accordance with Commission Implementing Regulation (EU) 2019/250."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "EC declaration of verification relating to compliance with the requirements from TSIs applicable to railway tunnel"@en ;
-                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/voiceOperationalCommImpl
@@ -8213,21 +8268,21 @@ era:voiceOperationalCommImpl rdf:type owl:DatatypeProperty ;
                              rdfs:comment "Voice and operational communication implementation."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Voice operational communication implementation"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/weight
 era:weight rdf:type owl:DatatypeProperty ;
            rdfs:domain era:LinearElementLink ;
            rdfs:range xsd:double ;
-           rdfs:comment """The weight of the edge between 2 topological nodes."""@en ;		   
-           skos:scopeNote """The value of the weight is represented by the length of the functional representation of the linear element defined by the property era:from of the era:LinearElementLink."""@en ; 
+           rdfs:comment "The weight of the edge between 2 topological nodes."@en ;
+           rdfs:label "weight"@en ;
            skos:example """ For example: 
 					:x rdf:type eraLinearElementLink;
 					 era:from :le1;
 					 era:to :le2;
 					 era:weight \"1.234\"^^xsd:double; #length of the track topologically represented as :le1"""@en ;
-           rdfs:label "weight"@en .
+           skos:scopeNote "The value of the weight is represented by the length of the functional representation of the linear element defined by the property era:from of the era:LinearElementLink."@en .
 
 
 ###  http://data.europa.eu/949/wheelSetGaugeTransformationMethod
@@ -8240,7 +8295,7 @@ era:wheelSetGaugeTransformationMethod rdf:type owl:DatatypeProperty ;
                                       rdfs:comment "Wheel gauge transformation method. Defined if more than one wheel gauges have been selected."@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Wheel set gauge transformation method"@en ;
-                                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/wheelchairSleepingPlaces
@@ -8253,7 +8308,7 @@ era:wheelchairSleepingPlaces rdf:type owl:DatatypeProperty ;
                              rdfs:comment "Number of wheelchair accessible sleeping places."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Wheelchair sleeping spaces"@en ;
-                             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/wheelchairSpaces
@@ -8266,7 +8321,7 @@ era:wheelchairSpaces rdf:type owl:DatatypeProperty ;
                      rdfs:comment "Number of wheelchair spaces."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Wheelchair spaces"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://purl.org/dc/terms/identifier
@@ -8279,39 +8334,39 @@ dcterms:identifier rdf:type owl:DatatypeProperty ;
 
 
 ###  http://www.opengis.net/ont/geosparql#asWKT
-<http://www.opengis.net/ont/geosparql#asWKT> rdf:type owl:DatatypeProperty ;
-                                             rdfs:subPropertyOf <http://www.opengis.net/ont/geosparql#hasSerialization> ;
-                                             rdfs:domain <http://www.opengis.net/ont/geosparql#Geometry> ;
-                                             rdfs:range <http://www.opengis.net/ont/geosparql#wktLiteral> ;
-                                             era:XMLName "OPGeographicLocation" ;
-                                             era:appendixD2Index "2.1.1" ,
-                                                                 "2.1.2" ,
-                                                                 "2.2.2" ;
-                                             era:rinfIndex "1.1.0.0.1.1" ,
-                                                           "1.1.1.0.1.1" ,
-                                                           "1.1.1.3.14.5" ,
-                                                           "1.2.0.0.0.5" ,
-                                                           "1.2.1.0.8.5" ;
-                                             <http://purl.org/dc/elements/1.1/contributor> "Matthew Perry" ;
-                                             <http://purl.org/dc/elements/1.1/creator> "OGC GeoSPARQL 1.0 Standard Working Group" ;
-                                             <http://purl.org/dc/elements/1.1/date> "2011-06-16"^^xsd:date ;
-                                             <http://purl.org/dc/elements/1.1/description> """
+geo:asWKT rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf geo:hasSerialization ;
+          rdfs:domain geo:Geometry ;
+          rdfs:range geo:wktLiteral ;
+          era:XMLName "OPGeographicLocation" ;
+          era:appendixD2Index "2.1.1" ,
+                              "2.1.2" ,
+                              "2.2.2" ;
+          era:rinfIndex "1.1.0.0.1.1" ,
+                        "1.1.1.0.1.1" ,
+                        "1.1.1.3.14.5" ,
+                        "1.2.0.0.0.5" ,
+                        "1.2.1.0.8.5" ;
+          dc:contributor "Matthew Perry" ;
+          dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+          dc:date "2011-06-16"^^xsd:date ;
+          dc:description """
       The WKT serialization of a geometry
     """@en ;
-                                             rdfs:comment """
+          rdfs:comment """
       The WKT serialization of a geometry
     """@en ;
-                                             rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> ,
-                                                              <http://www.opengis.net/spec/geosparql/1.0> ;
-                                             rdfs:label "asWKT"@en ;
-                                             skos:definition """
+          rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> ,
+                           <http://www.opengis.net/spec/geosparql/1.0> ;
+          rdfs:label "asWKT"@en ;
+          skos:definition """
       The WKT serialization of a geometry
     """@en ;
-                                             skos:prefLabel "asWKT"@en .
+          skos:prefLabel "asWKT"@en .
 
 
 ###  http://www.opengis.net/ont/geosparql#hasSerialization
-<http://www.opengis.net/ont/geosparql#hasSerialization> rdf:type owl:DatatypeProperty .
+geo:hasSerialization rdf:type owl:DatatypeProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#notation
@@ -8319,19 +8374,19 @@ skos:notation rdf:type owl:DatatypeProperty .
 
 
 ###  http://www.w3.org/ns/org#identifier
-<http://www.w3.org/ns/org#identifier> rdf:type owl:DatatypeProperty ;
-                                      rdfs:subPropertyOf skos:notation ;
-                                      rdfs:domain <http://www.w3.org/ns/org#Organization> ;
-                                      rdfs:comment "Código o identificador, como por ejemplo el CIF de una empresa, que permite identificar de forma inequívoca a una organización. Existen muchos códigos de identificación tanto nacionales como internacionales. Esta ontología no obliga al uso de ningún esquema en concreto. Los códigos de identificación utilizados en cada caso se deberían indicar mediante el uso de la propiedad “datatype” del valor del identificador. El uso de la propiedad “datatype” para especificar el esquema de notación utilizado está en consonancia con las buenas prácticas recomendadas para el uso de la propiedad `skos:notation`, de la que esta propiedad es una especialización."@es ,
-                                                   "Donne un identifiant, comme par exemple le numéro d'enregistrement d'une entreprise, qui peut être utilisé comme identifiant unique pour l'Organisation. De nombreux schémas nationaux et internationaux sont disponibles. Cette ontologie reste neutre par rapport au schéma utilisé. Le schéma particulier utilisé devrait être indiqué par le `datatype` de la valeur de l'identifiant. Utiliser les datatypes pour distinguer les schémas de notation est cohérent avec les bonnes pratiques pour `skos:notation` dont cette propriété est une spécialisation."@fr ,
-                                                   "Gives an identifier, such as a company registration number, that can be used to used to uniquely identify the organization. Many different national and international identier schemes are available. The org ontology is neutral to which schemes are used. The particular identifier scheme should be indicated by the datatype of the identifier value.  Using datatypes to distinguish the notation scheme used is consistent with recommended best practice for `skos:notation` of which this property is a specialization."@en ,
-                                                   "Indica un identificatore univoco per l'organizzazione, come ad esempio la partita IVA di un'azienda. Molti schemi di identificazione a livello nazionale e internazionale sono disponibili allo scopo. L'ontologia ORG è neutrale rispetto allo schema da utilizzare. Lo schema di identificazione dovrebbe essere indicato dal datatype del valore dell'identificatore. L'uso del datatype per distinguere lo schema di identificazione è coerente con le best practice per `skos:notation`, di cui questa proprietà è una specializzazione."@it ,
-                                                   "組織を一意に識別するために使用できる会社登録番号などの識別子を与えます。"@ja ;
-                                      rdfs:isDefinedBy <http://www.w3.org/ns/org> ;
-                                      rdfs:label "identifiant"@fr ,
-                                                 "identificatore"@it ,
-                                                 "identifier"@en ,
-                                                 "tiene identificador"@es .
+org:identifier rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf skos:notation ;
+               rdfs:domain org:Organization ;
+               rdfs:comment "Código o identificador, como por ejemplo el CIF de una empresa, que permite identificar de forma inequívoca a una organización. Existen muchos códigos de identificación tanto nacionales como internacionales. Esta ontología no obliga al uso de ningún esquema en concreto. Los códigos de identificación utilizados en cada caso se deberían indicar mediante el uso de la propiedad “datatype” del valor del identificador. El uso de la propiedad “datatype” para especificar el esquema de notación utilizado está en consonancia con las buenas prácticas recomendadas para el uso de la propiedad `skos:notation`, de la que esta propiedad es una especialización."@es ,
+                            "Donne un identifiant, comme par exemple le numéro d'enregistrement d'une entreprise, qui peut être utilisé comme identifiant unique pour l'Organisation. De nombreux schémas nationaux et internationaux sont disponibles. Cette ontologie reste neutre par rapport au schéma utilisé. Le schéma particulier utilisé devrait être indiqué par le `datatype` de la valeur de l'identifiant. Utiliser les datatypes pour distinguer les schémas de notation est cohérent avec les bonnes pratiques pour `skos:notation` dont cette propriété est une spécialisation."@fr ,
+                            "Gives an identifier, such as a company registration number, that can be used to used to uniquely identify the organization. Many different national and international identier schemes are available. The org ontology is neutral to which schemes are used. The particular identifier scheme should be indicated by the datatype of the identifier value.  Using datatypes to distinguish the notation scheme used is consistent with recommended best practice for `skos:notation` of which this property is a specialization."@en ,
+                            "Indica un identificatore univoco per l'organizzazione, come ad esempio la partita IVA di un'azienda. Molti schemi di identificazione a livello nazionale e internazionale sono disponibili allo scopo. L'ontologia ORG è neutrale rispetto allo schema da utilizzare. Lo schema di identificazione dovrebbe essere indicato dal datatype del valore dell'identificatore. L'uso del datatype per distinguere lo schema di identificazione è coerente con le best practice per `skos:notation`, di cui questa proprietà è una specializzazione."@it ,
+                            "組織を一意に識別するために使用できる会社登録番号などの識別子を与えます。"@ja ;
+               rdfs:isDefinedBy <http://www.w3.org/ns/org> ;
+               rdfs:label "identifiant"@fr ,
+                          "identificatore"@it ,
+                          "identifier"@en ,
+                          "tiene identificador"@es .
 
 
 ###  http://xmlns.com/foaf/0.1/name
@@ -8341,7 +8396,7 @@ foaf:name rdf:type owl:DatatypeProperty ;
           rdfs:comment "A name for some thing." ;
           rdfs:isDefinedBy foaf: ;
           rdfs:label "name" ;
-          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "testing" .
+          vs:term_status "testing" .
 
 
 ###  http://xmlns.com/foaf/0.1/nick
@@ -8349,7 +8404,7 @@ foaf:nick rdf:type owl:DatatypeProperty ;
           rdfs:comment "A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames)." ;
           rdfs:isDefinedBy foaf: ;
           rdfs:label "nickname" ;
-          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "testing" .
+          vs:term_status "testing" .
 
 
 #################################################################
@@ -8393,7 +8448,7 @@ era:BasicObject rdf:type owl:Class ;
 ###  http://data.europa.eu/949/Body
 era:Body rdf:type owl:Class ;
          rdfs:subClassOf [ rdf:type owl:Class ;
-                           owl:unionOf ( <http://www.w3.org/ns/org#Organization>
+                           owl:unionOf ( org:Organization
                                          foaf:Person
                                        )
                          ] ;
@@ -8432,7 +8487,7 @@ era:Certificate rdf:type owl:Class ;
                 rdfs:comment "TODO review:Certificate of a vehicle type. Can be in one of the following states: Amended, New, Suspended, Withdrawn."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Certificate"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/ContactLineSystem
@@ -8443,7 +8498,7 @@ era:ContactLineSystem rdf:type owl:Class ;
                       rdfs:comment "System that is used to transmit electrical energy to road or rail vehicles."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Contact Line System"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/Document
@@ -8453,7 +8508,7 @@ era:Document rdf:type owl:Class ;
              rdfs:comment "Document in any of the ERA systems, e.g. reference document in RINF."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "ERA Document"@en ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+             vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/ETCSLevel
@@ -8464,7 +8519,7 @@ era:ETCSLevel rdf:type owl:Class ;
               rdfs:comment "TSI compliant train protection system ERTMS / ETCS application level and baseline related to the track side equipment."@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "ETCS"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+              vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/EnergySubsystem
@@ -8475,7 +8530,7 @@ era:EnergySubsystem rdf:type owl:Class ;
 
 ###  http://data.europa.eu/949/Feature
 era:Feature rdf:type owl:Class ;
-            rdfs:subClassOf <http://www.opengis.net/ont/geosparql#Feature> ;
+            rdfs:subClassOf geo:Feature ;
             dcterms:created "2022-07-07"^^xsd:date ;
             dcterms:modified "2022-10-27"^^xsd:date ;
             rdfs:comment "Class that encompasses the features that are part of the physical infrastructure (class InfrastructureObject) and the topological objects (class TopologicalObject). It is a subclass of the geographical Feature class that has a spatial representation."@en ;
@@ -8497,7 +8552,7 @@ era:FrenchTrainDetectionSystemLimitation rdf:type owl:Class ;
 -8 45-second delay for specific announcement reset devices"""@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "Section with train detection limitation"@en ;
-                                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/InfraSubsystem
@@ -8508,7 +8563,7 @@ era:InfraSubsystem rdf:type owl:Class ;
 
 ###  http://data.europa.eu/949/InfrastructureManager
 era:InfrastructureManager rdf:type owl:Class ;
-                          rdfs:subClassOf <http://www.w3.org/ns/org#Organization> ;
+                          rdfs:subClassOf org:Organization ;
                           dcterms:isReplacedBy era:Body ;
                           rdfs:comment "(deprecated) The infrastructure manager owns and operates the railway network and related infrastructure."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -8564,7 +8619,7 @@ era:LineReference rdf:type owl:Class ;
                   rdfs:comment "TODO review: A reference to a specific national railway line."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Railway location"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                  vs:term_status "stable" ;
                   skos:altLabel "Line reference" .
 
 
@@ -8614,12 +8669,12 @@ Each track can have several load capability (structured) values, and each one ha
                                 "This class together with properties loadCapabilityLineCategory and loadCapabilitySpeed replaces the previous loadCapability SKOS property."@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Load capability"@en ;
-                   <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                   vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/Manufacturer
 era:Manufacturer rdf:type owl:Class ;
-                 rdfs:subClassOf <http://www.w3.org/ns/org#Organization> ;
+                 rdfs:subClassOf org:Organization ;
                  dcterms:created "2020-11-19"^^xsd:date ;
                  dcterms:modified "2020-11-19"^^xsd:date ,
                                   "2024-06-03"^^xsd:date ;
@@ -8627,7 +8682,7 @@ era:Manufacturer rdf:type owl:Class ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Manufacturer"@en ;
                  owl:deprecated "true"^^xsd:boolean ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/MaximumMagneticField
@@ -8641,7 +8696,7 @@ era:MaximumMagneticField rdf:type owl:Class ;
 It should be provided in 3 directions."""@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Maximum magnetic field"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                         vs:term_status "stable" ;
                          skos:scopeNote "The MaximumMagneticField class is applicable for axle counters."@en .
 
 
@@ -8651,7 +8706,7 @@ era:MaximumSpeedAndCantDeficiency rdf:type owl:Class ;
                                   rdfs:comment "Combination of maximum speed and maximum cant deficiency for which the vehicle was assessed."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Maximum speed and cant deficiency"@en ;
-                                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/MinAxleLoadVehicleCategory
@@ -8662,7 +8717,7 @@ era:MinAxleLoadVehicleCategory rdf:type owl:Class ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Min axle load vehicle category"@en ;
                                owl:deprecated "true"^^xsd:boolean ;
-                               <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                               vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/MinVehicleImpedance
@@ -8681,7 +8736,7 @@ Per Voltage:
 [3000]: [CCCC]+[ZZZZ], idem."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "Minimum Vehicle Impedance"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+                        vs:term_status "stable" ;
                         skos:scopeNote "The MinVehicleImpedance class is applicable for track circuits."@en .
 
 
@@ -8695,7 +8750,7 @@ era:NationalRailwayLine rdf:type owl:Class ;
 A line is a sequence of one or mores ections of line, which connects operational points and which may consist of several tracks used for regular railway operation."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "National railway line"@en ;
-                        <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                        vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/Network
@@ -8720,11 +8775,12 @@ era:OperationalPoint rdf:type owl:Class ;
                      rdfs:comment "An operational point (OP) means any location for train service operations, where train services may begin and end or change route, and where passenger or freight services may be provided; operational point also means any location at boundaries between Member States or infrastructure managers."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Operational Point"@en ;
-                     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                     vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/OrganisationRole
 era:OrganisationRole rdf:type owl:Class ;
+                     rdfs:comment "Represents an n-ary relationship between a Body and a role"@en ;
                      rdfs:label "Organisation Role"@en .
 
 
@@ -8740,7 +8796,7 @@ era:PhaseInfo rdf:type owl:Class ;
               rdfs:comment "Indication of required several information on phase separation."@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "Phase info"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> era:stable .
+              vs:term_status era:stable .
 
 
 ###  http://data.europa.eu/949/PlatformEdge
@@ -8758,7 +8814,7 @@ era:PlatformEdge rdf:type owl:Class ;
                  rdfs:comment "Platform for the purpose of RINF is understood as a platform edge. A platform concerns only the part of the structure neighbouring to the track (interfaced with trains)."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Platform edge"@en ;
-                 <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                 vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/Position
@@ -8801,7 +8857,7 @@ Each track can have several raised pantographs per train allowed (structured) va
 As for different speeds different combinations of number of pantographs and distance between them may exist, so this parameter can be repeated to present all of them."""@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Requirements for raised pantographs"@en ;
-                                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/Referent
@@ -8831,13 +8887,13 @@ era:SectionOfLine rdf:type owl:Class ;
                                   ] ;
                   era:appendixD2Index "2.1.1" ;
                   era:rinfIndex 1.1 ;
-                  <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
+                  dc:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                   dcterms:created "2021-04-02"^^xsd:date ;
                   dcterms:modified "2022-07-07"^^xsd:date ;
                   rdfs:comment "A section of line means the part of line between adjacent operational points and may consist of several tracks."@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Section Of Line"@en ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/Siding
@@ -8855,7 +8911,7 @@ era:Siding rdf:type owl:Class ;
            rdfs:comment "Sidings are all those tracks where running trains in service movements ends and which are not used for operational routing of a train."@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "Siding"@en ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" ;
+           vs:term_status "stable" ;
            skos:definition "Siding Any track(s) within an operational point which is not used for operational routing of a train."@en .
 
 
@@ -8867,14 +8923,14 @@ era:Signal rdf:type owl:Class ;
                             era:Track ,
                             era:Tunnel ;
            era:rinfIndex "1.2.1.0.8" ;
-           <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/2023-09-28> ;
+           dc:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/2023-09-28> ;
            dcterms:created "2021-04-01"^^xsd:date ;
            dcterms:modified "2022-10-27"^^xsd:date ;
            rdfs:comment """A railway signal is an installation next to the railway track for signalling the maximum allowed speed in the next block section to the train driver.
 Definition RSM: Apparatus by means of which a conventional visual or acoustic indication is given, generally concerning the movements of railway vehicles."""@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "Signal"@en ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/SignalsGrid
@@ -8892,9 +8948,9 @@ The switches' position in a SignalsGrid are controlled together by the interlock
 ###  http://data.europa.eu/949/SpecialArea
 era:SpecialArea rdf:type owl:Class ;
                 rdfs:subClassOf era:InfrastructureObject ;
-                era:annexD2Index "3.2.4" ,
-                                 "3.2.5" ;
-                <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
+                era:appendixD2Index "3.2.4" ,
+                                    "3.2.5" ;
+                dc:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                 dcterms:created "2022-10-27"^^xsd:date ,
                                 "2024-04-18"^^xsd:date ;
                 rdfs:comment """TODO review: Encompasses all those areas (outside of the operational gauge) or sections (those in tunnels excluded) which influence operation in the gauge itself, such as 
@@ -8908,21 +8964,21 @@ Industrial Risk Area: locations where it is dangerous for the driver to step out
 For these areas in tunnels, use era:SpecialTunnelArea."""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Special area"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/SpecialTunnelArea
 era:SpecialTunnelArea rdf:type owl:Class ;
                       rdfs:subClassOf era:SpecialArea ;
-                      era:annexD2Index "3.2.3" ;
-                      <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
+                      era:appendixD2Index "3.2.3" ;
+                      dc:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                       dcterms:created "2022-10-27"^^xsd:date ;
                       rdfs:comment """TODO review: Area or location within a tunnel where there are 
 - a safe area: a walkway, evacuation and rescue points;
 - a restricted area (non-stopping area or industrial risk location in a tunnel)."""@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Special tunnel area"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                      vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/SpotLocation
@@ -8939,7 +8995,7 @@ era:SubsetWithCommonCharacteristics rdf:type owl:Class ;
                                     rdfs:comment "A set of common technical characteristics that is shared by different infrastructure objects. The set of parameters may not be restricted to only one railway subsystem, but it can include common characteristics from each one of them (infrastructure, energy, track-side CCS)"@en ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "Subset with common characteristics"@en ;
-                                    <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                                    vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/SubsidiaryLocation
@@ -8959,11 +9015,11 @@ era:Switch rdf:type owl:Class ;
            rdfs:subClassOf era:BasicObject ;
            owl:disjointWith era:Track ,
                             era:Tunnel ;
-           <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg_impl/2019/776/oj> ;
+           dc:source <https://eur-lex.europa.eu/eli/reg_impl/2019/776/oj> ;
            rdfs:comment "A unit of track comprising two fixed rails (stock rails) and two movable rails (switch rails) used to direct vehicles from one track to another track."@en ;
            rdfs:label "Switch"@en ;
            rdfs:seeAlso <http://data.europa.eu/eli/reg/2014/1299/2019-06-16> ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/SystemSeparationInfo
@@ -8972,7 +9028,7 @@ era:SystemSeparationInfo rdf:type owl:Class ;
                          rdfs:comment "Indication of required several information on system separation."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "System separation info"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/TechnicalCharacteristics
@@ -8982,8 +9038,8 @@ era:TechnicalCharacteristics rdf:type owl:Class ;
 
 ###  http://data.europa.eu/949/TemporalFeature
 era:TemporalFeature rdf:type owl:Class ;
-                    rdfs:subClassOf <http://www.w3.org/2006/time#TemporalDuration> ,
-                                    <http://www.w3.org/2006/time#TemporalEntity> ;
+                    rdfs:subClassOf time:TemporalDuration ,
+                                    time:TemporalEntity ;
                     rdfs:label "Temporal Feature"@en .
 
 
@@ -8993,7 +9049,7 @@ era:TopologicalObject rdf:type owl:Class ;
                       rdfs:comment "Top level class for the the track network described as a topological node edge model"@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "Topological Object"@en ;
-                      <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable" .
+                      vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/Track
@@ -9006,7 +9062,7 @@ era:Track rdf:type owl:Class ;
           rdfs:comment "A running track means any track used for train service movements; passing loops and meeting loops on plain line or track connections only required for train operation are not published"@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "Running track"@en ;
-          <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+          vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/TrainDetectionSystem
@@ -9017,20 +9073,20 @@ era:TrainDetectionSystem rdf:type owl:Class ;
                          rdfs:comment "Safety system used to detect the presence of vehicles on the railway track."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Train Detection System"@en ;
-                         <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                         vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/Tunnel
 era:Tunnel rdf:type owl:Class ;
            rdfs:subClassOf era:BasicObject ;
            era:rinfIndex "1.2.2.0.5" ;
-           <http://purl.org/dc/elements/1.1/source> <https://eur-lex.europa.eu/eli/reg/2014/1303/2024-01-29> ;
+           dc:source <https://eur-lex.europa.eu/eli/reg/2014/1303/2024-01-29> ;
            dcterms:created "2020-07-29"^^xsd:date ;
            dcterms:modified "2022-07-07"^^xsd:date ;
            rdfs:comment "A railway tunnel is an excavation or a construction around the track provided to allow the railway to pass for example higher land, buildings or water."@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "Tunnel"@en ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+           vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/Vehicle
@@ -9040,12 +9096,12 @@ era:Vehicle rdf:type owl:Class ;
             rdfs:comment "A specific vehicle or wagon able and allowed to operate over railway infrastructure."@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             rdfs:label "Vehicle"@en ;
-            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+            vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/VehicleKeeper
 era:VehicleKeeper rdf:type owl:Class ;
-                  rdfs:subClassOf <http://www.w3.org/ns/org#Organization> ;
+                  rdfs:subClassOf org:Organization ;
                   dcterms:created "2020-11-23"^^xsd:date ;
                   dcterms:modified "2020-11-23"^^xsd:date ,
                                    "2024-04-18"^^xsd:date ,
@@ -9055,7 +9111,7 @@ exploits the vehicle as a means of transport and is registered as such in a vehi
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "Vehicle Keeper"@en ;
                   owl:deprecated "true"^^xsd:boolean ;
-                  <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/VehicleType
@@ -9079,15 +9135,15 @@ The above mentioned certificate should be documented using era:certificate.
 """@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Vehicle Type"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+                vs:term_status "stable" .
 
 
 ###  http://www.opengis.net/ont/geosparql#Feature
-<http://www.opengis.net/ont/geosparql#Feature> rdf:type owl:Class .
+geo:Feature rdf:type owl:Class .
 
 
 ###  http://www.opengis.net/ont/geosparql#Geometry
-<http://www.opengis.net/ont/geosparql#Geometry> rdf:type owl:Class .
+geo:Geometry rdf:type owl:Class .
 
 
 ###  http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag
@@ -9099,9 +9155,9 @@ rdfs:Resource rdf:type owl:Class .
 
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#Point
-<http://www.w3.org/2003/01/geo/wgs84_pos#Point> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> ;
-                                                rdfs:comment """ 
+wgs:Point rdf:type owl:Class ;
+          rdfs:subClassOf wgs:SpatialThing ;
+          rdfs:comment """ 
 Uniquely identified by lat/long/alt. i.e.
 
 spaciallyIntersects(P1, P2) :- lat(P1, LAT), long(P1, LONG), alt(P1, ALT),
@@ -9109,17 +9165,17 @@ spaciallyIntersects(P1, P2) :- lat(P1, LAT), long(P1, LONG), alt(P1, ALT),
 
 sameThing(P1, P2) :- type(P1, Point), type(P2, Point), spaciallyIntersects(P1, P2).
   """ ,
-                                                             """A point, typically described using a coordinate system relative to Earth, such as WGS84.
+                       """A point, typically described using a coordinate system relative to Earth, such as WGS84.
   """ ;
-                                                rdfs:label "Point" .
+          rdfs:label "Point" .
 
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing
-<http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> rdf:type owl:Class ;
-                                                       rdfs:comment """Anything with spatial extent, i.e. size, shape, or position.
+wgs:SpatialThing rdf:type owl:Class ;
+                 rdfs:comment """Anything with spatial extent, i.e. size, shape, or position.
  e.g. people, places, bowling balls, as well as abstract areas like cubes.
 """ ;
-                                                       rdfs:label "SpatialThing" .
+                 rdfs:label "SpatialThing" .
 
 
 ###  http://www.w3.org/2004/02/skos/core#Collection
@@ -9140,45 +9196,45 @@ skos:ConceptScheme rdf:type owl:Class .
 
 
 ###  http://www.w3.org/2006/time#Instant
-<http://www.w3.org/2006/time#Instant> rdf:type owl:Class .
+time:Instant rdf:type owl:Class .
 
 
 ###  http://www.w3.org/2006/time#TemporalDuration
-<http://www.w3.org/2006/time#TemporalDuration> rdf:type owl:Class ;
-                                               rdfs:comment "Time extent; duration of a time interval separate from its particular start position"@en ;
-                                               rdfs:label "Temporal duration"@en ;
-                                               skos:definition "Time extent; duration of a time interval separate from its particular start position"@en .
+time:TemporalDuration rdf:type owl:Class ;
+                      rdfs:comment "Time extent; duration of a time interval separate from its particular start position"@en ;
+                      rdfs:label "Temporal duration"@en ;
+                      skos:definition "Time extent; duration of a time interval separate from its particular start position"@en .
 
 
 ###  http://www.w3.org/2006/time#TemporalEntity
-<http://www.w3.org/2006/time#TemporalEntity> rdf:type owl:Class ;
-                                             owl:equivalentClass [ rdf:type owl:Class ;
-                                                                   owl:unionOf ( <http://www.w3.org/2006/time#Instant>
-                                                                                 <http://www.w3.org/2006/time#:Interval>
-                                                                               )
-                                                                 ] ;
-                                             rdfs:comment "A temporal interval or instant."@en ;
-                                             rdfs:label "Temporal entity"@en ;
-                                             skos:definition "A temporal interval or instant."@en .
+time:TemporalEntity rdf:type owl:Class ;
+                    owl:equivalentClass [ rdf:type owl:Class ;
+                                          owl:unionOf ( time:Instant
+                                                        <http://www.w3.org/2006/time#:Interval>
+                                                      )
+                                        ] ;
+                    rdfs:comment "A temporal interval or instant."@en ;
+                    rdfs:label "Temporal entity"@en ;
+                    skos:definition "A temporal interval or instant."@en .
 
 
-###  http://www.w3.org/2006/time#:Interval
-<http://www.w3.org/2006/time#:Interval> rdf:type owl:Class .
+###  http://www.w3.org/2006/time#Interval
+<http://www.w3.org/2006/time#Interval> rdf:type owl:Class .
 
 
 ###  http://www.w3.org/ns/org#Organization
-<http://www.w3.org/ns/org#Organization> rdf:type owl:Class ;
-                                        rdfs:subClassOf foaf:Agent ;
-                                        rdfs:comment "Grupo de personas que se organiza en una comunidad u otro tipo de estructura social, comercial o política. Dicho grupo tiene un objetivo o motivo común para su existencia que va más allá del conjunto de personas que lo forman y que puede actuar como “agente”. A menudo las organizaciones se pueden agrupar en estructuras jerárquicas. Se recomienda el uso de etiquetas de SKOS para denominar a cada “organización”. En concreto, `<http://www.w3.org/2004/02/skos/core#prefLabel>` para la denominación principal o recomendada (aquella reconocida legalmente, siempre que sea posible), `<http://www.w3.org/2004/02/skos/core#altLabel>` para denominaciones alternativas (nombre comercial, sigla, denominación por la que se conoce a la organización coloquialmente) y `skos:notation` para referirse al código que identifique a la organización en una lista de códigos. Denominaciones alternativas: _colectivo_ _corporación_ _grupo_"@es ,
-                                                     "Rappresenta una collezione di persone organizzate all'interno di una communità o di una qualche struttura sociale, commerciale o politica. Il gruppo condivide un obiettivo o una ragione d'essere che va oltre gli stessi membri appartenenti al gruppo e  può agire come un Agent. Le organizzazioni si possono spesso suddividere in strutture gerarchiche. Si raccomanda di usare le label per l'Organization mediante le proprietà di SKOS. In particolare, `<http://www.w3.org/2004/02/skos/core#prefLabel>` per il nome principale (possibilmente un nome legalmente riconosciuto)”, `<http://www.w3.org/2004/02/skos/core#altLabel>` come nome alternativo (denominazione commerciale, denominazione colloquiale) e `skos:notation` per indicare un codice di una lista di codici."@it ,
-                                                     "Represents a collection of people organized together into a community or other social, commercial or political structure. The group has some common purpose or reason for existence which goes beyond the set of people belonging to it and can act as an Agent. Organizations are often decomposable into hierarchical structures.  It is recommended that SKOS lexical labels should be used to label the Organization. In particular `<http://www.w3.org/2004/02/skos/core#prefLabel>` for the primary (possibly legally recognized name), `<http://www.w3.org/2004/02/skos/core#altLabel>` for alternative names (trading names, colloquial names) and `skos:notation` to denote a code from a code list. Alternative names: _Collective_ _Body_ _Org_ _Group_"@en ,
-                                                     "Représente un groupe de personnes organisées en communauté où tout autre forme de structure sociale, commerciale ou politique. Le groupe a un but commun ou une raison d'être qui va au-delà de la somme des personnes qui en font partie et peut agir en tant que \"Agent\". Les organisations sont souvent décomposables en structures hiérarchisées. Il est recommandé que des labels lexicaux SKOS soient utilisés pour nommer l'Organisation. En particulier `<http://www.w3.org/2004/02/skos/core#prefLabel>` pour le nom principal (en général le nom légal), `<http://www.w3.org/2004/02/skos/core#altLabel>` pour les noms alternatifs (marques, sigles, appellations familières) et `skos:notation` pour indiquer un code provenant d'une liste de code."@fr ,
-                                                     "コミュニティー、その他の社会、商業、政治的な構造に共に編入された人々の集合を表わします。グループには、そこに属する人々を超えた、存在に対するある共通の目的や理由があり、エージェント（代理）を務めることができます。組織は、多くの場合、階層構造に分割できます。"@ja ;
-                                        rdfs:isDefinedBy <http://www.w3.org/ns/org> ;
-                                        rdfs:label "Organisation"@fr ,
-                                                   "Organization"@en ,
-                                                   "Organizzazione"@it ,
-                                                   "organización"@es .
+org:Organization rdf:type owl:Class ;
+                 rdfs:subClassOf foaf:Agent ;
+                 rdfs:comment "Grupo de personas que se organiza en una comunidad u otro tipo de estructura social, comercial o política. Dicho grupo tiene un objetivo o motivo común para su existencia que va más allá del conjunto de personas que lo forman y que puede actuar como “agente”. A menudo las organizaciones se pueden agrupar en estructuras jerárquicas. Se recomienda el uso de etiquetas de SKOS para denominar a cada “organización”. En concreto, `<http://www.w3.org/2004/02/skos/core#prefLabel>` para la denominación principal o recomendada (aquella reconocida legalmente, siempre que sea posible), `<http://www.w3.org/2004/02/skos/core#altLabel>` para denominaciones alternativas (nombre comercial, sigla, denominación por la que se conoce a la organización coloquialmente) y `skos:notation` para referirse al código que identifique a la organización en una lista de códigos. Denominaciones alternativas: _colectivo_ _corporación_ _grupo_"@es ,
+                              "Rappresenta una collezione di persone organizzate all'interno di una communità o di una qualche struttura sociale, commerciale o politica. Il gruppo condivide un obiettivo o una ragione d'essere che va oltre gli stessi membri appartenenti al gruppo e  può agire come un Agent. Le organizzazioni si possono spesso suddividere in strutture gerarchiche. Si raccomanda di usare le label per l'Organization mediante le proprietà di SKOS. In particolare, `<http://www.w3.org/2004/02/skos/core#prefLabel>` per il nome principale (possibilmente un nome legalmente riconosciuto)”, `<http://www.w3.org/2004/02/skos/core#altLabel>` come nome alternativo (denominazione commerciale, denominazione colloquiale) e `skos:notation` per indicare un codice di una lista di codici."@it ,
+                              "Represents a collection of people organized together into a community or other social, commercial or political structure. The group has some common purpose or reason for existence which goes beyond the set of people belonging to it and can act as an Agent. Organizations are often decomposable into hierarchical structures.  It is recommended that SKOS lexical labels should be used to label the Organization. In particular `<http://www.w3.org/2004/02/skos/core#prefLabel>` for the primary (possibly legally recognized name), `<http://www.w3.org/2004/02/skos/core#altLabel>` for alternative names (trading names, colloquial names) and `skos:notation` to denote a code from a code list. Alternative names: _Collective_ _Body_ _Org_ _Group_"@en ,
+                              "Représente un groupe de personnes organisées en communauté où tout autre forme de structure sociale, commerciale ou politique. Le groupe a un but commun ou une raison d'être qui va au-delà de la somme des personnes qui en font partie et peut agir en tant que \"Agent\". Les organisations sont souvent décomposables en structures hiérarchisées. Il est recommandé que des labels lexicaux SKOS soient utilisés pour nommer l'Organisation. En particulier `<http://www.w3.org/2004/02/skos/core#prefLabel>` pour le nom principal (en général le nom légal), `<http://www.w3.org/2004/02/skos/core#altLabel>` pour les noms alternatifs (marques, sigles, appellations familières) et `skos:notation` pour indiquer un code provenant d'une liste de code."@fr ,
+                              "コミュニティー、その他の社会、商業、政治的な構造に共に編入された人々の集合を表わします。グループには、そこに属する人々を超えた、存在に対するある共通の目的や理由があり、エージェント（代理）を務めることができます。組織は、多くの場合、階層構造に分割できます。"@ja ;
+                 rdfs:isDefinedBy <http://www.w3.org/ns/org> ;
+                 rdfs:label "Organisation"@fr ,
+                            "Organization"@en ,
+                            "Organizzazione"@it ,
+                            "organización"@es .
 
 
 ###  http://xmlns.com/foaf/0.1/Agent
@@ -9192,7 +9248,7 @@ foaf:Document rdf:type owl:Class ;
               rdfs:comment "A document." ;
               rdfs:isDefinedBy foaf: ;
               rdfs:label "Document" ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+              vs:term_status "stable" .
 
 
 ###  http://xmlns.com/foaf/0.1/Organization
@@ -9204,7 +9260,7 @@ foaf:Person rdf:type owl:Class ;
             rdfs:subClassOf foaf:Agent ;
             rdfs:comment "A person." ;
             rdfs:label "Person" ;
-            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "stable" .
+            vs:term_status "stable" .
 
 
 ###  http://xmlns.com/foaf/0.1/Project
@@ -9215,20 +9271,20 @@ foaf:Project rdf:type owl:Class .
 #    Annotations
 #################################################################
 
-<http://www.w3.org/2003/01/geo/wgs84_pos#> rdfs:label "geo" .
+wgs: rdfs:label "geo" .
 
 
-<http://www.w3.org/2003/01/geo/wgs84_pos#lat_long> rdfs:comment "A comma-separated representation of a latitude, longitude coordinate." ;
-                                                   rdfs:label "Lat/long" .
+wgs:lat_long rdfs:comment "A comma-separated representation of a latitude, longitude coordinate." ;
+             rdfs:label "Lat/long" .
 
 
-<http://www.w3.org/2003/01/geo/wgs84_pos#location> era:rinfIndex "1.1.0.0.1.1" ,
-                                                                 "1.1.1.0.1.1" ,
-                                                                 "1.1.1.3.14.5" ,
-                                                                 "1.2.0.0.0.5" ,
-                                                                 "1.2.1.0.8.5" ;
-                                                   era:usedInRCCCalculations "true"^^xsd:boolean ;
-                                                   rdfs:comment """The relation between something and the point, 
+wgs:location era:rinfIndex "1.1.0.0.1.1" ,
+                           "1.1.1.0.1.1" ,
+                           "1.1.1.3.14.5" ,
+                           "1.2.0.0.0.5" ,
+                           "1.2.1.0.8.5" ;
+             era:usedInRCCCalculations "true"^^xsd:boolean ;
+             rdfs:comment """The relation between something and the point, 
  or other geometrical thing in space, where it is.  For example, the realtionship between
  a radio tower and a Point with a given lat and long.
  Or a relationship between a park and its outline as a closed arc of points, or a road and
@@ -9236,7 +9292,7 @@ foaf:Project rdf:type owl:Class .
  Clearly in practice there will be limit to the accuracy of any such statement, but one would expect
  an accuracy appropriate for the size of the object and uses such as mapping .
  """ ;
-                                                   rdfs:label "Location" .
+             rdfs:label "Location" .
 
 
 #################################################################

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -55,7 +55,7 @@ Revision 13-08-2024:
 - renamed prefix qudt: to unit: to avoid confusion as per issue #47. 
 - merged annexD2Index with appendixD2index as per issue #50. 
 - added range and/or domain for annotation properties as per issue #56. 
-- fixed label and comment for the properies era:ETCSLevel and era:ETCSLevelType as per issue #60. 
+- fixed label and comment for the properties era:ETCSLevel and era:ETCSLevelType as per issue #60. 
 
 Revision 12-08-2024:
 - removed owl:incompatibleWith in a property as per issue #71.


### PR DESCRIPTION
- clarified the comment and label for ORG pattern as per issue #74.
- renamed prefix qudt: to unit: to avoid confusion as per issue #47. 
- merged annexD2Index with appendixD2index as per issue #50. 
- added range and/or domain for annotation properties as per issue #56. 
- fixed label and comment for the properties era:ETCSLevel and era:ETCSLevelType as per issue #60.