### PR TITLE
LD4RAIL 1069 migration ontology 3.0.1 t0 3.1.0 (new)

### DIFF
--- a/era-skos/era-skos-ConditionsUseReflectivePlates.ttl
+++ b/era-skos/era-skos-ConditionsUseReflectivePlates.ttl
@@ -52,7 +52,7 @@ era-condrefplat:00 a skos:Concept;
   skos:notation "Placeholder";
   skos:prefLabel "Placeholder" ;
   rdfs:comment "Placeholder" ;
-  owl:deprecated "false"^^xsd:boolean .
+   .
 
 
 

--- a/era-skos/era-skos-ConditionsUseReflectivePlates.ttl
+++ b/era-skos/era-skos-ConditionsUseReflectivePlates.ttl
@@ -1,0 +1,63 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix era: <http://data.europa.eu/949/> .
+@prefix era-skos: <http://data.europa.eu/949/concepts/> .
+
+@prefix era-condrefplat: <http://data.europa.eu/949/concepts/standard-combined-transport-roller-units/> .
+
+
+
+
+
+#################################################################
+#
+#    Concept Schemes
+#
+#################################################################
+
+
+
+
+era-condrefplat:StandardCombinedTransportRollerUnits a skos:ConceptScheme ; 
+    dct:issued "2024-09-24"^^xsd:date ;
+    cc:license <https://creativecommons.org/licenses/by/4.0/> ;
+    rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
+    rdfs:label "Conditions for use of reflective plates"@en ;
+    skos:prefLabel "Conditions for use of reflective plates"@en ;
+    dct:title "Concept scheme grouping conditions for use of reflective plates"@en .
+
+
+
+#################################################################
+#
+#    Concept instances
+#
+#################################################################
+
+
+## To be generated when values are available under the condition the scheme is relevant.
+## Work to do by the CCS 2024 members"
+
+
+########## Conditions Use Reflective Plates ##########
+
+era-condrefplat:00 a skos:Concept;
+  skos:inScheme era-condrefplat:ConditionsUseReflectivePlates; skos:topConceptOf era-condrefplat:ConditionsUseReflectivePlates ; 
+  skos:note "Value collected from TWG RINF CCS 2024 members"@en;
+  skos:notation "Placeholder";
+  skos:prefLabel "Placeholder" ;
+  rdfs:comment "Placeholder" ;
+  owl:deprecated "false"^^xsd:boolean .
+
+
+
+
+
+
+
+

--- a/era-skos/era-skos-GSMRCSConstraints.ttl
+++ b/era-skos/era-skos-GSMRCSConstraints.ttl
@@ -55,7 +55,7 @@ era-gsmrc:00 a skos:Concept;
   skos:notation "Placeholder";
   skos:prefLabel "Placeholder" ;
   rdfs:comment "Placeholder" ;
-  owl:deprecated "false"^^xsd:boolean .
+  .
 
 
 

--- a/era-skos/era-skos-LinesideDistanceIndicationAppearance.ttl
+++ b/era-skos/era-skos-LinesideDistanceIndicationAppearance.ttl
@@ -1,0 +1,63 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix era: <http://data.europa.eu/949/> .
+@prefix era-skos: <http://data.europa.eu/949/concepts/> .
+
+@prefix era-ldia: <http://data.europa.eu/949/concepts/lineside-distance-indication-appearance/> .
+
+
+
+
+
+#################################################################
+#
+#    Concept Schemes
+#
+#################################################################
+
+
+
+
+era-ldia:LinesideDistanceIndicationAppearance a skos:ConceptScheme ; 
+    dct:issued "2024-09-24"^^xsd:date ;
+    cc:license <https://creativecommons.org/licenses/by/4.0/> ;
+    rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
+    rdfs:label "Lineside distance indication appearance"@en ;
+    skos:prefLabel "Lineside distance indication appearance"@en ;
+    dct:title "Concept scheme grouping lineside distance indication appearance"@en .
+
+
+
+#################################################################
+#
+#    Concept instances
+#
+#################################################################
+
+
+## To be generated when values are available under the condition the scheme is relevant.
+## Work to do by the CCS 2024 members"
+
+
+########## Lineside Distance Indication Appearance ##########
+
+era-ldia:00 a skos:Concept;
+  skos:inScheme era-ldia:LinesideDistanceIndicationAppearance; skos:topConceptOf era-ldia:LinesideDistanceIndicationAppearance ; 
+  skos:note "Value collected from TWG RINF CCS 2024 members"@en;
+  skos:notation "Placeholder";
+  skos:prefLabel "Placeholder" ;
+  rdfs:comment "Placeholder" ;
+  owl:deprecated "false"^^xsd:boolean .
+
+
+
+
+
+
+
+

--- a/era-skos/era-skos-LinesideDistanceIndicationAppearance.ttl
+++ b/era-skos/era-skos-LinesideDistanceIndicationAppearance.ttl
@@ -52,7 +52,7 @@ era-ldia:00 a skos:Concept;
   skos:notation "Placeholder";
   skos:prefLabel "Placeholder" ;
   rdfs:comment "Placeholder" ;
-  owl:deprecated "false"^^xsd:boolean .
+   .
 
 
 

--- a/era-skos/era-skos-OnboardErrorCorrections.ttl
+++ b/era-skos/era-skos-OnboardErrorCorrections.ttl
@@ -8,7 +8,7 @@
 @prefix era: <http://data.europa.eu/949/> .
 @prefix era-skos: <http://data.europa.eu/949/concepts/> .
 
-@prefix era-onboardcorrections: <http://data.europa.eu/949/concepts/onboard-corrections/> .
+@prefix era-onboarderrorcorrections: <http://data.europa.eu/949/concepts/error-corrections/> .
 
 
 
@@ -19,14 +19,14 @@
 #################################################################
 
 
-era-onboardcorrections:OnboardCorrections a skos:ConceptScheme ; 
+era-onboarderrorcorrections:OnboardErrorCorrections a skos:ConceptScheme ; 
     dct:issued "2024-05-27"^^xsd:date ;
     dct:modified "2024-09-09"^^xsd:date ;
     era:rinfIndex "1.1.1.3.1.2", "1.2.1.1.1.19" ; 
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
-    skos:prefLabel "Onboard Corrections"@en ;
-    rdfs:label "Onboard Corrections"@en ;
+    skos:prefLabel "Onboard Error Corrections"@en ;
+    rdfs:label "Onboard Error Corrections"@en ;
     dct:title "Concept scheme grouping ETCS, GSM-R and ATO error or enhancement corrections *required* to be implemented by the Onboard."@en .
 
 
@@ -41,166 +41,163 @@ era-onboardcorrections:OnboardCorrections a skos:ConceptScheme ;
 
 ########## Onboard Error Corrections Collections##########
 
-era-onboardcorrections:Error a skos:Collection ;
+era-onboarderrorcorrections:Error a skos:Collection ;
     skos:prefLabel "Error"@en;
     skos:notation "Error"^^xsd:string ;
-    skos:member era-onboardcorrections:887 ;
-    skos:member era-onboardcorrections:940 ;
-    skos:member era-onboardcorrections:994 ;
-    skos:member era-onboardcorrections:1120 ;
-    skos:member era-onboardcorrections:1146 ;
-    skos:member era-onboardcorrections:1166 ;
-    skos:member era-onboardcorrections:1170 ;
-    skos:member era-onboardcorrections:1171 ;
-    skos:member era-onboardcorrections:1240 ;
-    skos:member era-onboardcorrections:1251 ;
-    skos:member era-onboardcorrections:1252 ;
-    skos:member era-onboardcorrections:1259 ;
-    skos:member era-onboardcorrections:1263 ;
-    skos:member era-onboardcorrections:1264 ;
-    skos:member era-onboardcorrections:1267 ;
-    skos:member era-onboardcorrections:1274 ;
-    skos:member era-onboardcorrections:1282 ;
-    skos:member era-onboardcorrections:1288 ;
-    skos:member era-onboardcorrections:1295 ;
-    skos:member era-onboardcorrections:1296 ;
-    skos:member era-onboardcorrections:1300 ;
-    skos:member era-onboardcorrections:1306 ;
-    skos:member era-onboardcorrections:1309 ;
-    skos:member era-onboardcorrections:1310 ;
-    skos:member era-onboardcorrections:1319 ;
-    skos:member era-onboardcorrections:1324 ;
-    skos:member era-onboardcorrections:1325 ;
-    skos:member era-onboardcorrections:1326 ;
-    skos:member era-onboardcorrections:1327 ;
-    skos:member era-onboardcorrections:1332 ;
-    skos:member era-onboardcorrections:1333 ;
-    skos:member era-onboardcorrections:1334 ;
-    skos:member era-onboardcorrections:1335 ;
-    skos:member era-onboardcorrections:1338 ;
-    skos:member era-onboardcorrections:1340 ;
-    skos:member era-onboardcorrections:1342 ;
-    skos:member era-onboardcorrections:1347 ;
-    skos:member era-onboardcorrections:1348 ;
-    skos:member era-onboardcorrections:1349 ;
-    skos:member era-onboardcorrections:1353 ;
-    skos:member era-onboardcorrections:1354 ;
-    skos:member era-onboardcorrections:1358 ;
-    skos:member era-onboardcorrections:1372 ;
-    skos:member era-onboardcorrections:1376 ;
-    skos:member era-onboardcorrections:1377 ;
-    skos:member era-onboardcorrections:1382 ;
-    skos:member era-onboardcorrections:1384 ;
-    skos:member era-onboardcorrections:1386 ;
-    skos:member era-onboardcorrections:1387 ;
-    skos:member era-onboardcorrections:1389 ;
-    skos:member era-onboardcorrections:1396 ;
-    skos:member era-onboardcorrections:1397 ;
-    skos:member era-onboardcorrections:1398 ;
-    skos:member era-onboardcorrections:1408 ;
-    skos:member era-onboardcorrections:1409 ;
-    skos:member era-onboardcorrections:1411 ;
-    skos:member era-onboardcorrections:1414 ;
-    skos:member era-onboardcorrections:1415 ;
-    skos:member era-onboardcorrections:1417 ;
-    skos:member era-onboardcorrections:1418 ;
-    skos:member era-onboardcorrections:1423 ;
-    skos:member era-onboardcorrections:1427 ;
-    skos:member era-onboardcorrections:1428 ;
-    skos:member era-onboardcorrections:1431 ;
-    skos:member era-onboardcorrections:1432 ;
-    skos:member era-onboardcorrections:5037 ;
-    skos:member era-onboardcorrections:5038 ;
-    skos:member era-onboardcorrections:5039 ;
-    skos:member era-onboardcorrections:5040 ;
-    skos:member era-onboardcorrections:5041 ;
-    skos:member era-onboardcorrections:5042 ;
-    skos:member era-onboardcorrections:5049 ;
-    skos:member era-onboardcorrections:5050 ;
-skos:member era-onboardcorrections:1293 ;
-skos:member era-onboardcorrections:1313 ;
-skos:member era-onboardcorrections:1406 ;
-skos:member era-onboardcorrections:1419 ;
-skos:member era-onboardcorrections:1021 ;
-skos:member era-onboardcorrections:1128 ;
-skos:member era-onboardcorrections:1130 ;
-skos:member era-onboardcorrections:1162 ;
-skos:member era-onboardcorrections:1290 ;
-skos:member era-onboardcorrections:1292 ;
-skos:member era-onboardcorrections:1307 ;
-skos:member era-onboardcorrections:1320 ;
-skos:member era-onboardcorrections:1321 ;
-skos:member era-onboardcorrections:1322 ;
-skos:member era-onboardcorrections:1328 ;
-skos:member era-onboardcorrections:1329 ;
-skos:member era-onboardcorrections:1330 ;
-skos:member era-onboardcorrections:1331 ;
-skos:member era-onboardcorrections:1341 ;
-skos:member era-onboardcorrections:1345 ;
-skos:member era-onboardcorrections:1371 ;
-skos:member era-onboardcorrections:1383 ;
-skos:member era-onboardcorrections:1395 ;
-skos:member era-onboardcorrections:1405 ;
-skos:member era-onboardcorrections:1410 ;
-skos:member era-onboardcorrections:1413 ;
-skos:member era-onboardcorrections:1429 ;
-skos:member era-onboardcorrections:5036 ;
-skos:member era-onboardcorrections:5054 ;
-skos:member era-onboardcorrections:5057 ;
-skos:member era-onboardcorrections:1023 ;
-skos:member era-onboardcorrections:1028 ;
-skos:member era-onboardcorrections:1317 ;
-    skos:note "Value introduced in TWG RINF CCS 2024"@en.
+    skos:member era-onboarderrorcorrections:887 ;
+    skos:member era-onboarderrorcorrections:940 ;
+    skos:member era-onboarderrorcorrections:994 ;
+    skos:member era-onboarderrorcorrections:1120 ;
+    skos:member era-onboarderrorcorrections:1146 ;
+    skos:member era-onboarderrorcorrections:1166 ;
+    skos:member era-onboarderrorcorrections:1170 ;
+    skos:member era-onboarderrorcorrections:1171 ;
+    skos:member era-onboarderrorcorrections:1240 ;
+    skos:member era-onboarderrorcorrections:1251 ;
+    skos:member era-onboarderrorcorrections:1252 ;
+    skos:member era-onboarderrorcorrections:1259 ;
+    skos:member era-onboarderrorcorrections:1263 ;
+    skos:member era-onboarderrorcorrections:1264 ;
+    skos:member era-onboarderrorcorrections:1267 ;
+    skos:member era-onboarderrorcorrections:1274 ;
+    skos:member era-onboarderrorcorrections:1282 ;
+    skos:member era-onboarderrorcorrections:1288 ;
+    skos:member era-onboarderrorcorrections:1295 ;
+    skos:member era-onboarderrorcorrections:1296 ;
+    skos:member era-onboarderrorcorrections:1300 ;
+    skos:member era-onboarderrorcorrections:1306 ;
+    skos:member era-onboarderrorcorrections:1310 ;
+    skos:member era-onboarderrorcorrections:1319 ;
+    skos:member era-onboarderrorcorrections:1324 ;
+    skos:member era-onboarderrorcorrections:1325 ;
+    skos:member era-onboarderrorcorrections:1326 ;
+    skos:member era-onboarderrorcorrections:1327 ;
+    skos:member era-onboarderrorcorrections:1332 ;
+    skos:member era-onboarderrorcorrections:1333 ;
+    skos:member era-onboarderrorcorrections:1334 ;
+    skos:member era-onboarderrorcorrections:1335 ;
+    skos:member era-onboarderrorcorrections:1338 ;
+    skos:member era-onboarderrorcorrections:1340 ;
+    skos:member era-onboarderrorcorrections:1342 ;
+    skos:member era-onboarderrorcorrections:1347 ;
+    skos:member era-onboarderrorcorrections:1348 ;
+    skos:member era-onboarderrorcorrections:1349 ;
+    skos:member era-onboarderrorcorrections:1353 ;
+    skos:member era-onboarderrorcorrections:1354 ;
+    skos:member era-onboarderrorcorrections:1358 ;
+    skos:member era-onboarderrorcorrections:1372 ;
+    skos:member era-onboarderrorcorrections:1376 ;
+    skos:member era-onboarderrorcorrections:1377 ;
+    skos:member era-onboarderrorcorrections:1382 ;
+    skos:member era-onboarderrorcorrections:1384 ;
+    skos:member era-onboarderrorcorrections:1386 ;
+    skos:member era-onboarderrorcorrections:1387 ;
+    skos:member era-onboarderrorcorrections:1389 ;
+    skos:member era-onboarderrorcorrections:1396 ;
+    skos:member era-onboarderrorcorrections:1397 ;
+    skos:member era-onboarderrorcorrections:1398 ;
+    skos:member era-onboarderrorcorrections:1408 ;
+    skos:member era-onboarderrorcorrections:1409 ;
+    skos:member era-onboarderrorcorrections:1411 ;
+    skos:member era-onboarderrorcorrections:1414 ;
+    skos:member era-onboarderrorcorrections:1415 ;
+    skos:member era-onboarderrorcorrections:1417 ;
+    skos:member era-onboarderrorcorrections:1418 ;
+    skos:member era-onboarderrorcorrections:1423 ;
+    skos:member era-onboarderrorcorrections:1427 ;
+    skos:member era-onboarderrorcorrections:1428 ;
+    skos:member era-onboarderrorcorrections:1431 ;
+    skos:member era-onboarderrorcorrections:1432 ;
+    skos:member era-onboarderrorcorrections:5037 ;
+    skos:member era-onboarderrorcorrections:5038 ;
+    skos:member era-onboarderrorcorrections:5039 ;
+    skos:member era-onboarderrorcorrections:5040 ;
+    skos:member era-onboarderrorcorrections:5041 ;
+    skos:member era-onboarderrorcorrections:5042 ;
+    skos:member era-onboarderrorcorrections:5049 ;
+    skos:member era-onboarderrorcorrections:5050 ;
+	skos:member era-onboarderrorcorrections:1293 ;
+	skos:member era-onboarderrorcorrections:1313 ;
+	skos:member era-onboarderrorcorrections:1406 ;
+	skos:member era-onboarderrorcorrections:1419 ;
+	skos:member era-onboarderrorcorrections:1021 ;
+	skos:member era-onboarderrorcorrections:1128 ;
+	skos:member era-onboarderrorcorrections:1130 ;
+	skos:member era-onboarderrorcorrections:1162 ;
+	skos:member era-onboarderrorcorrections:1290 ;
+	skos:member era-onboarderrorcorrections:1292 ;
+	skos:member era-onboarderrorcorrections:1307 ;
+    skos:member era-onboarderrorcorrections:1309 ;
+	skos:member era-onboarderrorcorrections:1320 ;
+	skos:member era-onboarderrorcorrections:1321 ;
+	skos:member era-onboarderrorcorrections:1322 ;
+	skos:member era-onboarderrorcorrections:1328 ;
+	skos:member era-onboarderrorcorrections:1329 ;
+	skos:member era-onboarderrorcorrections:1330 ;
+	skos:member era-onboarderrorcorrections:1331 ;
+	skos:member era-onboarderrorcorrections:1341 ;
+	skos:member era-onboarderrorcorrections:1345 ;
+	skos:member era-onboarderrorcorrections:1371 ;
+	skos:member era-onboarderrorcorrections:1383 ;
+	skos:member era-onboarderrorcorrections:1395 ;
+	skos:member era-onboarderrorcorrections:1405 ;
+	skos:member era-onboarderrorcorrections:1410 ;
+	skos:member era-onboarderrorcorrections:1413 ;
+	skos:member era-onboarderrorcorrections:1429 ;
+	skos:member era-onboarderrorcorrections:5036 ;
+	skos:member era-onboarderrorcorrections:5054 ;
+	skos:member era-onboarderrorcorrections:5057 ;
+	skos:member era-onboarderrorcorrections:1023 ;
+	skos:member era-onboarderrorcorrections:1028 ;
+	skos:member era-onboarderrorcorrections:1317 .
 
-era-onboardcorrections:Enhancement a skos:Collection ;
+era-onboarderrorcorrections:Enhancement a skos:Collection ;
     skos:prefLabel "Enhancement"@en;
-    skos:notation "Enhancementr"^^xsd:string ;
-    skos:member era-onboardcorrections:1370 ;
-    
-    skos:note "Value introduced in TWG RINF CCS 2024"@en.
+    skos:notation "Enhancement"^^xsd:string ;
+    skos:member era-onboarderrorcorrections:1370 .
 
 
 ########## Onboard Error Corrections ##########
 
-era-onboardcorrections:887 a skos:Concept ;
+era-onboarderrorcorrections:887 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Position Report Consistency (Follow-up of CR556)"@en;
     skos:prefLabel "CR887"@en ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:940 a skos:Concept ;
+era-onboarderrorcorrections:940 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Minimum Safe Rear End position and position reporting ambiguities"@en ;
     skos:prefLabel "CR940"@en;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:994 a skos:Concept ;
+era-onboarderrorcorrections:994 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Text message start conditions"@en ;
     skos:prefLabel "CR994"@en;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1120 a skos:Concept ;
+era-onboarderrorcorrections:1120 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Uncertain handling of some infill information"@en ;
     skos:prefLabel "CR1120"@en;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1146 a skos:Concept ;
+era-onboarderrorcorrections:1146 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Euroradio HDLC parameters"@en ;
     skos:prefLabel "CR1146"@en;
@@ -208,9 +205,9 @@ era-onboardcorrections:1146 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1166 a skos:Concept ;
+era-onboarderrorcorrections:1166 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Ambiguities in driver acknowledgement requirements"@en ;
     skos:prefLabel "CR1166"@en;
@@ -218,9 +215,9 @@ era-onboardcorrections:1166 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1170 a skos:Concept ;
+era-onboarderrorcorrections:1170 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Ambiguity about the list of traction systems accepted by a diesel engine"@en ;
     skos:prefLabel "CR1170"@en;
@@ -228,9 +225,9 @@ era-onboardcorrections:1170 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1171 a skos:Concept ;
+era-onboarderrorcorrections:1171 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Messages containing shifted location reference when orientation of LRBG is unknown"@en ;
     skos:prefLabel "CR1171"@en;
@@ -238,9 +235,9 @@ era-onboardcorrections:1171 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1240 a skos:Concept ;
+era-onboarderrorcorrections:1240 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "attack from unlinked balise"@en ;
     skos:prefLabel "CR1240"@en;
@@ -248,9 +245,9 @@ era-onboardcorrections:1240 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1251 a skos:Concept ;
+era-onboarderrorcorrections:1251 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Use of inconsistent or incomplete terms for the cooperative MA shortening function"@en ;
     skos:prefLabel "CR1251"@en;
@@ -258,9 +255,9 @@ era-onboardcorrections:1251 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1252 a skos:Concept ;
+era-onboarderrorcorrections:1252 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Ambiguities about release speed and application of A.3.4 in case a train accepts a CES"@en ;
     skos:prefLabel "CR1252"@en;
@@ -268,9 +265,9 @@ era-onboardcorrections:1252 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1259 a skos:Concept ;
+era-onboarderrorcorrections:1259 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Accuracy of distances measured on-board not considered when determining Release Speed from MRSP"@en ;
     skos:prefLabel "CR1259"@en;
@@ -278,9 +275,9 @@ era-onboardcorrections:1259 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1263 a skos:Concept ;
+era-onboarderrorcorrections:1263 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "MA request condition when LoA speed is above MRSP"@en ;
     skos:prefLabel "CR1263"@en;
@@ -288,9 +285,9 @@ era-onboardcorrections:1263 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1264 a skos:Concept ;
+era-onboarderrorcorrections:1264 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-  skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+  skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
   skos:note "Value introduced in TWG RINF CCS 2024"@en;
   skos:definition "Exhaustiveness of the list of actions not to be reverted or executed twice"@en ;
   skos:prefLabel "CR1264"@en;
@@ -298,9 +295,9 @@ era-onboardcorrections:1264 a skos:Concept ;
   dct:status "Presented_to_EC"@en;
   era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1267 a skos:Concept ;
+era-onboarderrorcorrections:1267 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Acquiring the list of available networks whilst communication session is established"@en ;
     skos:prefLabel "CR1267"@en;
@@ -308,9 +305,9 @@ era-onboardcorrections:1267 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1274 a skos:Concept ;
+era-onboarderrorcorrections:1274 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Problem to compare locations in the absence of linking information"@en ;
     skos:prefLabel "CR1274"@en;
@@ -318,9 +315,9 @@ era-onboardcorrections:1274 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1282 a skos:Concept ;
+era-onboarderrorcorrections:1282 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Subset-044 chapter on safety is inconsistent with Subset-026 regarding handling of EOLM info"@en ;
     skos:prefLabel "CR1282"@en;
@@ -328,9 +325,9 @@ era-onboardcorrections:1282 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1288 a skos:Concept ;
+era-onboarderrorcorrections:1288 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Shortcomings due to specific locations temporarily considered as the EOA/SvL"@en ;
     skos:prefLabel "CR1288"@en;
@@ -338,9 +335,9 @@ era-onboardcorrections:1288 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1295 a skos:Concept ;
+era-onboarderrorcorrections:1295 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "TSR inhibition in SB and SR modes"@en ;
     skos:prefLabel "CR1295"@en;
@@ -348,9 +345,9 @@ era-onboardcorrections:1295 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1296 a skos:Concept ;
+era-onboarderrorcorrections:1296 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Wrong assumption in on-board calculation of release speed"@en ;
     skos:prefLabel "CR1296"@en;
@@ -358,9 +355,9 @@ era-onboardcorrections:1296 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1300 a skos:Concept ;
+era-onboarderrorcorrections:1300 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Follow-up to CR977"@en ;
     skos:prefLabel "CR1300"@en;
@@ -368,9 +365,9 @@ era-onboardcorrections:1300 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1306 a skos:Concept ;
+era-onboarderrorcorrections:1306 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Undefined sequence of actions following the filtering of trackside information as per SRS 4.8"@en ;
     skos:prefLabel "CR1306"@en;
@@ -378,19 +375,18 @@ era-onboardcorrections:1306 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1309 a skos:Concept ;
+era-onboarderrorcorrections:1309 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Enhancement of HDLC to handle retransmission of SABME message"@en ;
-    skos:prefLabel "CR1309"@en;
-    
+    skos:prefLabel "CR1309"@en;   
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1310 a skos:Concept ;
+era-onboarderrorcorrections:1310 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "DNS/ETCS on-board communication handling"@en ;
     skos:prefLabel "CR1310"@en;
@@ -398,9 +394,9 @@ era-onboardcorrections:1310 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:1311 a skos:Concept ;
+era-onboarderrorcorrections:1311 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Inconsistency in Subset-026 regarding the relevance of Q_SLEEPSESSION for session termination orders"@en ;
     skos:prefLabel "CR1311"@en;
@@ -408,9 +404,9 @@ era-onboardcorrections:1311 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1312 a skos:Concept ;
+era-onboarderrorcorrections:1312 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Undefined sequence of actions following the filtering of trackside information as per SRS 4.8 (part 2)"@en ;
     skos:prefLabel "CR1312"@en;
@@ -418,9 +414,9 @@ era-onboardcorrections:1312 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1318 a skos:Concept ;
+era-onboarderrorcorrections:1318 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Ambiguity in determination of location accuracy"@en ;
     skos:prefLabel "CR1318"@en;
@@ -428,9 +424,9 @@ era-onboardcorrections:1318 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1319 a skos:Concept ;
+era-onboarderrorcorrections:1319 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Support of different transmission speeds (ETCS data)"@en ;
     skos:prefLabel "CR1319"@en;
@@ -438,9 +434,9 @@ era-onboardcorrections:1319 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:1324 a skos:Concept ;
+era-onboarderrorcorrections:1324 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Problems with applying SRS clauses related to the supervision of an unprotected LX"@en ;
     skos:prefLabel "CR1324"@en;
@@ -448,9 +444,9 @@ era-onboardcorrections:1324 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1325 a skos:Concept ;
+era-onboarderrorcorrections:1325 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Rejection of safety relevant information due to pending acknowledgement of validated train data"@en ;
     skos:prefLabel "CR1325"@en;
@@ -458,9 +454,9 @@ era-onboardcorrections:1325 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1326 a skos:Concept ;
+era-onboarderrorcorrections:1326 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Display conflict in area D of ETCS DMI"@en ;
     skos:prefLabel "CR1326"@en;
@@ -468,9 +464,9 @@ era-onboardcorrections:1326 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1327 a skos:Concept ;
+era-onboarderrorcorrections:1327 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Reset of confidence interval"@en ;
     skos:prefLabel "CR1327"@en;
@@ -478,9 +474,9 @@ era-onboardcorrections:1327 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1332 a skos:Concept ;
+era-onboarderrorcorrections:1332 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Release speed calculated on-board while a LTO in rear of the EOA is stored on-board"@en ;
     skos:prefLabel "CR1332"@en;
@@ -488,9 +484,9 @@ era-onboardcorrections:1332 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1333 a skos:Concept ;
+era-onboarderrorcorrections:1333 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Subset-026 clause 3.12.4.4 does not cover the case of reception of a new MA without mode profile"@en ;
     skos:prefLabel "CR1333"@en;
@@ -498,20 +494,20 @@ era-onboardcorrections:1333 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1334 a skos:Concept ;
+era-onboarderrorcorrections:1334 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Ambiguity regarding the mode and level end events for the display of a text message"@en ;
     skos:prefLabel "CR1334"@en;
     
     dct:status "Presented_to_EC"@en;
-    dct:replaces era-onboardcorrections:1023 ;
+    dct:replaces era-onboarderrorcorrections:1023 ;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1335 a skos:Concept ;
+era-onboarderrorcorrections:1335 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Train categories B3 on B2"@en ;
     skos:prefLabel "CR1335"@en;
@@ -520,9 +516,9 @@ era-onboardcorrections:1335 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1338 a skos:Concept ;
+era-onboarderrorcorrections:1338 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Issues regarding the forwarding of data to a National System"@en ;
     skos:prefLabel "CR1338"@en;
@@ -530,9 +526,9 @@ era-onboardcorrections:1338 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1340 a skos:Concept ;
+era-onboarderrorcorrections:1340 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Maximum D_LRBG exceeded"@en ;
     skos:prefLabel "CR1340"@en;
@@ -540,9 +536,9 @@ era-onboardcorrections:1340 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1342 a skos:Concept ;
+era-onboarderrorcorrections:1342 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Unpractical coexistence between level 2 and level 3"@en ;
     skos:prefLabel "CR1342"@en;
@@ -550,9 +546,9 @@ era-onboardcorrections:1342 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:1347 a skos:Concept ;
+era-onboarderrorcorrections:1347 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Unclear specification of 'balise detection degradation' function"@en ;
     skos:prefLabel "CR1347"@en;
@@ -560,9 +556,9 @@ era-onboardcorrections:1347 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1348 a skos:Concept ;
+era-onboarderrorcorrections:1348 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "No change of speed and distance monitoring supervision status"@en ;
     skos:prefLabel "CR1348"@en;
@@ -570,9 +566,9 @@ era-onboardcorrections:1348 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1349 a skos:Concept ;
+era-onboarderrorcorrections:1349 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Ambiguity in display of override status"@en ;
     skos:prefLabel "CR1349"@en;
@@ -580,9 +576,9 @@ era-onboardcorrections:1349 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1353 a skos:Concept ;
+era-onboarderrorcorrections:1353 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Undefined term 'the level is configured on-board'"@en ;
     skos:prefLabel "CR1353"@en;
@@ -590,9 +586,9 @@ era-onboardcorrections:1353 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1354 a skos:Concept ;
+era-onboarderrorcorrections:1354 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Misleading term 'the expected balise group is found'"@en ;
     skos:prefLabel "CR1354"@en;
@@ -600,9 +596,9 @@ era-onboardcorrections:1354 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1358 a skos:Concept ;
+era-onboarderrorcorrections:1358 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Missing confidence interval to supervise the SR distance"@en ;
     skos:prefLabel "CR1358"@en;
@@ -610,18 +606,18 @@ era-onboardcorrections:1358 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1370 a skos:Concept ;
+era-onboarderrorcorrections:1370 a skos:Concept ;
     skos:note "Value introduced in TWG RINF CCS 2024. Is not a mandatory CR but replaces one."@en;
     skos:definition "Relocation without linking"@en ;
     skos:prefLabel "CR1370"@en;
      
     dct:status "Presented_to_EC"@en;
-    dct:replaces era-onboardcorrections:1406 ;
+    dct:replaces era-onboarderrorcorrections:1406 ;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1372 a skos:Concept ;
+era-onboarderrorcorrections:1372 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Uniqueness of BG IDs vs. VBC function"@en ;
     skos:prefLabel "CR1372"@en;
@@ -629,9 +625,9 @@ era-onboardcorrections:1372 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1376 a skos:Concept ;
+era-onboarderrorcorrections:1376 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "List of available levels after transition announcement"@en ;
     skos:prefLabel "CR1376"@en;
@@ -639,9 +635,9 @@ era-onboardcorrections:1376 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1377 a skos:Concept ;
+era-onboarderrorcorrections:1377 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Handling of an RBC transition order for a different RBC during an on-going RBC/RBC handover"@en ;
     skos:prefLabel "CR1377"@en;
@@ -649,9 +645,9 @@ era-onboardcorrections:1377 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1382 a skos:Concept ;
+era-onboarderrorcorrections:1382 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Repositioning information in a BG containing infill MA"@en ;
     skos:prefLabel "CR1382"@en;
@@ -659,9 +655,9 @@ era-onboardcorrections:1382 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1384 a skos:Concept ;
+era-onboarderrorcorrections:1384 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Issues when the on-board supervises an MA with release speed"@en ;
     skos:prefLabel "CR1384"@en;
@@ -669,9 +665,9 @@ era-onboardcorrections:1384 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1386 a skos:Concept ;
+era-onboarderrorcorrections:1386 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Inconsistent speed and distance monitoring transition when the train speed is equal to the release or target speed"@en ;
     skos:prefLabel "CR1386"@en;
@@ -679,9 +675,9 @@ era-onboardcorrections:1386 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1387 a skos:Concept ;
+era-onboarderrorcorrections:1387 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Inconsistency regarding the way to send the Train Data during SoM"@en ;
     skos:prefLabel "CR1387"@en;
@@ -689,9 +685,9 @@ era-onboardcorrections:1387 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1389 a skos:Concept ;
+era-onboarderrorcorrections:1389 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Reaction when CI of the odometry is exceeding the accuracy requirement of 5m+5% (SS-41)"@en ;
     skos:prefLabel "CR1389"@en;
@@ -699,9 +695,9 @@ era-onboardcorrections:1389 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1396 a skos:Concept ;
+era-onboarderrorcorrections:1396 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Resolution of the VBC validity period"@en ;
     skos:prefLabel "CR1396"@en;
@@ -709,9 +705,9 @@ era-onboardcorrections:1396 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1397 a skos:Concept ;
+era-onboarderrorcorrections:1397 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Sorting speed based upon mass per unit length"@en ;
     skos:prefLabel "CR1397"@en;
@@ -719,9 +715,9 @@ era-onboardcorrections:1397 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1398 a skos:Concept ;
+era-onboarderrorcorrections:1398 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Risk for deadlock in the clock offset update procedure in SUBSET-098"@en ;
     skos:prefLabel "CR1398"@en;
@@ -729,9 +725,9 @@ era-onboardcorrections:1398 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1408 a skos:Concept ;
+era-onboarderrorcorrections:1408 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Train data before SoM position report"@en ;
     skos:prefLabel "CR1408"@en;
@@ -739,9 +735,9 @@ era-onboardcorrections:1408 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1409 a skos:Concept ;
+era-onboarderrorcorrections:1409 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "'Infinite' information in RRI"@en ;
     skos:prefLabel "CR1409"@en;
@@ -749,9 +745,9 @@ era-onboardcorrections:1409 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1411 a skos:Concept ;
+era-onboarderrorcorrections:1411 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Inconsistency section timer expires"@en ;
     skos:prefLabel "CR1411"@en;
@@ -759,9 +755,9 @@ era-onboardcorrections:1411 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1414 a skos:Concept ;
+era-onboarderrorcorrections:1414 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Traction cut-off ambiguity"@en ;
     skos:prefLabel "CR1414"@en;
@@ -769,9 +765,9 @@ era-onboardcorrections:1414 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1415 a skos:Concept ;
+era-onboarderrorcorrections:1415 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "KMS protocol issue"@en ;
     skos:prefLabel "CR1415"@en;
@@ -779,9 +775,9 @@ era-onboardcorrections:1415 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:1417 a skos:Concept ;
+era-onboarderrorcorrections:1417 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "TCP connection loss detection"@en ;
     skos:prefLabel "CR1417"@en;
@@ -789,9 +785,9 @@ era-onboardcorrections:1417 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:1418 a skos:Concept ;
+era-onboarderrorcorrections:1418 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Unclear management of MA section timers"@en ;
     skos:prefLabel "CR1418"@en;
@@ -799,9 +795,9 @@ era-onboardcorrections:1418 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1423 a skos:Concept ;
+era-onboarderrorcorrections:1423 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Unacceptable risks with High Priority Data"@en ;
     skos:prefLabel "CR1423"@en;
@@ -809,9 +805,9 @@ era-onboardcorrections:1423 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1427 a skos:Concept ;
+era-onboarderrorcorrections:1427 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Radio hole functionality shortcomings"@en ;
     skos:prefLabel "CR1427"@en;
@@ -819,9 +815,9 @@ era-onboardcorrections:1427 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1428 a skos:Concept ;
+era-onboarderrorcorrections:1428 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Alignment of KM related variables and messages"@en ;
     skos:prefLabel "CR1428"@en;
@@ -829,9 +825,9 @@ era-onboardcorrections:1428 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:1431 a skos:Concept ;
+era-onboarderrorcorrections:1431 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Unclear management of the time stamp of the SH request included in the SH Authorised message"@en ;
     skos:prefLabel "CR1431"@en;
@@ -839,9 +835,9 @@ era-onboardcorrections:1431 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:1432 a skos:Concept ;
+era-onboarderrorcorrections:1432 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Wrong value of T_traction in on-board calculation of release speed"@en ;
     skos:prefLabel "CR1432"@en;
@@ -849,9 +845,9 @@ era-onboardcorrections:1432 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1"@en.
 
-era-onboardcorrections:5037 a skos:Concept ;
+era-onboarderrorcorrections:5037 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Use of High Priority call GID 200"@en;
     skos:prefLabel "CR5037"@en;
@@ -859,9 +855,9 @@ era-onboardcorrections:5037 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"RMR B1R1"@en.
 
-era-onboardcorrections:5038 a skos:Concept ;
+era-onboarderrorcorrections:5038 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "FN Numbers registration/deregistration"@en;
     skos:prefLabel "CR5038"@en;
@@ -869,9 +865,9 @@ era-onboardcorrections:5038 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"RMR B1R1"@en.
 
-era-onboardcorrections:5039 a skos:Concept ;
+era-onboarderrorcorrections:5039 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Call arbitration table for cab radios"@en;
     skos:prefLabel "CR5039"@en;
@@ -879,9 +875,9 @@ era-onboardcorrections:5039 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"RMR B1R1"@en.
 
-era-onboardcorrections:5040 a skos:Concept ;
+era-onboarderrorcorrections:5040 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "MI/M misalignments in the specifications"@en;
     skos:prefLabel "CR5040"@en;
@@ -889,9 +885,9 @@ era-onboardcorrections:5040 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:5041 a skos:Concept ;
+era-onboarderrorcorrections:5041 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Radio characteristics for EDOR"@en;
     skos:prefLabel "CR5041"@en;
@@ -899,9 +895,9 @@ era-onboardcorrections:5041 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"RMR B1R1"@en.
 
-era-onboardcorrections:5042 a skos:Concept ;
+era-onboarderrorcorrections:5042 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Handling of temporary functional numbers during cab radio power on"@en;
     skos:prefLabel "CR5042"@en;
@@ -909,9 +905,9 @@ era-onboardcorrections:5042 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"RMR B1R1"@en.
 
-era-onboardcorrections:5049 a skos:Concept ;
+era-onboarderrorcorrections:5049 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "PPP Activation timeout is not defined and ETCS DNS query repetition is missing"@en ;
     skos:prefLabel "CR5049"@en;
@@ -919,9 +915,9 @@ era-onboardcorrections:5049 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline "ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:5050 a skos:Concept ;
+era-onboarderrorcorrections:5050 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Errors & inconsistencies found in FFFIS for SIM card"@en;
     skos:prefLabel "CR5050"@en;
@@ -929,294 +925,294 @@ era-onboardcorrections:5050 a skos:Concept ;
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"RMR B1R1"@en.
 
-era-onboardcorrections:1293 a skos:Concept ;
+era-onboarderrorcorrections:1293 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Ambiguity about clauses to be applied to messages containing high priority data"@en ;
     skos:prefLabel "CR1293"@en;
     
     dct:status "Superseded"@en;
-    dct:isReplacedBy era-onboardcorrections:1423 ;
+    dct:isReplacedBy era-onboarderrorcorrections:1423 ;
     era:targetBaseline "Part of BCA2018 (ETCS B4)"@en.
 
-era-onboardcorrections:1313 a skos:Concept ;
+era-onboarderrorcorrections:1313 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Unclear management of train position status on passing unlinked BG(s)"@en ;
     skos:prefLabel "CR1313"@en;
     
     dct:status "Superseded"@en;
-    dct:isReplacedBy era-onboardcorrections:1370 ;
+    dct:isReplacedBy era-onboarderrorcorrections:1370 ;
     era:targetBaseline "Part of BCA2018 (ETCS B4)"@en.
 
-era-onboardcorrections:1406 a skos:Concept ;
+era-onboarderrorcorrections:1406 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Handling of location based information referred to different BGs when the information cannot be relocated to the same BG"@en ;
     skos:prefLabel "CR1406"@en;
     
     dct:status "Superseded"@en;
-    dct:isReplacedBy era-onboardcorrections:1370 ;
+    dct:isReplacedBy era-onboarderrorcorrections:1370 ;
     era:targetBaseline "Part of BCA2018 (ETCS B4)"@en.
 
-era-onboardcorrections:1419 a skos:Concept ;
+era-onboarderrorcorrections:1419 a skos:Concept ;
     era:preventsService "true"^^xsd:boolean ; 
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:note "Value introduced in TWG RINF CCS 2024"@en;
     skos:definition "Undue extension of MA via a mode profile for further location"@en ;
     skos:prefLabel "CR1419"@en;
     
     dct:status "Superseded"@en;
-    dct:isReplacedBy era-onboardcorrections:1288 ;
+    dct:isReplacedBy era-onboarderrorcorrections:1288 ;
     era:targetBaseline "Part of BCA2018 (ETCS B4)"@en.
 
 
 
 ########## Onboard Error Corrections without preventing service ##########
 
-era-onboardcorrections:1021 a skos:Concept ;
+era-onboarderrorcorrections:1021 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Brake command revocation/acknowledgement issues"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1128 a skos:Concept ;
+era-onboarderrorcorrections:1128 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Passing Level 0 / Level NTC border in PT mode"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1130 a skos:Concept ;
+era-onboarderrorcorrections:1130 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Contradiction between SRS 3.12.2.8 (Trip at route unsuitability) and SRS 3.13.10.2.6/7"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1162 a skos:Concept ;
+era-onboarderrorcorrections:1162 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Functions that could use linking information in modes without linking consistency check"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1290 a skos:Concept ;
+era-onboarderrorcorrections:1290 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "The acquisition of the train running number via the train interface is not covered by Subset-034"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1292 a skos:Concept ;
+era-onboarderrorcorrections:1292 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "RAMS related supervision is missing in the active function table"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1304 a skos:Concept ;
+era-onboarderrorcorrections:1304 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Missing Level 3 safety requirements"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1307 a skos:Concept ;
+era-onboarderrorcorrections:1307 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Miscellaneous editorial findings in B3R2"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1320 a skos:Concept ;
+era-onboarderrorcorrections:1320 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "MA request issues"@en;
     
     dct:status "Presented_to_EC"@en;
-    dct:replaces era-onboardcorrections:1028 ;
+    dct:replaces era-onboarderrorcorrections:1028 ;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1321 a skos:Concept ;
+era-onboarderrorcorrections:1321 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Transition PS-SF inconsistent with other slave modes"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1322 a skos:Concept ;
+era-onboarderrorcorrections:1322 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Unavailability of Referenced Adaptation Layer Entity Conformance Requirements"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1328 a skos:Concept ;
+era-onboarderrorcorrections:1328 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Unclear expected on-board behaviour in case a change of mode has to be reported while the communication session with the RBC is under termination"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1329 a skos:Concept ;
+era-onboarderrorcorrections:1329 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Issues with SRS section 3.16 “Data Consistency”"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1330 a skos:Concept ;
+era-onboarderrorcorrections:1330 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "The permitted speed to display can be lower than the speed of the MRDT"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1331 a skos:Concept ;
+era-onboarderrorcorrections:1331 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Inconsistent DRIVER_ID specification in the SUBSET-027"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1341 a skos:Concept ;
+era-onboarderrorcorrections:1341 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Inconsistent use of the term 'reverse movement'"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1345 a skos:Concept ;
+era-onboarderrorcorrections:1345 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Missing requirement for CMD function"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1371 a skos:Concept ;
+era-onboarderrorcorrections:1371 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Missing PS IP network protocol conformance requirements"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1383 a skos:Concept ;
+era-onboarderrorcorrections:1383 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Wrong formulation of non-leading input information from rolling stock"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1395 a skos:Concept ;
+era-onboarderrorcorrections:1395 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Unclear on-board handling of a Packet 76 in an X=1 message"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1405 a skos:Concept ;
+era-onboarderrorcorrections:1405 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Error in the applicability conditions of [TS 27.010]"@en;
     
     dct:status "GSM"@en;
    era:targetBaseline "-R	Presented_to_EC	ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:1410 a skos:Concept ;
+era-onboarderrorcorrections:1410 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Sending static information to a vehicle regarding area in advance of an RBC-border"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1413 a skos:Concept ;
+era-onboarderrorcorrections:1413 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Speed limit for mode change OS, SH, LS"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1"@en.
 
-era-onboardcorrections:1429 a skos:Concept ;
+era-onboarderrorcorrections:1429 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Harmonisation of the FQDN"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:5036 a skos:Concept ;
+era-onboarderrorcorrections:5036 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Support of different transmission speeds (voice)"@en;
     
     dct:status "R"@en;
     era:targetBaseline	"Presented_to_EC	RMR B1R1"@en.
 
-era-onboardcorrections:5054 a skos:Concept ;
+era-onboarderrorcorrections:5054 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "RBC number format defined on FFFIS for Euroradio needs to be aligned with Subset-054"@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:5057 a skos:Concept ;
+era-onboarderrorcorrections:5057 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Not possible to support Mobile Class A for EDOR, update of references, chapters numbering and other misalignments."@en;
     
     dct:status "Presented_to_EC"@en;
     era:targetBaseline	"ETCS B4R1 & RMR B1R1"@en.
 
-era-onboardcorrections:1023 a skos:Concept ;
+era-onboarderrorcorrections:1023 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "Conditions for start/end message"@en;
     
     dct:status "Superseded"@en;
-    dct:isReplacedBy era-onboardcorrections:1334 ;
+    dct:isReplacedBy era-onboarderrorcorrections:1334 ;
     era:targetBaseline	"part of BCA2018 (ETCS B4)"@en.
 
-era-onboardcorrections:1028 a skos:Concept ;
+era-onboarderrorcorrections:1028 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "End condition for sending MA requests"@en;
     
     dct:status "Superseded"@en;
-    dct:isReplacedBy era-onboardcorrections:1320 ;
+    dct:isReplacedBy era-onboarderrorcorrections:1320 ;
     era:targetBaseline	"part of BCA2018 (ETCS B4)"@en.
 
-era-onboardcorrections:1317 a skos:Concept ;
+era-onboarderrorcorrections:1317 a skos:Concept ;
     era:preventsService "false"^^xsd:boolean ;
-    skos:inScheme era-onboardcorrections:OnboardCorrections; skos:topConceptOf era-onboardcorrections:OnboardCorrections ;
+    skos:inScheme era-onboarderrorcorrections:OnboardErrorCorrections; skos:topConceptOf era-onboarderrorcorrections:OnboardErrorCorrections ;
     skos:definition "No explicit handling of loop message consistency error"@en;
     
     dct:status "Superseded"@en;
-    dct:isReplacedBy era-onboardcorrections:1329 ;
+    dct:isReplacedBy era-onboarderrorcorrections:1329 ;
     era:targetBaseline	"part of BCA2018 (ETCS B4)"@en.

--- a/era-skos/era-skos-OperationalRegimeTypes.ttl
+++ b/era-skos/era-skos-OperationalRegimeTypes.ttl
@@ -52,7 +52,7 @@ era-regtype:00 a skos:Concept;
   skos:notation "Placeholder";
   skos:prefLabel "Placeholder" ;
   rdfs:comment "Placeholder" ;
-  owl:deprecated "false"^^xsd:boolean .
+   .
 
 
 

--- a/era-skos/era-skos-OperationalRegimeTypes.ttl
+++ b/era-skos/era-skos-OperationalRegimeTypes.ttl
@@ -1,0 +1,63 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix era: <http://data.europa.eu/949/> .
+@prefix era-skos: <http://data.europa.eu/949/concepts/> .
+
+@prefix era-regtype: <http://data.europa.eu/949/concepts/operational-regime-types/> .
+
+
+
+
+
+#################################################################
+#
+#    Concept Schemes
+#
+#################################################################
+
+
+
+
+era-regtype:OperationalRegimeTypes a skos:ConceptScheme ; 
+    dct:issued "2024-09-24"^^xsd:date ;
+    cc:license <https://creativecommons.org/licenses/by/4.0/> ;
+    rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
+    rdfs:label "Operational regime types"@en ;
+    skos:prefLabel "Operational regime types"@en ;
+    dct:title "Concept scheme grouping Operational regime types"@en .
+
+
+
+#################################################################
+#
+#    Concept instances
+#
+#################################################################
+
+
+## To be generated when values are available under the condition the scheme is relevant.
+## Work to do by the CCS 2024 members"
+
+
+########## Operational Regime Types ##########
+
+era-regtype:00 a skos:Concept;
+  skos:inScheme era-regtype:OperationalRegimeTypes; skos:topConceptOf era-regtype:OperationalRegimeTypes ; 
+  skos:note "Value collected from TWG RINF CCS 2024 members"@en;
+  skos:notation "Placeholder";
+  skos:prefLabel "Placeholder" ;
+  rdfs:comment "Placeholder" ;
+  owl:deprecated "false"^^xsd:boolean .
+
+
+
+
+
+
+
+

--- a/era-skos/era-skos-OrgRoles.ttl
+++ b/era-skos/era-skos-OrgRoles.ttl
@@ -12,6 +12,7 @@
 era-organisation-roles:OrgRoles a skos:ConceptScheme ;
 	dct:issued "2024-07-31"^^xsd:date ;
     dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2024-10-07"^^xsd:date ;
    	cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Organisation roles used in different domains at ERA"@en ;
     rdfs:label "Organisation roles"@en ;
@@ -19,9 +20,11 @@ era-organisation-roles:OrgRoles a skos:ConceptScheme ;
     dct:title "Concept scheme grouping roles held by organisations"@en ;
 	skos:hasTopConcept era-organisation-roles:IM, era-organisation-roles:RU , era-organisation-roles:Owner,
 	era-organisation-roles:Keeper, era-organisation-roles:Applicant, era-organisation-roles:ECM, era-organisation-roles:Manufacturer,
-    era-organisation-roles:NSA ;	
+    era-organisation-roles:NSA, era-organisation-roles:MWS, era-organisation-roles:NIB, era-organisation-roles:CAB, era-organisation-roles:AB,
+    era-organisation-roles:NAB, era-organisation-roles:CB, era-organisation-roles:TDGCA, era-organisation-roles:RB,
+    era-organisation-roles:SB 	;	
 		.
-
+    
 
 era-organisation-roles:IM a skos:Concept ;
         skos:inScheme era-organisation-roles:OrgRoles ;
@@ -29,10 +32,25 @@ era-organisation-roles:IM a skos:Concept ;
 		skos:altLabel "IM"@en ; 
         skos:notation "IM"^^xsd:string ;
 		skos:topConceptOf era-organisation-roles:OrgRoles ; 
+        skos:narrower era-organisation-roles:IM-1, era-organisation-roles:IM-2 ;
 		skos:definition """ A body or firm responsible for the operation, maintenance and renewal of railway infrastructure on a network, as well as responsible for participating in its development as determined by the Member State within the framework of its general policy on development and financing of infrastructure"""@en ;
 		dct:source <http://data.europa.eu/eli/dir/2012/34/2019-01-01> ; 
 		.
-		
+era-organisation-roles:IM-1 a skos:Concept ;
+		skos:prefLabel "Infrastructure manager operating railway lines (including sidings and stations operations) "@en ;
+        skos:altLabel "IM-1"@en ; 
+        skos:notation "IM-1"^^xsd:string ;
+		skos:broader era-organisation-roles:IM ;  
+		skos:inScheme era-organisation-roles: ; 
+        .		
+
+era-organisation-roles:IM-2 a skos:Concept ;
+		skos:prefLabel "Infrastructure manager operating terminals (including sidings and stations operations) "@en ;
+        skos:altLabel "IM-2"@en ; 
+        skos:notation "IM-2"^^xsd:string ;
+		skos:broader era-organisation-roles:IM ;  
+		skos:inScheme era-organisation-roles: ; 
+        .			
 
 era-organisation-roles:RU a skos:Concept ;
 		skos:prefLabel "Railway Undertaking"@en ;
@@ -40,12 +58,130 @@ era-organisation-roles:RU a skos:Concept ;
         skos:notation "RU"^^xsd:string ;
 		skos:inScheme era-organisation-roles:OrgRoles ;
 		skos:topConceptOf era-organisation-roles:OrgRoles ;
+        skos:narrower era-organisation-roles:RU-1, era-organisation-roles:RU-2, era-organisation-roles:RU-3, era-organisation-roles:RU-4, era-organisation-roles:RU-5 ; 
 		skos:definition """ 
 		 Any public or private undertaking licensed according to this Directive, the principal business of which is to provide services for the transport of goods and/or passengers by rail with a requirement that the undertaking ensure traction; this also includes undertakings which provide traction only
 		 """@en ;
 		dct:source <http://data.europa.eu/eli/dir/2012/34/2019-01-01> ;
 		.
-		
+era-organisation-roles:AB  a skos:Concept; 
+			skos:inScheme era-organisation-roles: ;
+			skos:prefLabel "Assessment body"@en; 
+			skos:topConceptOf era-organisation-roles: ;
+			skos:definition "An independent and competent external or internal individual, organisation or entity which undertakes investigation to provide a judgement, based on evidence, of the suitability of a system to fulfil its safety requirements"@en ;
+			dct:source <http://data.europa.eu/eli/reg_impl/2013/402/2015-08-03> ;
+			skos:altLabel "AB"@en;
+            skos:notation "AB"^^xsd:string ;
+.
+
+era-organisation-roles:RB  a skos:Concept; 
+			skos:inScheme era-organisation-roles: ;
+			skos:prefLabel "Representative body"@en; 
+			skos:topConceptOf era-organisation-roles: ;
+			skos:altLabel "RB"@en;
+            skos:notation "RB"^^xsd:string .
+
+era-organisation-roles:CAB  a skos:Concept; 
+			skos:inScheme era-organisation-roles: ;
+			skos:prefLabel "Conformity assessment body"@en; 
+			skos:topConceptOf era-organisation-roles: ;
+			skos:scopeNote " as defined in Article 2 of Regulation (EC) No 765/2008"@en ;
+			skos:definition "A body that performs conformity assessment activities including calibration, testing, certification and inspection"@en ;
+			dct:source <http://data.europa.eu/eli/reg_impl/2013/402/2015-08-03>,  <http://data.europa.eu/eli/reg/2008/765/oj>, <http://data.europa.eu/eli/reg/2008/765/2021-07-16> ;
+			skos:altLabel "CAB"@en;
+            skos:notation "CAB"^^xsd:string ;
+.
+
+era-organisation-roles:NAB  a skos:Concept; 
+			skos:inScheme era-organisation-roles: ;
+			skos:prefLabel "National accreditation body"@en; 
+			skos:topConceptOf era-organisation-roles: ;
+			skos:scopeNote " as defined in Article 2 of Regulation (EC) No 765/2008"@en ;
+			skos:definition "The sole body in a Member State that performs accreditation with authority derived from the State"@en ;
+			dct:source <http://data.europa.eu/eli/reg/2008/765/oj> ;
+			skos:altLabel "NAB"@en;
+            skos:notation "NAB"^^xsd:string .
+
+era-organisation-roles:CB  a skos:Concept; 
+			skos:inScheme era-organisation-roles: ;
+			skos:prefLabel "Certification body"@en; 
+			skos:topConceptOf era-organisation-roles: ;
+			skos:scopeNote " as defined in Article 3 of Regulation (EU) No 445/2011"@en ;
+			skos:definition "a body, designated in accordance with Article 10 of (EU) No 445/2011, responsible for the certification of entities in charge of maintenance, on the basis of the criteria in Annex II of (EU) No 445/2011"@en ;
+			dct:source <https://eur-lex.europa.eu/eli/reg/2011/445/oj> ;
+			skos:altLabel "CB"@en;
+            skos:notation "CB"^^xsd:string ;
+.
+
+era-organisation-roles:TDGCA  a skos:Concept; 
+			skos:inScheme era-organisation-roles: ;
+			skos:prefLabel "Transport of Dangerous Goods Competent Authority"@en; 
+			skos:topConceptOf era-organisation-roles: ;
+			skos:scopeNote " as referred to in section 1.8.5.1 of RID"@en ;
+            skos:notation "TDG CA"^^xsd:string ;
+			skos:altLabel "TDG CA"@en;
+			.
+
+era-organisation-roles:SB a skos:Concept; 
+			skos:inScheme era-organisation-roles: ;
+			skos:prefLabel "Sector organisation"@en; 
+			skos:topConceptOf era-organisation-roles: ;
+			skos:altLabel "sector body"@en;
+            skos:altLabel "SB"@en;
+            skos:notation "SB"^^xsd:string ;
+			.
+
+era-organisation-roles:RU-1 a skos:Concept ;
+		skos:prefLabel "Railway Undertaking operating passenger trains "@en ;
+		skos:broader era-organisation-roles:RU ;  
+		skos:inScheme era-organisation-roles: ; 
+        skos:altLabel "RU-1"@en;
+        skos:notation "RU-1"^^xsd:string ;
+        .
+
+era-organisation-roles:RU-2 a skos:Concept ;
+		skos:prefLabel "Railway Undertaking operating high speed passenger trains "@en ;
+		skos:broader era-organisation-roles:RU ;  
+		skos:inScheme era-organisation-roles: ; 
+        skos:altLabel "RU-2"@en;
+        skos:notation "RU-2"^^xsd:string ;
+        .
+
+era-organisation-roles:RU-3 a skos:Concept ;
+		skos:prefLabel "Railway Undertaking operating freight trains "@en ;
+		skos:broader era-organisation-roles:RU ;  
+		skos:inScheme era-organisation-roles: ; 
+        skos:altLabel "RU-3"@en;
+        skos:notation "RU-3"^^xsd:string ;
+        .
+
+era-organisation-roles:RU-4 a skos:Concept ;
+		skos:prefLabel "Railway Undertaking operating dangerous goods freight trains"@en ;
+		skos:broader era-organisation-roles:RU ;  
+		skos:inScheme era-organisation-roles: ; 
+        skos:altLabel "RU-4"@en;
+        skos:notation "RU-4"^^xsd:string ;
+        .
+
+era-organisation-roles:RU-5 a skos:Concept ;
+		skos:prefLabel "Railway Undertaking operating terminals"@en ;
+		skos:broader era-organisation-roles:RU ;  
+		skos:inScheme era-organisation-roles: ; 
+        skos:altLabel "RU-5"@en;
+        skos:notation "RU-5"^^xsd:string ;
+        .
+
+era-organisation-roles:NIB a skos:Concept; 
+		skos:prefLabel "National investigating body"@en ; 
+		skos:inScheme era-organisation-roles: ;
+		skos:altLabel "NIB"@en;
+        skos:notation "NIB"^^xsd:string ;
+		skos:topConceptOf era-organisation-roles: ;
+		skos:scopeNote "National investigating body provided for in Article 22 of Directive (EU) 2016/798 "@en ;
+        dct:source <http://data.europa.eu/eli/dir/2016/798/oj> ;
+  		.
+
+
 era-organisation-roles:Owner a skos:Concept; 
 		skos:prefLabel "Railway Vehicle Owner"@en ; 
 		skos:inScheme era-organisation-roles:OrgRoles ;
@@ -53,7 +189,7 @@ era-organisation-roles:Owner a skos:Concept;
         skos:notation "Owner"^^xsd:string ;
 		skos:topConceptOf era-organisation-roles:OrgRoles ;
 		skos:definition "The natural or legal person being the owner of a vehicle exploited as a means of transport and is registered as such in a vehicle register referred to in Article 47"@en;
-        dct:references <http://data.europa.eu/eli/dir/2016/797/oj>, <http://data.europa.eu/eli/dir/2016/797/2020-05-28>;
+        dct:source <http://data.europa.eu/eli/dir/2016/797/oj>, <http://data.europa.eu/eli/dir/2016/797/2020-05-28>;
   		.
 
 era-organisation-roles:Keeper   a skos:Concept; 
@@ -61,7 +197,7 @@ era-organisation-roles:Keeper   a skos:Concept;
 			skos:prefLabel "Railway Vehicle Keeper"@en; 
 			skos:topConceptOf era-organisation-roles:OrgRoles ;
 			skos:definition "The natural or legal person that, being the owner of a vehicle or having the right to use it, exploits the vehicle as a means of transport and is registered as such in a vehicle register"@en ;
-			dct:references <http://data.europa.eu/eli/dir/2016/797/oj>,  <http://data.europa.eu/eli/dir/2016/797/2020-05-28>;
+			dct:source <http://data.europa.eu/eli/dir/2016/797/oj>,  <http://data.europa.eu/eli/dir/2016/797/2020-05-28>;
             skos:notation "Keeper"^^xsd:string ;
 			skos:altLabel "Keeper"@en;
 			.
@@ -74,7 +210,7 @@ era-organisation-roles:Applicant a skos:Concept;
 			skos:definition """ A natural or legal person requesting an authorisation, be it a railway undertaking, an infrastructure manager or any other person or legal entity, such as a manufacturer, an owner or a keeper """@en, 
 			   """ a natural or legal person requesting the Agency's decision for the approval of the technical solutions envisaged for the ERTMS track-side equipment projects """@en ;
 			
-			dct:references <http://data.europa.eu/eli/dir/2016/797/oj>,  <http://data.europa.eu/eli/dir/2016/797/2020-05-28> ;
+			dct:source <http://data.europa.eu/eli/dir/2016/797/oj>,  <http://data.europa.eu/eli/dir/2016/797/2020-05-28> ;
 			.
 
 era-organisation-roles:ECM a skos:Concept;
@@ -84,7 +220,7 @@ era-organisation-roles:ECM a skos:Concept;
 			  skos:definition """An entity in charge of the maintenance of a vehicle,  and registered as such in a vehicle register referred to in Article 47 of Directive (EU) 2016/797"""@en ;
               skos:scopeNote """ As defined in Article 3, point (20) of Directive (EU) 2016/798 and certified in accordance with Article 3 of Implementing Regulation (EU) 2019/779 """@en ; 
 			  skos:narrower era-organisation-roles:ECM-b , era-organisation-roles:ECM-c, era-organisation-roles:ECM-d ; 
-			  dct:references <http://data.europa.eu/eli/dir/2016/797/oj>, <http://data.europa.eu/eli/dir/2016/797/2020-05-28>;
+			  dct:source <http://data.europa.eu/eli/dir/2016/797/oj>, <http://data.europa.eu/eli/dir/2016/797/2020-05-28>;
               skos:notation "ECM"^^xsd:string ;
 			  skos:altLabel "ECM"@en .
 
@@ -121,7 +257,7 @@ era-organisation-roles:MWS a skos:Concept;
 			  skos:narrower era-organisation-roles:MWS-b , era-organisation-roles:MSW-c, era-organisation-roles:MSW-d ; 
 			  skos:topConceptOf era-organisation-roles:OrgRoles;
 			  skos:definition """An entity in charge of the maintenance of a vehicle,  and registered as such in a vehicle register referred to in Article 47 of Directive (EU) 2016/797"""@en ;
-			  dct:references <http://data.europa.eu/eli/dir/2016/798/oj>, <http://data.europa.eu/eli/reg_impl/2019/779/oj>; 
+			  dct:source <http://data.europa.eu/eli/dir/2016/798/oj>, <http://data.europa.eu/eli/reg_impl/2019/779/oj>; 
 			  skos:altLabel "MWS"@en .
 
 
@@ -158,7 +294,7 @@ era-organisation-roles:Manufacturer   a skos:Concept ;
 				Any natural or legal person who manufactures a product in the form of interoperability constituents, subsystems or vehicles, or has it designed or manufactured, and markets it under his name or trademark
 			"""@en ;
 			
-			dct:references <http://data.europa.eu/eli/dir/2016/797/2020-05-28> ; 
+			dct:source <http://data.europa.eu/eli/dir/2016/797/2020-05-28> ; 
 		    .
 
 era-organisation-roles:NSA   a skos:Concept;

--- a/era-skos/era-skos-OrientationDirections.ttl
+++ b/era-skos/era-skos-OrientationDirections.ttl
@@ -1,0 +1,63 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix era: <http://data.europa.eu/949/> .
+@prefix era-skos: <http://data.europa.eu/949/concepts/> .
+
+@prefix era-orient: <http://data.europa.eu/949/concepts/orientations/> .
+
+
+
+
+
+#################################################################
+#
+#    Concept Schemes
+#
+#################################################################
+
+
+
+
+era-orient:OrientationDirections a skos:ConceptScheme ; 
+    dct:issued "2024-09-24"^^xsd:date ;
+    cc:license <https://creativecommons.org/licenses/by/4.0/> ;
+    rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
+    rdfs:label "Directions of the orientation of a railway element"@en ;
+    skos:prefLabel "Directions of the orientation of a railway element"@en ;
+    dct:title "Concept scheme grouping railway element orientation' directions"@en .
+
+
+
+#################################################################
+#
+#    Concept instances
+#
+#################################################################
+
+
+## To be generated when values are available under the condition the scheme is relevant.
+## Work to do by the CCS 2024 members"
+
+
+########## Orientation Directions ##########
+
+era-orient:00 a skos:Concept;
+  skos:inScheme era-orient:OrientationDirections; skos:topConceptOf era-orient:Directions ; 
+  skos:note "Value collected from TWG RINF CCS 2024 members"@en;
+  skos:notation "Placeholder";
+  skos:prefLabel "Placeholder" ;
+  rdfs:comment "Placeholder" ;
+  owl:deprecated "false"^^xsd:boolean .
+
+
+
+
+
+
+
+

--- a/era-skos/era-skos-OrientationDirections.ttl
+++ b/era-skos/era-skos-OrientationDirections.ttl
@@ -52,7 +52,7 @@ era-orient:00 a skos:Concept;
   skos:notation "Placeholder";
   skos:prefLabel "Placeholder" ;
   rdfs:comment "Placeholder" ;
-  owl:deprecated "false"^^xsd:boolean .
+   .
 
 
 

--- a/era-skos/era-skos-ReferenceSystems.ttl
+++ b/era-skos/era-skos-ReferenceSystems.ttl
@@ -1,0 +1,63 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix era: <http://data.europa.eu/949/> .
+@prefix era-skos: <http://data.europa.eu/949/concepts/> .
+
+@prefix era-refsys: <http://data.europa.eu/949/concepts/lines/ReferenceSystems> .
+
+
+
+
+
+#################################################################
+#
+#    Concept Schemes
+#
+#################################################################
+
+
+
+
+era-refsys:ReferemceSystems a skos:ConceptScheme ; 
+    dct:issued "2024-09-24"^^xsd:date ;
+    cc:license <https://creativecommons.org/licenses/by/4.0/> ;
+    rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
+    rdfs:label "Line reference systems"@en ;
+    skos:prefLabel "Line reference systems"@en ;
+    dct:title "Concept scheme grouping line reference systems"@en .
+
+
+
+#################################################################
+#
+#    Concept instances
+#
+#################################################################
+
+
+## To be generated when values are available under the condition the scheme is relevant.
+## Work to do by the CCS 2024 members"
+
+
+########## Line Reference Systems ##########
+
+era-refsys:00 a skos:Concept;
+  skos:inScheme era-refsys:ReferemceSystems; skos:topConceptOf era-refsys:ReferemceSystems ; 
+  skos:note "Value collected from TWG RINF CCS 2024 members"@en;
+  skos:notation "Placeholder";
+  skos:prefLabel "Placeholder" ;
+  rdfs:comment "Placeholder" ;
+  owl:deprecated "false"^^xsd:boolean .
+
+
+
+
+
+
+
+

--- a/era-skos/era-skos-ReferenceSystems.ttl
+++ b/era-skos/era-skos-ReferenceSystems.ttl
@@ -52,7 +52,7 @@ era-refsys:00 a skos:Concept;
   skos:notation "Placeholder";
   skos:prefLabel "Placeholder" ;
   rdfs:comment "Placeholder" ;
-  owl:deprecated "false"^^xsd:boolean .
+   .
 
 
 

--- a/era-skos/era-skos-StandardCombinedTransportRollerUnits.ttl
+++ b/era-skos/era-skos-StandardCombinedTransportRollerUnits.ttl
@@ -52,7 +52,7 @@ era-sctru:00 a skos:Concept;
   skos:notation "Placeholder";
   skos:prefLabel "Placeholder" ;
   rdfs:comment "Placeholder" ;
-  owl:deprecated "false"^^xsd:boolean .
+   .
 
 
 

--- a/era-skos/era-skos-StandardCombinedTransportRollerUnits.ttl
+++ b/era-skos/era-skos-StandardCombinedTransportRollerUnits.ttl
@@ -1,0 +1,63 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix era: <http://data.europa.eu/949/> .
+@prefix era-skos: <http://data.europa.eu/949/concepts/> .
+
+@prefix era-sctru: <http://data.europa.eu/949/concepts/standard-combined-transport-roller-units/> .
+
+
+
+
+
+#################################################################
+#
+#    Concept Schemes
+#
+#################################################################
+
+
+
+
+era-sctru:StandardCombinedTransportRollerUnits a skos:ConceptScheme ; 
+    dct:issued "2024-09-24"^^xsd:date ;
+    cc:license <https://creativecommons.org/licenses/by/4.0/> ;
+    rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
+    rdfs:label "Standard combined transport profile numbers for roller units"@en ;
+    skos:prefLabel "Standard combined transport profile numbers for roller units"@en ;
+    dct:title "Concept scheme grouping standard combined transport profile numbers for roller units"@en .
+
+
+
+#################################################################
+#
+#    Concept instances
+#
+#################################################################
+
+
+## To be generated when values are available under the condition the scheme is relevant.
+## Work to do by the CCS 2024 members"
+
+
+########## Standard Combined Transport Roller Units ##########
+
+era-sctru:00 a skos:Concept;
+  skos:inScheme era-sctru:StandardCombinedTransportRollerUnits; skos:topConceptOf era-sctru:StandardCombinedTransportRollerUnits ; 
+  skos:note "Value collected from TWG RINF CCS 2024 members"@en;
+  skos:notation "Placeholder";
+  skos:prefLabel "Placeholder" ;
+  rdfs:comment "Placeholder" ;
+  owl:deprecated "false"^^xsd:boolean .
+
+
+
+
+
+
+
+

--- a/era-skos/era-skos-SubsidiaryLocationTypes.ttl
+++ b/era-skos/era-skos-SubsidiaryLocationTypes.ttl
@@ -1,0 +1,63 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix era: <http://data.europa.eu/949/> .
+@prefix era-skos: <http://data.europa.eu/949/concepts/> .
+
+@prefix era-subloctype: <http://data.europa.eu/949/concepts/subsidiary-location-types/> .
+
+
+
+
+
+#################################################################
+#
+#    Concept Schemes
+#
+#################################################################
+
+
+
+
+era-subloctype:SubsidiaryLocationTypes a skos:ConceptScheme ; 
+    dct:issued "2024-09-24"^^xsd:date ;
+    cc:license <https://creativecommons.org/licenses/by/4.0/> ;
+    rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
+    rdfs:label "Subsidiary location types"@en ;
+    skos:prefLabel "Subsidiary location types"@en ;
+    dct:title "Concept scheme grouping subsidiary location types"@en .
+
+
+
+#################################################################
+#
+#    Concept instances
+#
+#################################################################
+
+
+## To be generated when values are available under the condition the scheme is relevant.
+## Work to do by the CCS 2024 members"
+
+
+########## Subsidiary Location Types ##########
+
+era-subloctype:00 a skos:Concept;
+  skos:inScheme era-subloctype:SubsidiaryLocationTypes; skos:topConceptOf era-subloctype:SubsidiaryLocationTypes ; 
+  skos:note "Value collected from TWG RINF CCS 2024 members"@en;
+  skos:notation "Placeholder";
+  skos:prefLabel "Placeholder" ;
+  rdfs:comment "Placeholder" ;
+  owl:deprecated "false"^^xsd:boolean .
+
+
+
+
+
+
+
+

--- a/era-skos/era-skos-SubsidiaryLocationTypes.ttl
+++ b/era-skos/era-skos-SubsidiaryLocationTypes.ttl
@@ -52,7 +52,7 @@ era-subloctype:00 a skos:Concept;
   skos:notation "Placeholder";
   skos:prefLabel "Placeholder" ;
   rdfs:comment "Placeholder" ;
-  owl:deprecated "false"^^xsd:boolean .
+   .
 
 
 

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -51,6 +51,7 @@ skos:changeNote """Revision 24-09-2024
 - Deleted foaf:Project, no Usage in ontology and the concept is not part of the domain.
 - Fix bug era:direction, change skos:definition to rdfs:label
 - Fix Typo definition NationalRailwayLine, Network
+- According to conceptual design import gsp:SpatialObject  sf:LineString, sf:MultiPolygon, sf:Point and also other superclasses in the hierarchy of these classes.
 
 
 Revision 20-09-2024
@@ -9161,11 +9162,177 @@ The above mentioned certificate should be documented using era:certificate.
 
 
 ###  http://www.opengis.net/ont/geosparql#Feature
-geo:Feature rdf:type owl:Class .
+geo:Feature rdf:type owl:Class ;
+            rdfs:subClassOf geo:SpatialObject ;
+            owl:disjointWith geo:Geometry ;
+            dc:contributor "Matthew Perry" ;
+            dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+            dc:date "2011-06-16"^^xsd:date ;
+            dc:description """
+      This class represents the top-level feature type. This class is 
+      equivalent to GFI_Feature defined in ISO 19156:2011, and it is 
+      superclass of all feature types.
+    """@en ;
+            rdfs:comment """
+      This class represents the top-level feature type. This class is 
+      equivalent to GFI_Feature defined in ISO 19156:2011, and it is 
+      superclass of all feature types.
+    """@en ;
+            rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> ,
+                             <http://www.opengis.net/ont/gml> ,
+                             <http://www.opengis.net/spec/geosparql/1.0> ;
+            rdfs:label "Feature"@en ;
+            skos:definition """
+      This class represents the top-level feature type. This class is 
+      equivalent to GFI_Feature defined in ISO 19156:2011, and it is 
+      superclass of all feature types.
+    """@en ;
+            skos:prefLabel "Feature"@en .
 
 
 ###  http://www.opengis.net/ont/geosparql#Geometry
-geo:Geometry rdf:type owl:Class .
+geo:Geometry rdf:type owl:Class ;
+             rdfs:subClassOf geo:SpatialObject ;
+             dc:contributor "Matthew Perry" ;
+             dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+             dc:date "2011-06-16"^^xsd:date ;
+             dc:description """
+      The class represents the top-level geometry type. This class is 
+      equivalent to the UML class GM_Object defined in ISO 19107, and 
+      it is superclass of all geometry types.
+    """@en ;
+             rdfs:comment """
+      The class represents the top-level geometry type. This class is 
+      equivalent to the UML class GM_Object defined in ISO 19107, and 
+      it is superclass of all geometry types.
+    """@en ;
+             rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> ,
+                              <http://www.opengis.net/ont/gml> ,
+                              <http://www.opengis.net/spec/geosparql/1.0> ;
+             rdfs:label "Geometry"@en ;
+             skos:definition """
+      The class represents the top-level geometry type. This class is 
+      equivalent to the UML class GM_Object defined in ISO 19107, and 
+      it is superclass of all geometry types.
+    """@en ;
+             skos:prefLabel "Geometry"@en .
+
+
+###  http://www.opengis.net/ont/geosparql#SpatialObject
+geo:SpatialObject rdf:type owl:Class ;
+                  dc:contributor "Matthew Perry" ;
+                  dc:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
+                  dc:date "2011-06-16"^^xsd:date ;
+                  dc:description """
+      The class spatial-object represents everything that can have 
+      a spatial representation. It is superclass of feature and geometry.
+    """@en ;
+                  rdfs:comment """
+      The class spatial-object represents everything that can have 
+      a spatial representation. It is superclass of feature and geometry.
+    """@en ;
+                  rdfs:isDefinedBy <http://www.opengis.net/ont/geosparql> ,
+                                   <http://www.opengis.net/ont/gml> ,
+                                   <http://www.opengis.net/spec/geosparql/1.0> ;
+                  rdfs:label "SpatialObject"@en ;
+                  skos:definition """
+      The class spatial-object represents everything that can have 
+      a spatial representation. It is superclass of feature and geometry.
+    """@en ;
+                  skos:prefLabel "SpatialObject"@en .
+
+
+###  http://www.opengis.net/ont/sf#Curve
+<http://www.opengis.net/ont/sf#Curve> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://www.opengis.net/ont/sf#Geometry> ;
+                                      rdfs:comment """
+A Curve is a 1-dimensional geometric object usually stored as a sequence of Points, with the subtype of Curve specifying the form of the interpolation between Points. This specification defines only one subclass of Curve, LineString, which uses linear interpolation between Points.
+A Curve is a 1-dimensional geometric object that is the homeomorphic image of a real, closed, interval.
+A Curve is simple if it does not pass through the same Point twice with the possible exception of the two end
+points.
+A Curve is closed if its start Point is equal to its end Point.
+The boundary of a closed Curve is empty.
+A Curve that is simple and closed is a Ring.
+The boundary of a non-closed Curve consists of its two end Points.
+A Curve is defined as topologically closed, that is, it contains its endpoints f(a) and f(b).
+    """@en ;
+                                      rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+                                      rdfs:label "Curve"@en .
+
+
+###  http://www.opengis.net/ont/sf#Geometry
+<http://www.opengis.net/ont/sf#Geometry> rdf:type owl:Class ;
+                                         rdfs:subClassOf geo:Geometry ;
+                                         rdfs:comment """
+Geometry is the root class of the hierarchy.
+The instantiable subclasses of Geometry are restricted to 0, 1 and 2-dimensional geometric objects that exist in 2, 3 or 4-dimensional coordinate space (R2, R3 or R4). Geometry values in R2 have points with coordinate values for x and y. Geometry values in R3 have points with coordinate values for x, y and z or for x, y and m. Geometry values in R4 have points with coordinate values for x, y, z and m.
+The interpretation of the coordinates is subject to the coordinate reference systems associated to the point. All coordinates within a geometry object should be in the same coordinate reference systems. Each coordinate shall be unambiguously associated to a coordinate reference system either directly or through its containing geometry. The z coordinate of a point is typically, but not necessarily, represents altitude or elevation. The m coordinate represents a measurement.
+All Geometry classes described in this specification are defined so that instances of Geometry are topologically closed, i.e. all represented geometries include their boundary as point sets. This does not affect their representation, and open version of the same classes may be used in other circumstances, such as topological representations.
+    """@en ;
+                                         rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+                                         rdfs:label "Geometry"@en .
+
+
+###  http://www.opengis.net/ont/sf#GeometryCollection
+<http://www.opengis.net/ont/sf#GeometryCollection> rdf:type owl:Class ;
+                                                   rdfs:subClassOf <http://www.opengis.net/ont/sf#Geometry> ;
+                                                   rdfs:comment """
+A GeometryCollection is a geometric object that is a collection of some number of geometric objects.
+All the elements in a GeometryCollection shall be in the same Spatial Reference System. This is also the Spatial Reference System for the GeometryCollection.
+GeometryCollection places no other constraints on its elements. Subclasses of GeometryCollection may restrict membership based on dimension and may also place other constraints on the degree of spatial overlap between elements.
+    """@en ;
+                                                   rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+                                                   rdfs:label "Geometry Collection"@en .
+
+
+###  http://www.opengis.net/ont/sf#LineString
+<http://www.opengis.net/ont/sf#LineString> rdf:type owl:Class ;
+                                           rdfs:subClassOf <http://www.opengis.net/ont/sf#Curve> ;
+                                           rdfs:comment """
+A LineString is a Curve with linear interpolation between Points. Each consecutive pair of Points defines a Line segment.
+    """@en ;
+                                           rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+                                           rdfs:label "Line String"@en .
+
+
+###  http://www.opengis.net/ont/sf#MultiPolygon
+<http://www.opengis.net/ont/sf#MultiPolygon> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://www.opengis.net/ont/sf#MultiSurface> ;
+                                             rdfs:comment """
+A MultiPolygon is a MultiSurface whose elements are Polygons.
+The assertions for MultiPolygons are as follows.
+a) The interiors of 2 Polygons that are elements of a MultiPolygon may not intersect.
+b) The boundaries of any 2 Polygons that are elements of a MultiPolygon may not cross and may touch at only a finite number of Points.
+c) A MultiPolygon is defined as topologically closed.
+d) A MultiPolygon may not have cut lines, spikes or punctures, a MultiPolygon is a regular closed Point set,
+e) The interior of a MultiPolygon with more than 1 Polygon is not connected; the number of connected components of the interior of a MultiPolygon is equal to the number of Polygons in the MultiPolygon. 
+The boundary of a MultiPolygon is a set of closed Curves (LineStrings) corresponding to the boundaries of its element Polygons. Each Curve in the boundary of the MultiPolygon is in the boundary of exactly 1 element Polygon, and every Curve in the boundary of an element Polygon is in the boundary of the MultiPolygon.
+    """@en ;
+                                             rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+                                             rdfs:label "Multi Polygon"@en .
+
+
+###  http://www.opengis.net/ont/sf#MultiSurface
+<http://www.opengis.net/ont/sf#MultiSurface> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://www.opengis.net/ont/sf#GeometryCollection> ;
+                                             rdfs:comment """
+A MultiSurface is a 2-dimensional GeometryCollection whose elements are Surfaces, all using coordinates from the same coordinate reference system. The geometric interiors of any two Surfaces in a MultiSurface may not intersect in the full coordinate system. The boundaries of any two coplanar elements in a MultiSurface may intersect, at most, at a finite number of Points. If they were to meet along a curve, they could be merged into a single surface.
+A MultiSurface may be used to represent heterogeneous surfaces collections of polygons and polyhedral surfaces. It defines a set of methods for its subclasses. The subclass of MultiSurface is MultiPolygon corresponding to a collection of Polygons only. Other collections shall use MultiSurface.
+    """@en ;
+                                             rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+                                             rdfs:label "Multi Surface"@en .
+
+
+###  http://www.opengis.net/ont/sf#Point
+<http://www.opengis.net/ont/sf#Point> rdf:type owl:Class ;
+                                      rdfs:subClassOf <http://www.opengis.net/ont/sf#Geometry> ;
+                                      rdfs:comment """
+A Point is a 0-dimensional geometric object and represents a single location in coordinate space. 
+A Point has an x-coordinate value, a y-coordinate value. If called for by the associated Spatial Reference System, it may also have coordinate values for z and m.
+The boundary of a Point is the empty set.
+    """@en ;
+                                      rdfs:isDefinedBy <http://www.opengis.net/ont/sf> ;
+                                      rdfs:label "Point"@en .
 
 
 ###  http://www.w3.org/1999/02/22-rdf-syntax-ns#Bag
@@ -9326,6 +9493,7 @@ wgs:lat_long rdfs:comment "A comma-separated representation of a latitude, longi
 
 
 wgs:location rdfs:label "Location" ;
+             era:rinfIndex "1.1.0.0.1.1" ;
              rdfs:comment """The relation between something and the point, 
  or other geometrical thing in space, where it is.  For example, the realtionship between
  a radio tower and a Point with a given lat and long.
@@ -9334,8 +9502,7 @@ wgs:location rdfs:label "Location" ;
  Clearly in practice there will be limit to the accuracy of any such statement, but one would expect
  an accuracy appropriate for the size of the object and uses such as mapping .
  """ ;
-             era:rinfIndex "1.1.0.0.1.1" ,
-                           "1.1.1.3.14.5" ,
+             era:rinfIndex "1.1.1.3.14.5" ,
                            "1.2.1.0.8.5" ,
                            "1.2.0.0.0.5" ;
              era:usedInRCCCalculations "true"^^xsd:boolean ;

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -34,7 +34,8 @@ dcterms:modified "2024-04-18"^^xsd:date ,
                  "2024-08-12"^^xsd:date ,
                  "2024-08-13"^^xsd:date ,
                  "2024-09-20"^^xsd:date ,
-                 "2024-09-24"^^xsd:date ;
+                 "2024-09-24"^^xsd:date ,
+                 "2024-09-25"^^xsd:date ;
 dcterms:publisher "European Union Agency for Railways" ;
 dcterms:title "ERA Ontology"@en ;
 rdfs:comment """This is the human and machine readable Ontology governed by the European Union Agency for Railways (https://www.era.europa.eu/). It represents the concepts and relationships linked to the sectorial legal framework and the use cases under the AgencyÂ´s remit, as described in the Commission Implementing Regulation (EU) [to be updated after publication] on the common specifications for the register of railway infrastructure [to be updated after publication].
@@ -46,7 +47,18 @@ rdfs:label "ERA Ontology"@en ;
 owl:priorVersion "https://github.com/Interoperable-data/ERA_vocabulary/releases/v3.0.0"^^xsd:anyURI ;
 owl:versionInfo "v3.1.0"@en ;
 owl:versionURI <https://github.com/Interoperable-data/ERA_vocabulary/releases/releases/v3.1.0> ;
-skos:changeNote """Revision 24-09-2024
+skos:changeNote """Revision 25-09-2024
+- Deprecated minimumTemperature and maximumTemperature as both RINF and ERATV define a temprature range with a list of predefined values.
+- Changed era:trainDetectionSystemSpecificChecks from a data property to an object property (It is a list of predefined values). Added the pointer to its SKOS Concept Scheme. 
+- Fixed annotation inSKOSConceptScheme for property era:osmClass 
+- Deleted from definitions (rdfs:comment) URIs referring to the source and  added them as dcterms:source annotations. Replaced all rdfs:seeAlso to dcterms:source for consistency in the annotations.
+- Removed duplicate properties appendixD2Index and appendixD3Index, fixed references to point to remaining properties.
+- Fixed 1.2.1.1.2.12 Specific constraints imposed by the GSM-R network, deleted  1.1... RINF index. Fixed 1.1.1.3.3.12 & 1.2.1.1.2.13 as the correct RINF indexes  of \"Radio Network ID\".
+- Added isReplacedBy annotations to deprecated classes era:Manufacturer and era.VehicleKeeper.
+- Fixed typo ammendment for amendment.
+- Added annotation dcterms:isReplacedBy era:errorCorrectionsOnBoard for era:gsmrErrorCorrectionsOnBoard, era:etcsErrorCorrectionsOnBoard, era:ertmsErrorCorrectionsOnBoard.
+
+Revision 24-09-2024
 - Add annotation in SKOSConceptScheme to era:operationalRegimeType, era:subsidiaryLocationType, era:conditionsUseReflectivePlates, era:standardCombinedTransportRollerUnit, era:linesideDistanceIndicationAppearance  (currently placeholder concept schemes to be developed)
 - Deleted foaf:Project, no Usage in ontology and the concept is not part of the domain.
 - Fix bug era:direction, change skos:definition to rdfs:label
@@ -140,10 +152,6 @@ era:appendixD2Index rdf:type owl:AnnotationProperty ;
                     rdfs:range xsd:string .
 
 
-###  http://data.europa.eu/949/appendixD2index
-era:appendixD2index rdf:type owl:AnnotationProperty .
-
-
 ###  http://data.europa.eu/949/appendixD3Index
 era:appendixD3Index rdf:type owl:AnnotationProperty ;
                     dcterms:created "2022-11-04"^^xsd:date ;
@@ -153,10 +161,6 @@ era:appendixD3Index rdf:type owl:AnnotationProperty ;
                     rdfs:label "Appendix D3 index"@en ;
                     vs:term_status "stable" ;
                     rdfs:range xsd:string .
-
-
-###  http://data.europa.eu/949/appendixD3index
-era:appendixD3index rdf:type owl:AnnotationProperty .
 
 
 ###  http://data.europa.eu/949/canonicalURI
@@ -233,8 +237,8 @@ era:unitOfMeasure rdf:type owl:AnnotationProperty ;
 ###  http://data.europa.eu/949/usedInRCCCalculations
 era:usedInRCCCalculations rdf:type owl:AnnotationProperty ;
                           dcterms:created "2023-04-12"^^xsd:date ;
-                          rdfs:comment """Indicates whether a RINF parameter is used in Route Compatibility Check calculations according to Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision.
-https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj#:~:text=Commission%20Implementing%20Regulation."""@en ;
+                          dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj#:~:text=Commission%20Implementing%20Regulation> ;
+                          rdfs:comment "Indicates whether a RINF parameter is used in Route Compatibility Check calculations according to Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "Parameter is used in Route Compatibility Check (RCC) calculations"@en ;
                           rdfs:range xsd:boolean .
@@ -471,7 +475,7 @@ era:allocationCompany rdf:type owl:ObjectProperty ;
                       rdfs:domain era:SubsidiaryLocation ;
                       rdfs:range era:Body ;
                       dcterms:created "2024-05-24"^^xsd:date ;
-                      rdfs:comment "the organisation in charge to allocate the code for the subsidiary location"@en ;
+                      rdfs:comment "The organisation in charge to allocate the code for the subsidiary location."@en ;
                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                       rdfs:label "allocation company"@en .
 
@@ -1141,11 +1145,11 @@ era:etcsMVersion rdf:type owl:ObjectProperty ,
                  dcterms:created "2021-08-08"^^xsd:date ;
                  dcterms:modified "2021-09-12"^^xsd:date ,
                                   "2024-04-18"^^xsd:date ;
-                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                  rdfs:comment "ETCS M_version according to SRS 7.5.1.9."@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "ETCS M_version"@en ;
-                 rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                  vs:term_status "stable" ;
                  skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -1182,11 +1186,11 @@ The technical document will be updated within 10 working days after positive ass
 The ESC Types shall only be used when published with status ‘Valid’ in the Agency Technical document referred above."""@en ;
                             dcterms:modified "2021-09-12"^^xsd:date ;
                             dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/776/oj> ,
+                                           <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ,
                                            <https://www.era.europa.eu/system/files/2023-05/esc-rsc_technical_document_en.pdf> ;
                             rdfs:comment "ETCS requirements used for demonstrating technical compatibility."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "ETCS system compatibility"@en ;
-                            rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                             vs:term_status "stable" ;
                             skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -1204,13 +1208,13 @@ era:etcsTransmittedTrackConditions rdf:type owl:ObjectProperty ,
                                    dcterms:created "2022-11-16"^^xsd:date ;
                                    dcterms:modified "2023-03-14"^^xsd:date ,
                                                     "2023-04-18"^^xsd:date ;
-                                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                                  <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                    rdfs:comment """Transmittable track conditions by the CCSSubsystem, as per CCS TSI.
 
 See: TSI CCS (Subset-026, Chapter 5, section 5.18.1.1)"""@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "Track conditions which can be transmitted"@en ;
-                                   rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                    vs:term_status "unstable" ;
                                    skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -1502,8 +1506,7 @@ era:gsmrConstraintsOperateOnlyInCircuitSwitch rdf:type owl:ObjectProperty ;
                                               era:XMLName "CRG_ConstraintsCS" ;
                                               era:appendixD3Index "2.2" ;
                                               era:inSkosConceptScheme <http://data.europa.eu/949/concepts/gsmr-cs-constraints/GSMRConstraints> ;
-                                              era:rinfIndex "1.1.1.3.3.12" ,
-                                                            "1.2.1.1.2.12" ;
+                                              era:rinfIndex "1.2.1.1.2.12" ;
                                               dcterms:created "2023-03-14"^^xsd:date ;
                                               dcterms:modified "2024-04-18"^^xsd:date ;
                                               rdfs:comment "These constraints, where applicable, are meant to manage the limited number of circuit-switched radio connections that can be handled simultaneously by a Radio Block Center."@en ;
@@ -1885,13 +1888,13 @@ era:mNvcontact rdf:type owl:ObjectProperty ,
                dcterms:created "2022-11-07"^^xsd:date ;
                dcterms:modified "2023-03-14"^^xsd:date ,
                                 "2024-04-18"^^xsd:date ;
-               dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+               dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                              <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                rdfs:comment """On-Board system reaction when T_NVCONTACT expires.
 
 See: TSI CCS (Subset-026, chapter 7. 7.5.1.74 M_NVCONTACT)"""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "M_NVCONTACT"@en ;
-               rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                vs:term_status "unstable" ;
                skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -1975,7 +1978,7 @@ era:maxSandingOutput rdf:type owl:ObjectProperty ;
                      dcterms:created "2021-08-08"^^xsd:date ;
                      dcterms:modified "2023-03-14"^^xsd:date ;
                      rdfs:comment """Maximum amount of sand accepted on the track within value of sanding output for 30s, given in grams.
-Deprecated according to the ammendment to the Regulation (EU) 2019/777."""@en ;
+Deprecated according to the amendment to the Regulation (EU) 2019/777."""@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Maximum amount of sand"@en ;
                      owl:deprecated "true"^^xsd:boolean ;
@@ -1992,7 +1995,7 @@ era:minAxleLoadVehicleCategory rdf:type owl:ObjectProperty ;
                                dcterms:created "2021-08-08"^^xsd:date ;
                                dcterms:modified "2023-03-14"^^xsd:date ;
                                rdfs:comment """Represents the category of vehicle which is amended by value of minimum permitted axle load [tons] (property minAxleLoad).
-Deprecated according to the ammendment to the Regulation (EU) 2019/777."""@en ;
+Deprecated according to the amendment to the Regulation (EU) 2019/777."""@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Minimum axle load vehicle category"@en ;
                                owl:deprecated "true"^^xsd:boolean ;
@@ -2230,7 +2233,7 @@ era:osmClass rdf:type owl:ObjectProperty ;
                                        )
                          ] ;
              rdfs:range skos:Concept ;
-             era:inSkosConceptScheme <http://data.europa.eu/949/concepts/osmclass/OSMClasses> ;
+             era:inSkosConceptScheme <http://data.europa.eu/949/concepts/osm-classes/OSMClasses> ;
              rdfs:comment "(deprecated) not in use any more"@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "Open street map class"@en ;
@@ -2293,11 +2296,11 @@ era:otherTrainProtection rdf:type owl:ObjectProperty ,
                          dcterms:modified "2021-09-12"^^xsd:date ,
                                           "2024-04-18"^^xsd:date ;
                          dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/2023-09-28> ,
-                                        <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                                        <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                        <https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf> ;
                          rdfs:comment "Indication of existence of other system than ETCS for degraded situation."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Other train protection, control and warning systems for degraded situation"@en ;
-                         rdfs:seeAlso <https://www.era.europa.eu/system/files/2023-11/%5BK%5D%20ERA-TD-2011-09-INT-Coded%20restrictions-final.pdf> ;
                          vs:term_status "stable" ;
                          skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -2490,13 +2493,13 @@ era:qNvdriverAdhes rdf:type owl:ObjectProperty ,
                                  "1.2.1.1.1.16.11" ;
                    dcterms:created "2024-04-18"^^xsd:date ;
                    dcterms:modified "2024-09-20"^^xsd:date ;
-                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                  <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                    rdfs:comment """Qualifier determining whether the driver is allowed to modify the adhesion factor used by the ETCS on-board to calculate the braking curves. 
 
 See: TSI CCS (Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES)"""@en ;
                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                    rdfs:label "Q_NVDRIVER_ADHES"@en ;
-                   rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                    vs:term_status "stable" ;
                    skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -2569,13 +2572,13 @@ era:reasonsEtcsRadioBlockCenterReject rdf:type owl:ObjectProperty ,
                                       dcterms:created "2022-11-07"^^xsd:date ;
                                       dcterms:modified "2023-03-14"^^xsd:date ,
                                                        "2024-04-18"^^xsd:date ;
-                                      dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                                      dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                                     <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                       rdfs:comment """List of cases subject to system design choices made by the infrastructure manager according to the specification referenced in TSI CCS. 
 
 See: Subset 26, Chapter 5 5.4 Procedure start of mission."""@en ;
                                       rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                       rdfs:label "Reasons for which an ETCS Radio Block Center can reject a train"@en ;
-                                      rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                       vs:term_status "unstable" ;
                                       skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -2630,11 +2633,11 @@ era:safeConsistLengthInformationNecessary rdf:type owl:ObjectProperty ,
                                                         "1.2.1.1.1.11" ;
                                           dcterms:created "2023-03-14"^^xsd:date ;
                                           dcterms:modified "2024-04-18"^^xsd:date ;
-                                          dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                                          dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                                         <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                           rdfs:comment "Indication whether safe consist train length information from on-board is required to access the line for safety reasons and the required safety integrity level."@en ;
                                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                           rdfs:label "Safe consist length information from on-board necessary for access the line and SIL"@en ;
-                                          rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                           vs:term_status "stable" ;
                                           skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -2929,7 +2932,7 @@ era:tdsMinAxleLoadVehicleCategory rdf:type owl:ObjectProperty ;
                                   era:rinfIndex "1.1.1.3.7.11.1" ;
                                   dcterms:created "2023-01-25"^^xsd:date ;
                                   dcterms:modified "2023-03-14"^^xsd:date ;
-                                  rdfs:comment "Indication of load given in tons depending of the category of vehicle. Deprecated according to the ammendment to the Regulation (EU) 2019/777."@en ;
+                                  rdfs:comment "Indication of load given in tons depending of the category of vehicle. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Train detection system min axle load vehicle category"@en ;
                                   owl:deprecated "true"^^xsd:boolean ;
@@ -3102,6 +3105,29 @@ era:trainDetectionSystem rdf:type owl:ObjectProperty ;
                          vs:term_status "stable" .
 
 
+###  http://data.europa.eu/949/trainDetectionSystemSpecificCheck
+era:trainDetectionSystemSpecificCheck rdf:type owl:ObjectProperty ;
+                                      rdfs:domain era:TrainDetectionSystem ;
+                                      rdfs:range skos:Concept ;
+                                      era:XMLName "CTD_TCCheck" ;
+                                      era:inSkosConceptScheme <http://data.europa.eu/949/concepts/train-detection-specific-checks/TrainDetectionSystemsSpecificChecks> ;
+                                      era:rinfIndex "1.1.1.3.7.1.2" ,
+                                                    "1.2.1.1.6.1" ;
+                                      era:usedInRCCCalculations "false"^^xsd:boolean ;
+                                      dcterms:created "2020-08-24"^^xsd:date ;
+                                      dcterms:modified "2021-08-08"^^xsd:date ,
+                                                       "2024-04-18"^^xsd:date ,
+                                                       "2024-09-25"^^xsd:date ;
+                                      dcterms:relation era:trainDetectionSystemSpecificCheckDocument ;
+                                      dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
+                                      rdfs:comment "Reference to the technical specification of train detection system."@en ;
+                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                      rdfs:label "Type of track circuits or axle counters to which specific checks are needed. "@en ;
+                                      owl:deprecated "false"^^xsd:boolean ;
+                                      vs:term_status "stable" ;
+                                      skos:scopeNote "String containing the name of the TD system for which checks are mentioned in 1.1.1.3.7.1.3."@en .
+
+
 ###  http://data.europa.eu/949/trainDetectionSystemSpecificCheckDocument
 era:trainDetectionSystemSpecificCheckDocument rdf:type owl:ObjectProperty ;
                                               rdfs:domain era:TrainDetectionSystem ;
@@ -3158,7 +3184,7 @@ era:tsiCompliantCompositeBrakeBlocks rdf:type owl:ObjectProperty ;
                                      era:rinfIndex "1.1.1.3.7.21" ;
                                      dcterms:created "2021-08-08"^^xsd:date ;
                                      dcterms:modified "2023-03-14"^^xsd:date ;
-                                     rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. TSI compliance of rules on the use of composite brake blocks."@en ;
+                                     rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. TSI compliance of rules on the use of composite brake blocks."@en ;
                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                      rdfs:label "TSI compliance of rules on the use of composite brake blocks"@en ;
                                      owl:deprecated "true"^^xsd:boolean ;
@@ -3174,7 +3200,7 @@ era:tsiCompliantFerromagneticWheel rdf:type owl:ObjectProperty ;
                                    era:rinfIndex "1.1.1.3.7.14" ;
                                    dcterms:created "2021-08-08"^^xsd:date ;
                                    dcterms:modified "2023-03-14"^^xsd:date ;
-                                   rdfs:comment "TSI compliance of Ferromagnetic characteristics of wheel material required. Deprecated according to the ammendment to the Regulation (EU) 2019/777."@en ;
+                                   rdfs:comment "TSI compliance of Ferromagnetic characteristics of wheel material required. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                    rdfs:label "TSI compliance of Ferromagnetic characteristics of wheel material required"@en ;
                                    owl:deprecated "true"^^xsd:boolean ;
@@ -3190,7 +3216,7 @@ era:tsiCompliantMaxDistConsecutiveAxles rdf:type owl:ObjectProperty ;
                                         era:rinfIndex "1.1.1.3.7.2.1" ;
                                         dcterms:created "2021-08-07"^^xsd:date ;
                                         dcterms:modified "2023-03-14"^^xsd:date ;
-                                        rdfs:comment "Indication whether required distance between two consecutive axles is compliant with the TSI. Deprecated according to the ammendment to the Regulation (EU) 2019/777."@en ;
+                                        rdfs:comment "Indication whether required distance between two consecutive axles is compliant with the TSI. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "TSI compliance of maximum permitted distance between two consecutive axles"@en ;
                                         owl:deprecated "true"^^xsd:boolean ;
@@ -3206,7 +3232,7 @@ era:tsiCompliantMaxImpedanceWheelset rdf:type owl:ObjectProperty ;
                                      era:rinfIndex "1.1.1.3.7.15.1" ;
                                      dcterms:created "2021-08-08"^^xsd:date ;
                                      dcterms:modified "2023-03-14"^^xsd:date ;
-                                     rdfs:comment "TSI compliance of maximum permitted impedance between opposite wheels of a wheelset. Deprecated according to the ammendment to the Regulation (EU) 2019/777."@en ;
+                                     rdfs:comment "TSI compliance of maximum permitted impedance between opposite wheels of a wheelset. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                      rdfs:label "TSI compliance of maximum permitted impedance between opposite wheels of a wheelset"@en ;
                                      owl:deprecated "true"^^xsd:boolean ;
@@ -3222,7 +3248,7 @@ era:tsiCompliantMetalConstruction rdf:type owl:ObjectProperty ;
                                   era:rinfIndex "1.1.1.3.7.13" ;
                                   dcterms:created "2021-08-08"^^xsd:date ;
                                   dcterms:modified "2023-03-14"^^xsd:date ;
-                                  rdfs:comment "TSI compliance of rules for vehicle metal construction. Deprecated according to the ammendment to the Regulation (EU) 2019/777."@en ;
+                                  rdfs:comment "TSI compliance of rules for vehicle metal construction. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "TSI compliance of rules for vehicle metal construction"@en ;
                                   owl:deprecated "true"^^xsd:boolean ;
@@ -3238,7 +3264,7 @@ era:tsiCompliantMetalFreeSpace rdf:type owl:ObjectProperty ;
                                era:rinfIndex "1.1.1.3.7.12" ;
                                dcterms:created "2021-08-08"^^xsd:date ;
                                dcterms:modified "2023-03-14"^^xsd:date ;
-                               rdfs:comment "TSI compliance of rules for metal-free space around wheels. Deprecated according to the ammendment to the Regulation (EU) 2019/777."@en ;
+                               rdfs:comment "TSI compliance of rules for metal-free space around wheels. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "TSI compliance of rules for metal-free space around wheels"@en ;
                                owl:deprecated "true"^^xsd:boolean ;
@@ -3254,7 +3280,7 @@ era:tsiCompliantRSTShuntImpedance rdf:type owl:ObjectProperty ;
                                   era:rinfIndex "1.1.1.3.7.23" ;
                                   dcterms:created "2021-08-08"^^xsd:date ;
                                   dcterms:modified "2023-03-14"^^xsd:date ;
-                                  rdfs:comment "TSI compliance of rules on combination of RST characteristics influencing shunting impedance. Deprecated according to the ammendment to the Regulation (EU) 2019/777."@en ;
+                                  rdfs:comment "TSI compliance of rules on combination of RST characteristics influencing shunting impedance. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "TSI compliance of rules on combination of RST characteristics influencing shunting impedance"@en ;
                                   owl:deprecated "true"^^xsd:boolean ;
@@ -3270,7 +3296,7 @@ era:tsiCompliantSandCharacteristics rdf:type owl:ObjectProperty ;
                                     era:rinfIndex "1.1.1.3.7.19" ;
                                     dcterms:created "2021-08-08"^^xsd:date ;
                                     dcterms:modified "2023-03-14"^^xsd:date ;
-                                    rdfs:comment "TSI Compliance of rules on sand characteristics. Deprecated according to the ammendment to the Regulation (EU) 2019/777." ;
+                                    rdfs:comment "TSI Compliance of rules on sand characteristics. Deprecated according to the amendment to the Regulation (EU) 2019/777." ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "TSI Compliance of rules on sand characteristics"@en ;
                                     owl:deprecated "true"^^xsd:boolean ;
@@ -3285,7 +3311,7 @@ era:tsiCompliantSanding rdf:type owl:ObjectProperty ;
                         era:rinfIndex "1.1.1.3.7.16" ;
                         dcterms:created "2021-08-08"^^xsd:date ;
                         dcterms:modified "2023-03-14"^^xsd:date ;
-                        rdfs:comment "TSI compliance of sanding rules to allow compatibility with track circuits. Too much sand brings the risk of not detecting trains in tracks equipped with track circuits. Deprecated according to the ammendment to the Regulation (EU) 2019/777."@en ;
+                        rdfs:comment "TSI compliance of sanding rules to allow compatibility with track circuits. Too much sand brings the risk of not detecting trains in tracks equipped with track circuits. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "TSI compliance of sanding"@en ;
                         owl:deprecated "true"^^xsd:boolean ;
@@ -3301,7 +3327,7 @@ era:tsiCompliantShuntDevices rdf:type owl:ObjectProperty ;
                              era:rinfIndex "1.1.1.3.7.22" ;
                              dcterms:created "2021-08-08"^^xsd:date ;
                              dcterms:modified "2023-03-14"^^xsd:date ;
-                             rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. TSI compliance of rules on shunt assisting devices."@en ;
+                             rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. TSI compliance of rules on shunt assisting devices."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "TSI compliance of rules on shunt assisting devices"@en ;
                              owl:deprecated "true"^^xsd:boolean ;
@@ -3967,7 +3993,8 @@ era:dNvpotrp rdf:type owl:DatatypeProperty ,
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2023-03-14"^^xsd:date ,
                               "2024-04-18"^^xsd:date ;
-             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                            <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              rdfs:comment """Maximum distance for reversing in Post Trip mode in metres. 
 
 Precision: [NNNNNN.N], with N a decimal number (0÷9)
@@ -3975,7 +4002,6 @@ Precision: [NNNNNN.N], with N a decimal number (0÷9)
 See: TSI CCS (Subset 26, chapter 7. 7.5.1.16 D_NVPOTRP)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "D_NVPOTRP"@en ;
-             rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              vs:term_status "stable" ;
              skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -3993,7 +4019,8 @@ era:dNvroll rdf:type owl:DatatypeProperty ,
             dcterms:created "2022-11-07"^^xsd:date ;
             dcterms:modified "2023-03-14"^^xsd:date ,
                              "2024-04-18"^^xsd:date ;
-            dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+            dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                           <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
             rdfs:comment """Parameter used by the ETCS on-board to supervise the distance allowed to be travelled under the roll-away protection and the reverse movement protection, in metres.
 
 Precision: [NNNNNN.N], with N a decimal number (0÷9).
@@ -4001,7 +4028,6 @@ Precision: [NNNNNN.N], with N a decimal number (0÷9).
 See: TSI CCS (Subset 26, chapter 7. 7.5.1.17 D_NVROLL)"""@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             rdfs:label "D_NVROLL"@en ;
-            rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
             vs:term_status "stable" ;
             skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -4042,8 +4068,8 @@ era:demonstrationINF rdf:type owl:DatatypeProperty ;
                                    "1.2.2.0.1.2" ;
                      dcterms:created "2021-08-03"^^xsd:date ;
                      dcterms:modified "2024-01-08"^^xsd:date ;
-                     rdfs:comment """Unique number for EI declarations following the same format requirements as specified for EC declarations in Annex VII of Commission Implementing Regulation (EU) 2019/250.
-In https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019R0777&from=EN"""@en ;
+                     dcterms:source <https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019R0777&from=EN> ;
+                     rdfs:comment "Unique number for EI declarations following the same format requirements as specified for EC declarations in Annex VII of Commission Implementing Regulation (EU) 2019/250."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "EI declaration of demonstration (as defined Commission 2014/881/EU) for track relating to compliance with the requirements from TSIs applicable to infrastructure subsystem"@en ;
                      vs:term_status "stable" .
@@ -4304,10 +4330,11 @@ era:ertmsErrorCorrectionsOnBoard rdf:type owl:DatatypeProperty ;
                                  rdfs:domain era:CCSSubsystem ;
                                  rdfs:range xsd:anyURI ;
                                  dcterms:created "2024-01-08"^^xsd:date ;
+                                 dcterms:isReplacedBy era:errorCorrectionsOnboard ;
                                  dcterms:modified "2024-04-18"^^xsd:date ;
                                  rdfs:comment "List of unacceptable errors impacting the IM network that are required to be solved in the on-board according to the TSI CCS (point 7.2.10.3 - specification maintenance point)."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                 rdfs:label "(Deprecated) ERTMS error corrections required for the on-board. Use: errorCorrectionsOnboard"@en ;
+                                 rdfs:label "(Deprecated) ERTMS error corrections required for the on-board."@en ;
                                  owl:deprecated "true"^^xsd:boolean ;
                                  vs:term_status "stable" .
 
@@ -4331,11 +4358,12 @@ era:etcsErrorCorrectionsOnboard rdf:type owl:DatatypeProperty ;
                                 rdfs:range xsd:anyURI ;
                                 era:rinfIndex "1.2.1.1.1.19" ;
                                 dcterms:created "2023-03-14"^^xsd:date ;
+                                dcterms:isReplacedBy era:errorCorrectionsOnboard ;
                                 dcterms:modified "2024-01-08"^^xsd:date ,
                                                  "2024-04-18"^^xsd:date ;
                                 rdfs:comment "List of unacceptable errors impacting the IM network that are required to be solved in the on-board ETCS according to the CCS TSI point 7.2.10.3 specification maintenance point."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                rdfs:label "(Deprecated) ETCS error corrections required for the on-board. Use: errorCorrectionsOnboard"@en ;
+                                rdfs:label "(Deprecated) ETCS error corrections required for the on-board."@en ;
                                 owl:deprecated "true"^^xsd:boolean ;
                                 vs:term_status "stable" .
 
@@ -4351,11 +4379,11 @@ era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty ,
                                                        "1.2.1.1.1.13" ;
                                          dcterms:created "2022-11-04"^^xsd:date ;
                                          dcterms:modified "2024-04-18"^^xsd:date ;
-                                         dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                                         dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                                        <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                          rdfs:comment "If the trackside does not implement any solution to cover defective LXs (which are normally protected by means of a technical system), then drivers will be required to comply with instructions received from other sources."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                          rdfs:label "ETCS trackside implements level crossing procedure or an equivalent solution"@en ;
-                                         rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                          vs:term_status "stable" ;
                                          skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -4414,11 +4442,11 @@ NID_XUSER values managed by ERA in a document about ETCS variables available on 
 See: TSI CCS (7.4.3 & 6.2.4.2)"""@en ;
                          dcterms:modified "2021-09-12"^^xsd:date ,
                                           "2024-04-18"^^xsd:date ;
-                         dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                         dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                        <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                          rdfs:comment "Indication whether data for national packet 44 applications is transmitted between track and train."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "ETCS national packet 44 application implemented"@en ;
-                         rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                          vs:term_status "stable" ;
                          skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -4444,7 +4472,7 @@ era:etcsOptionalFunctions rdf:type owl:DatatypeProperty ;
                           dcterms:created "2021-08-08"^^xsd:date ;
                           dcterms:modified "2023-03-14"^^xsd:date ;
                           dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
-                          rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. Optional ETCS functions which might improve operation on the line."@en ;
+                          rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. Optional ETCS functions which might improve operation on the line."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "ETCS optional functions"@en ;
                           owl:deprecated "true"^^xsd:boolean ;
@@ -4479,11 +4507,11 @@ era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty ,
                                  dcterms:created "2022-11-04"^^xsd:date ;
                                  dcterms:modified "2023-03-14"^^xsd:date ,
                                                   "2024-04-18"^^xsd:date ;
-                                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                                <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                  rdfs:comment "If the trackside does not provide Track Conditions, the driver will need to be informed about such conditions via alternative methods."@en ;
                                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                  rdfs:label "Is the ETCS trackside engineered to transmit Track Conditions"@en ;
-                                 rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                                  vs:term_status "stable" ;
                                  skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -4536,7 +4564,7 @@ era:flangeLubeRules rdf:type owl:DatatypeProperty ;
                     era:rinfIndex "1.1.1.3.7.20" ;
                     dcterms:created "2021-08-08"^^xsd:date ;
                     dcterms:modified "2023-03-14"^^xsd:date ;
-                    rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. Indication whether rules for activation or deactivation of flange lubrication exist."@en ;
+                    rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. Indication whether rules for activation or deactivation of flange lubrication exist."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Existence of rules on on-board flange lubrication"@en ;
                     owl:deprecated "true"^^xsd:boolean ;
@@ -4708,6 +4736,7 @@ era:gsmrErrorCorrectionsOnboard rdf:type owl:DatatypeProperty ;
                                 rdfs:domain era:CCSSubsystem ;
                                 rdfs:range xsd:anyURI ;
                                 dcterms:created "2023-03-14"^^xsd:date ;
+                                dcterms:isReplacedBy era:errorCorrectionsOnboard ;
                                 dcterms:modified "2024-01-08"^^xsd:date ,
                                                  "2024-04-18"^^xsd:date ;
                                 rdfs:comment """List of unacceptable errors impacting the IM network that are required to be solved in the on-board according to the CCS TSI point 7.2.10.3 specification maintenance point.
@@ -4831,11 +4860,11 @@ These conditions and restrictions of use are considered in section 6.4 of the CC
 and deviations – Guidelines for using the ERA template) with the following link."""@en ;
                                   dcterms:modified "2024-01-08"^^xsd:date ,
                                                    "2024-04-18"^^xsd:date ;
-                                  dcterms:source <https://www.era.europa.eu/content/certification-issues> ;
+                                  dcterms:source <https://www.era.europa.eu/content/certification-issues> ,
+                                                 <https://www.era.europa.eu/system/files/2022-11/restrictions_and_added_functions_en_1.doc> ;
                                   rdfs:comment "Indication whether restrictions or conditions due to partial compliance with the TSI CCS exist."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "Existence of operating restrictions or conditions"@en ;
-                                  rdfs:seeAlso <https://www.era.europa.eu/system/files/2022-11/restrictions_and_added_functions_en_1.doc> ;
                                   vs:term_status "stable" ;
                                   skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -4950,7 +4979,7 @@ era:hasOtherTrainProtection rdf:type owl:DatatypeProperty ;
                             era:rinfIndex "1.1.1.3.5.1" ;
                             dcterms:created "2021-08-09"^^xsd:date ;
                             dcterms:modified "2023-03-14"^^xsd:date ;
-                            rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. Indication if other train protection, control and warning systems in normal operation are installed lineside."@en ;
+                            rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. Indication if other train protection, control and warning systems in normal operation are installed lineside."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Existence of other train protection, control and warning systems installed"@en ;
                             owl:deprecated "true"^^xsd:boolean ;
@@ -5308,12 +5337,12 @@ Each Section of Line may concern only one IM. """@en ;
            dcterms:isReplacedBy era:organisationCode ;
            dcterms:modified "2024-01-08"^^xsd:date ,
                             "2024-06-03"^^xsd:date ;
-           dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
+           dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ,
+                          <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02012L0034-20190101#tocId45> ;
            rdfs:comment """(deprecated) Infrastructure manager means any body or firm responsible in particular for establishing, managing and maintaining railway infrastructure, including traffic management and control-command and signalling; 
 the functions of the infrastructure manager on a network or part of a network may be allocated to different bodies or firms. Definition in (Article 3(2))"""@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "Infrastructure manager (IM)'s code"@en ;
-           rdfs:seeAlso <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A02012L0034-20190101#tocId45> ;
            owl:deprecated "true"^^xsd:boolean ;
            vs:term_status "stable" .
 
@@ -5604,13 +5633,13 @@ era:mNvderun rdf:type owl:DatatypeProperty ,
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2023-03-14"^^xsd:date ,
                               "2023-04-18"^^xsd:date ;
-             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                            <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              rdfs:comment """Entry of Driver ID permitted while running. 
 
 See: TSI CCS (Subset 26, chapter 7. 7.5.1.75 M_NVDERUN)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "M_NVDERUN"@en ;
-             rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              vs:term_status "stable" ;
              skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -5691,7 +5720,7 @@ era:maxDistConsecutiveAxles rdf:type owl:DatatypeProperty ;
                             era:unitOfMeasure unit:MilliM ;
                             dcterms:created "2021-08-08"^^xsd:date ;
                             dcterms:modified "2023-03-14"^^xsd:date ;
-                            rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter. Indication of maximum permitted distance between two consecutive axles in case of TSI non-compliance, given in millimetres."@en ;
+                            rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter. Indication of maximum permitted distance between two consecutive axles in case of TSI non-compliance, given in millimetres."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Maximum permitted distance between two consecutive axles in case of TSI non-compliance"@en ;
                             vs:term_status "stable" .
@@ -5706,7 +5735,7 @@ era:maxDistEndTrainFirstAxle rdf:type owl:DatatypeProperty ;
                              era:unitOfMeasure unit:MilliM ;
                              dcterms:created "2021-08-08"^^xsd:date ;
                              dcterms:modified "2023-03-14"^^xsd:date ;
-                             rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. Indication of maximum distance between end of train and first axle, given in millimetres, applicable for both sides (front and rear) of a vehicle or train."@en ;
+                             rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. Indication of maximum distance between end of train and first axle, given in millimetres, applicable for both sides (front and rear) of a vehicle or train."@en ;
                              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                              rdfs:label "Maximum distance between end of train and first axle"@en ;
                              owl:deprecated "true"^^xsd:boolean ;
@@ -5727,7 +5756,7 @@ era:maxFlangeHeight rdf:type owl:DatatypeProperty ;
                     era:unitOfMeasure unit:MilliM ;
                     dcterms:created "2021-08-08"^^xsd:date ;
                     dcterms:modified "2023-03-14"^^xsd:date ;
-                    rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter. Maximum permitted flange height, given in millimiters."@en ;
+                    rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter. Maximum permitted flange height, given in millimiters."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Maximum permitted height of the flange"@en ;
                     vs:term_status "stable" .
@@ -6044,10 +6073,13 @@ era:maximumTemperature rdf:type owl:DatatypeProperty ;
                        era:rinfIndex "1.1.1.1.2.6" ;
                        era:usedInRCCCalculations "true"^^xsd:boolean ;
                        dcterms:created "2020-08-24"^^xsd:date ;
-                       dcterms:modified "2021-09-10"^^xsd:date ;
-                       rdfs:comment "Maximum temperature allowed for unrestricted operation access, according to European standard."@en ;
+                       dcterms:isReplacedBy era:TemperatureRange ;
+                       dcterms:modified "2021-09-10"^^xsd:date ,
+                                        "2024-09-25"^^xsd:date ;
+                       rdfs:comment "Deprecated because both RINF and ERATV define a temperature range as a set of predefined values (see https://www.era.europa.eu/system/files/2023-04/iu-eratv_application_guide_for_register_2016-797_en_0.pdf). Maximum temperature allowed for unrestricted operation access, according to European standard."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Temperature range (maximum)"@en ;
+                       owl:deprecated "true"^^xsd:boolean ;
                        vs:term_status "stable" .
 
 
@@ -6097,7 +6129,7 @@ era:minAxleLoad rdf:type owl:DatatypeProperty ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Minimum permitted axle load"@en ;
                 vs:term_status "stable" ;
-                skos:scopeNote "Should be deprecated according to the ammendment to the Regulation (EU) 2019/777 but remains because it is also a parameter of ERATV."@en .
+                skos:scopeNote "Should be deprecated according to the amendment to the Regulation (EU) 2019/777 but remains because it is also a parameter of ERATV."@en .
 
 
 ###  http://data.europa.eu/949/minDistConsecutiveAxles
@@ -6114,7 +6146,7 @@ era:minDistConsecutiveAxles rdf:type owl:DatatypeProperty ;
                             era:unitOfMeasure unit:MilliM ;
                             dcterms:created "2021-08-08"^^xsd:date ;
                             dcterms:modified "2023-03-14"^^xsd:date ;
-                            rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
+                            rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Minimum permitted distance between two consecutive axles"@en ;
                             vs:term_status "stable" ;
@@ -6135,7 +6167,7 @@ era:minDistFirstLastAxle rdf:type owl:DatatypeProperty ;
                          era:unitOfMeasure unit:MilliM ;
                          dcterms:created "2021-08-08"^^xsd:date ;
                          dcterms:modified "2023-03-14"^^xsd:date ;
-                         rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
+                         rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "Minimum permitted distance between first and last axle"@en ;
                          vs:term_status "stable" ;
@@ -6156,7 +6188,7 @@ era:minFlangeHeight rdf:type owl:DatatypeProperty ;
                     era:unitOfMeasure unit:MilliM ;
                     dcterms:created "2021-08-08"^^xsd:date ;
                     dcterms:modified "2021-09-01"^^xsd:date ;
-                    rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
+                    rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "Minimum permitted height of the flange"@en ;
                     vs:term_status "stable" ;
@@ -6177,7 +6209,7 @@ era:minFlangeThickness rdf:type owl:DatatypeProperty ;
                        era:unitOfMeasure unit:MilliM ;
                        dcterms:created "2021-08-08"^^xsd:date ;
                        dcterms:modified "2021-09-01"^^xsd:date ;
-                       rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
+                       rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Minimum permitted thickness of the flange"@en ;
                        vs:term_status "stable" ;
@@ -6198,7 +6230,7 @@ era:minRimWidth rdf:type owl:DatatypeProperty ;
                 era:unitOfMeasure unit:MilliM ;
                 dcterms:created "2021-08-08"^^xsd:date ;
                 dcterms:modified "2023-03-14"^^xsd:date ;
-                rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
+                rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "Minimum permitted width of the rim"@en ;
                 vs:term_status "stable" .
@@ -6254,7 +6286,7 @@ era:minWheelDiameter rdf:type owl:DatatypeProperty ;
                      era:unitOfMeasure unit:MilliM ;
                      dcterms:created "2021-08-08"^^xsd:date ;
                      dcterms:modified "2023-03-14"^^xsd:date ;
-                     rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
+                     rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. However, the parameter remains as it is also an ERATV parameter."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Minimum permitted wheel diameter"@en ;
                      vs:term_status "stable" ;
@@ -6339,10 +6371,13 @@ era:minimumTemperature rdf:type owl:DatatypeProperty ;
                        era:rinfIndex "1.1.1.1.2.6" ;
                        era:usedInRCCCalculations "true"^^xsd:boolean ;
                        dcterms:created "2020-08-24"^^xsd:date ;
-                       dcterms:modified "2021-09-10"^^xsd:date ;
-                       rdfs:comment "Minimum temperature allowed for unrestricted operation access, according to European standard."@en ;
+                       dcterms:isReplacedBy era:temperatureRange ;
+                       dcterms:modified "2021-09-10"^^xsd:date ,
+                                        "2024-09-25"^^xsd:date ;
+                       rdfs:comment "Deprecated because both RINF and ERATV define a temperature range as a set of predefined values (see https://www.era.europa.eu/system/files/2023-04/iu-eratv_application_guide_for_register_2016-797_en_0.pdf). Minimum temperature allowed for unrestricted operation access, according to European standard."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "Temperature range (minimum)"@en ;
+                       owl:deprecated "true"^^xsd:boolean ;
                        vs:term_status "stable" .
 
 
@@ -6425,7 +6460,7 @@ era:multipleTrainProtectionRequired rdf:type owl:DatatypeProperty ;
                                     era:rinfIndex "1.1.1.3.5.2" ;
                                     dcterms:created "2021-08-09"^^xsd:date ;
                                     dcterms:modified "2023-03-14"^^xsd:date ;
-                                    rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. Indication whether more than one train protection, control and warning system is required to be on-board and active simultaneously."@en ;
+                                    rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. Indication whether more than one train protection, control and warning system is required to be on-board and active simultaneously."@en ;
                                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                     rdfs:label "Need for more than one train protection, control and warning system required on board"@en ;
                                     owl:deprecated "true"^^xsd:boolean ;
@@ -6478,7 +6513,7 @@ era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty ,
                              rdfs:domain era:CCSSubsystem ;
                              rdfs:range xsd:string ;
                              era:XMLName "CPE_NVBRAKEMOD" ;
-                             era:appendixD3index "1.5.13" ;
+                             era:appendixD3Index "1.5.13" ;
                              era:rinfIndex "1.1.1.3.2.16.13" ,
                                            "1.2.1.1.1.16.13" ;
                              dcterms:created "2023-03-14"^^xsd:date ;
@@ -6971,18 +7006,18 @@ era:qNvsbtsmperm rdf:type owl:DatatypeProperty ,
                  rdfs:domain era:CCSSubsystem ;
                  rdfs:range xsd:boolean ;
                  era:XMLName "CPE_QNVSBTSMPERM" ;
-                 era:appendixD3index "1.5.12" ;
+                 era:appendixD3Index "1.5.12" ;
                  era:rinfIndex "1.1.1.3.2.16.12" ,
                                "1.2.1.1.1.16.12" ;
                  dcterms:created "2023-03-14"^^xsd:date ;
                  dcterms:modified "2024-04-18"^^xsd:date ;
-                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                 dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                  rdfs:comment """Permission to use service brake in target speed monitoring.
 
 See: TSI CCS (Subset-026, chapter 7. 7.5.1.124 Q_NVSBTSMPERM)"""@en ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Q_NVSBTSMPERM"@en ;
-                 rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                  vs:term_status "stable" ;
                  skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -7006,7 +7041,7 @@ era:radioNetworkId rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:string ;
                    era:XMLName "CRG_RadioNID" ;
                    era:appendixD2Index "3.4.4" ;
-                   era:rinfIndex "1.1.1.3.3.13" ,
+                   era:rinfIndex "1.1.1.3.3.12" ,
                                  "1.2.1.1.2.13" ;
                    dcterms:created "2023-03-14"^^xsd:date ;
                    dcterms:modified "2024-04-18"^^xsd:date ;
@@ -7218,7 +7253,7 @@ era:requiredSandingOverride rdf:type owl:DatatypeProperty ;
                             dcterms:created "2021-08-08"^^xsd:date ;
                             dcterms:modified "2023-03-14"^^xsd:date ;
                             dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
-                            rdfs:comment "Indication whether possibility to activate/deactivate sanding devices by driver, according to instructions from the Infrastructure Manager, is required or not. Deprecated according to the ammendment to the Regulation (EU) 2019/777."@en ;
+                            rdfs:comment "Indication whether possibility to activate/deactivate sanding devices by driver, according to instructions from the Infrastructure Manager, is required or not. Deprecated according to the amendment to the Regulation (EU) 2019/777."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "Sanding override by driver required"@en ;
                             owl:deprecated "true"^^xsd:boolean ;
@@ -7584,7 +7619,8 @@ era:tNvcontact rdf:type owl:DatatypeProperty ,
                dcterms:created "2022-11-07"^^xsd:date ;
                dcterms:modified "2023-03-14"^^xsd:date ,
                                 "2024-04-18"^^xsd:date ;
-               dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+               dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                              <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                rdfs:comment """Maximum time without a safe message from Radio Block Center before train reacts in seconds. 
 
 Precision: [NNN], with N a decimal number (0÷9), NNN = 255 means ∞ seconds, so values cannot be higher.
@@ -7592,7 +7628,6 @@ Precision: [NNN], with N a decimal number (0÷9), NNN = 255 means ∞ seconds, s
 See: TSI CCS (Subset 26, chapter 7. 7.5.1.148 T_NVCONTACT)"""@en ;
                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                rdfs:label "T_NVCONTACT"@en ;
-               rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                vs:term_status "stable" ;
                skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -7610,7 +7645,8 @@ era:tNvovtrp rdf:type owl:DatatypeProperty ,
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2023-03-14"^^xsd:date ,
                               "2024-04-18"^^xsd:date ;
-             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+             dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                            <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              rdfs:comment """Maximum time for overriding the train trip in seconds.
 
 Precision: [NNN], with N a decimal number (0÷9)
@@ -7618,7 +7654,6 @@ Precision: [NNN], with N a decimal number (0÷9)
 See: TSI CCS (Subset 26, chapter 7. 7.5.1.149 T_NVOVTRP)"""@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "T_NVOVTRP"@en ;
-             rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
              vs:term_status "stable" ;
              skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -7715,7 +7750,7 @@ era:tiltingSupported rdf:type owl:DatatypeProperty ;
                      era:rinfIndex "1.1.1.3.12.1" ;
                      dcterms:created "2021-08-09"^^xsd:date ;
                      dcterms:modified "2023-03-14"^^xsd:date ;
-                     rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. Indication whether tilting functions are supported by ETCS."@en ;
+                     rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. Indication whether tilting functions are supported by ETCS."@en ;
                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                      rdfs:label "Indication whether tilting functions are supported by ETCS"@en ;
                      owl:deprecated "true"^^xsd:boolean ;
@@ -7767,27 +7802,6 @@ era:trainControlSwitchOverSpecialConditions rdf:type owl:DatatypeProperty ;
                                             vs:term_status "stable" .
 
 
-###  http://data.europa.eu/949/trainDetectionSystemSpecificCheck
-era:trainDetectionSystemSpecificCheck rdf:type owl:DatatypeProperty ;
-                                      rdfs:domain era:TrainDetectionSystem ;
-                                      rdfs:range xsd:string ;
-                                      era:XMLName "CTD_TCCheck" ;
-                                      era:rinfIndex "1.1.1.3.7.1.2" ,
-                                                    "1.2.1.1.6.1" ;
-                                      era:usedInRCCCalculations "false"^^xsd:boolean ;
-                                      dcterms:created "2020-08-24"^^xsd:date ;
-                                      dcterms:modified "2021-08-08"^^xsd:date ,
-                                                       "2024-04-18"^^xsd:date ;
-                                      dcterms:relation era:trainDetectionSystemSpecificCheckDocument ;
-                                      dcterms:source <https://www.era.europa.eu/system/files/2023-09/index077_-_ERA_ERTMS_033281_v5.pdf> ;
-                                      rdfs:comment "Reference to the technical specification of train detection system."@en ;
-                                      rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                      rdfs:label "Type of track circuits or axle counters to which specific checks are needed. "@en ;
-                                      owl:deprecated "false"^^xsd:boolean ;
-                                      vs:term_status "stable" ;
-                                      skos:scopeNote "String containing the name of the TD system for which checks are mentioned in 1.1.1.3.7.1.3."@en .
-
-
 ###  http://data.europa.eu/949/trainIntegrityOnBoardRequired
 era:trainIntegrityOnBoardRequired rdf:type owl:DatatypeProperty ,
                                            owl:FunctionalProperty ;
@@ -7805,7 +7819,7 @@ era:trainIntegrityOnBoardRequired rdf:type owl:DatatypeProperty ,
                                                          ]
                                              ] ;
                                   era:XMLName "CPE_IntegrityConfirmation" ;
-                                  era:appendixD2index "3.4.11" ;
+                                  era:appendixD2Index "3.4.11" ;
                                   era:rinfIndex "1.1.1.3.2.8" ,
                                                 "1.2.1.1.1.8" ;
                                   era:usedInRCCCalculations "true"^^xsd:boolean ;
@@ -8020,7 +8034,8 @@ era:vNvallowovtrp rdf:type owl:DatatypeProperty ,
                   era:unitOfMeasure unit:KiloM-PER-HR ;
                   dcterms:created "2022-11-07"^^xsd:date ;
                   dcterms:modified "2023-03-14"^^xsd:date ;
-                  dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                  dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                                 <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                   rdfs:comment """Speed limit allowing the driver to select the “override” function in km/h.
 
 Format: [NNF], with N a decimal number (0÷9), F=(0|5), max. `600`.
@@ -8028,7 +8043,6 @@ Format: [NNF], with N a decimal number (0÷9), F=(0|5), max. `600`.
 See: TSI CCS (Subset-026, Chapter 7. 7.5.1.161)"""@en ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "V_NVALLOWOVTRP"@en ;
-                  rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                   vs:term_status "stable" ;
                   skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -8045,7 +8059,8 @@ era:vNvsupovtrp rdf:type owl:DatatypeProperty ,
                 era:unitOfMeasure unit:KiloM-PER-HR ;
                 dcterms:created "2022-11-07"^^xsd:date ;
                 dcterms:modified "2023-03-14"^^xsd:date ;
-                dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
+                               <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                 rdfs:comment """Override speed limit to be supervised when the “override” function is active in km/h.
 
 Format: [NNF], with N a decimal number (0÷9), F=(0|5), max. `600`.
@@ -8053,7 +8068,6 @@ Format: [NNF], with N a decimal number (0÷9), F=(0|5), max. `600`.
 See: TSI CCS (Subset-026, chapter 7. 7.5.1.163 V_NVSUPOVTRP)"""@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "V_NVSUPOVTRP"@en ;
-                rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
                 vs:term_status "stable" ;
                 skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
@@ -8258,8 +8272,8 @@ era:verificationINF rdf:type owl:DatatypeProperty ;
                                   "1.2.2.0.1.1" ;
                     dcterms:created "2021-08-03"^^xsd:date ;
                     dcterms:modified "2024-01-08"^^xsd:date ;
-                    rdfs:comment """Unique number for EC declarations in accordance with Commission Implementing Regulation (EU) 2019/250.
-In https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019R0777&from=EN."""@en ;
+                    dcterms:source <https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32019R0777&from=EN> ;
+                    rdfs:comment "Unique number for EC declarations in accordance with Commission Implementing Regulation (EU) 2019/250."@en ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "EC declaration of verification for track relating to compliance with the requirements from TSIs applicable to infrastructure subsystem"@en ;
                     vs:term_status "stable" .
@@ -8437,6 +8451,7 @@ foaf:nick rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/AggregatedObject
 era:AggregatedObject rdf:type owl:Class ;
                      rdfs:subClassOf era:InfrastructureObject ;
+                     owl:disjointWith era:BasicObject ;
                      rdfs:comment "An aggregated object is an infrastructure object defined at a higher level of granularity, containing at least one basic object. Example: in one operational point we can find several tracks, switches, signals, etc."@en ;
                      rdfs:label "Aggregated Object"@en .
 
@@ -8699,6 +8714,8 @@ Each track can have several load capability (structured) values, and each one ha
 era:Manufacturer rdf:type owl:Class ;
                  rdfs:subClassOf org:Organization ;
                  dcterms:created "2020-11-19"^^xsd:date ;
+                 dcterms:isReplacedBy era:Body ,
+                                      era:manufacturer ;
                  dcterms:modified "2020-11-19"^^xsd:date ,
                                   "2024-06-03"^^xsd:date ;
                  rdfs:comment "(deprecated) Replaced by the era:Body class and era:manufacturer property. A company or organization that manufactures vehicles."@en ;
@@ -8736,7 +8753,7 @@ era:MaximumSpeedAndCantDeficiency rdf:type owl:Class ;
 era:MinAxleLoadVehicleCategory rdf:type owl:Class ;
                                dcterms:created "2023-01-25"^^xsd:date ;
                                dcterms:modified "2023-03-14"^^xsd:date ;
-                               rdfs:comment "Deprecated according to the ammendment to the Regulation (EU) 2019/777. Represents information that indicates the load given in tons depending of the category of vehicle. Its properties are minAxleLoadVehicleCategory and minAxleLoad."@en ;
+                               rdfs:comment "Deprecated according to the amendment to the Regulation (EU) 2019/777. Represents information that indicates the load given in tons depending of the category of vehicle. Its properties are minAxleLoadVehicleCategory and minAxleLoad."@en ;
                                rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                rdfs:label "Min axle load vehicle category"@en ;
                                owl:deprecated "true"^^xsd:boolean ;
@@ -8850,24 +8867,24 @@ era:Position rdf:type owl:Class ;
 era:PrimaryLocation rdf:type owl:Class ;
                     rdfs:subClassOf era:AggregatedObject ;
                     owl:disjointWith era:RadioBlockCenter ;
+                    dcterms:source <http://taf-jsg.info/wp-content/uploads/2024/01/20231018-JGS-Handbook-3.4-with-XSD-3.4.0.0.pdf> ;
                     rdfs:comment """Primary Location is a place used by IM to define a path for a train in TAF/TAP TSI framework/messages. This location is a rail point inside the rail network where train starts, ends, stops, or runs through or change line. This location must be managed by an Infrastructure Manager (IM) identified by company code.
 Primary locations are for example: stations, yards, halts, handover points, border points, open access terminals. 
 Primary locations are identified by single and unique Primary Location codes. Primary location code is allocated based on processes defined by national entity. Primary location codes are used in any kind of TAF/TAP communication.
 
 See: Handbook 9.3.3 / page 60"""@en ;
-                    rdfs:label "Primary Location"@en ;
-                    rdfs:seeAlso <http://taf-jsg.info/wp-content/uploads/2024/01/20231018-JGS-Handbook-3.4-with-XSD-3.4.0.0.pdf> .
+                    rdfs:label "Primary Location"@en .
 
 
 ###  http://data.europa.eu/949/RadioBlockCenter
 era:RadioBlockCenter rdf:type owl:Class ;
                      rdfs:subClassOf era:AggregatedObject ;
+                     dcterms:source <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32023R1693&qid=1698394526534> ,
+                                    <https://www.era.europa.eu/system/files/2023-09/index003_-_SUBSET-023_v400.pdf> ;
                      rdfs:comment """ETCS trackside centralised unit controlling ETCS train movements in level 2.
 
 A centralised safety unit that receives train position information via radio and sends movement authorities via radio to trains."""@en ;
-                     rdfs:label "Radio Block Center"@en ;
-                     rdfs:seeAlso <https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32023R1693&qid=1698394526534> ,
-                                  <https://www.era.europa.eu/system/files/2023-09/index003_-_SUBSET-023_v400.pdf> .
+                     rdfs:label "Radio Block Center"@en .
 
 
 ###  http://data.europa.eu/949/RaisedPantographsDistanceAndSpeed
@@ -9028,9 +9045,9 @@ era:SubsidiaryLocation rdf:type owl:Class ;
                                          owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                          owl:onClass era:PrimaryLocation
                                        ] ;
+                       dcterms:source <http://taf-jsg.info/wp-content/uploads/2024/01/20231018-JGS-Handbook-3.4-with-XSD-3.4.0.0.pdf> ;
                        rdfs:comment "Subsidiary location must be linked to a Primary Location and specifies in more detailed way part, attributes, or usage of Primary location. It may be also a non-rail point or a rail point that is not managed by an Infrastructure Manager (IM). It may be defined by entity having company code according to their needs. The Subsidiary location is optional and dependent upon business needs."@en ;
-                       rdfs:label "Subsidiary location"@en ;
-                       rdfs:seeAlso <http://taf-jsg.info/wp-content/uploads/2024/01/20231018-JGS-Handbook-3.4-with-XSD-3.4.0.0.pdf> .
+                       rdfs:label "Subsidiary location"@en .
 
 
 ###  http://data.europa.eu/949/Switch
@@ -9039,9 +9056,9 @@ era:Switch rdf:type owl:Class ;
            owl:disjointWith era:Track ,
                             era:Tunnel ;
            dc:source <https://eur-lex.europa.eu/eli/reg_impl/2019/776/oj> ;
+           dcterms:source <http://data.europa.eu/eli/reg/2014/1299/2019-06-16> ;
            rdfs:comment "A unit of track comprising two fixed rails (stock rails) and two movable rails (switch rails) used to direct vehicles from one track to another track."@en ;
            rdfs:label "Switch"@en ;
-           rdfs:seeAlso <http://data.europa.eu/eli/reg/2014/1299/2019-06-16> ;
            vs:term_status "stable" .
 
 
@@ -9126,6 +9143,8 @@ era:Vehicle rdf:type owl:Class ;
 era:VehicleKeeper rdf:type owl:Class ;
                   rdfs:subClassOf org:Organization ;
                   dcterms:created "2020-11-23"^^xsd:date ;
+                  dcterms:isReplacedBy era:Body ,
+                                       era:vehicleKeeper ;
                   dcterms:modified "2020-11-23"^^xsd:date ,
                                    "2024-04-18"^^xsd:date ,
                                    "2024-06-03"^^xsd:date ;
@@ -9455,10 +9474,16 @@ foaf:Person rdf:type owl:Class ;
             vs:term_status "stable" .
 
 
-[ foaf:name "Dragos Patru" ;
+[ foaf:name "Ghislain Atemezing" ;
+  dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
 ] .
 
+[ foaf:name "Ghislain Atemezing" ;
+   dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
 [ foaf:name "Maarten Duhoux" ;
    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
  ] .
@@ -9471,13 +9496,7 @@ foaf:Person rdf:type owl:Class ;
    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
  ] .
 
-[ foaf:name "Ghislain Atemezing" ;
-   rdfs:seeAlso <https://orcid.org/0000-0003-1562-6922> ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Ghislain Atemezing" ;
-   rdfs:seeAlso <https://orcid.org/0000-0003-1562-6922> ;
+[ foaf:name "Dragos Patru" ;
    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
  ] .
 
@@ -9493,7 +9512,6 @@ wgs:lat_long rdfs:comment "A comma-separated representation of a latitude, longi
 
 
 wgs:location rdfs:label "Location" ;
-             era:rinfIndex "1.1.0.0.1.1" ;
              rdfs:comment """The relation between something and the point, 
  or other geometrical thing in space, where it is.  For example, the realtionship between
  a radio tower and a Point with a given lat and long.
@@ -9502,7 +9520,8 @@ wgs:location rdfs:label "Location" ;
  Clearly in practice there will be limit to the accuracy of any such statement, but one would expect
  an accuracy appropriate for the size of the object and uses such as mapping .
  """ ;
-             era:rinfIndex "1.1.1.3.14.5" ,
+             era:rinfIndex "1.1.0.0.1.1" ,
+                           "1.1.1.3.14.5" ,
                            "1.2.1.0.8.5" ,
                            "1.2.0.0.0.5" ;
              era:usedInRCCCalculations "true"^^xsd:boolean ;

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -1,3 +1,4 @@
+@prefix : <http://data.europa.eu/949/> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
@@ -15,6 +16,7 @@
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@base <http://data.europa.eu/949/> .
 
 <http://data.europa.eu/949/> rdf:type owl:Ontology ;
                               cc:license <https://creativecommons.org/licenses/by/4.0/> ;
@@ -37,7 +39,8 @@
                                                "2024-07-05"^^xsd:date ,
                                                "2024-08-02"^^xsd:date ,
                                                "2024-08-12"^^xsd:date ,
-                                               "2024-08-13"^^xsd:date ;
+                                               "2024-08-13"^^xsd:date ,
+                                               "2024-09-20"^^xsd:date ;
                               dcterms:publisher "European Union Agency for Railways" ;
                               dcterms:title "ERA Ontology"@en ;
                               rdfs:comment """This is the human and machine readable Ontology governed by the European Union Agency for Railways (https://www.era.europa.eu/). It represents the concepts and relationships linked to the sectorial legal framework and the use cases under the AgencyÂ´s remit, as described in the Commission Implementing Regulation (EU) [to be updated after publication] on the common specifications for the register of railway infrastructure [to be updated after publication].
@@ -49,7 +52,11 @@ The Ontology also includes the routebook concepts described in appendix D2 \"Ele
                               owl:priorVersion "https://github.com/Interoperable-data/ERA_vocabulary/releases/v3.0.0"^^xsd:anyURI ;
                               owl:versionInfo "v3.1.0"@en ;
                               owl:versionURI <https://github.com/Interoperable-data/ERA_vocabulary/releases/releases/v3.1.0> ;
-                              skos:changeNote """
+                              skos:changeNote """Revision 20-08-2024
+- Change era:qNvdriverAdhes to an object property that points to a SKOS concept scheme   (currently a boolean data property)
+- Add era:inSkosConceptScheme for  era:hasOrganisationRole
+- Add era:inSkosConceptScheme for era:operatingLanguage: http://publications.europa.eu/resource/authority/language
+
 Revision 13-08-2024:
 - clarified the comment and label for ORG pattern as per issue #74.
 - renamed prefix qudt: to unit: to avoid confusion as per issue #47. 
@@ -100,9 +107,7 @@ Revision 18-04-2024:
 - updated as per results of the Topical Working Group RINF-CCS (Draft report 0.2);
 - include upcoming remarks from TWG members (inclusing those as documented in Report 0.3);
 - linked with existing (updated) or new SKOS Concepts, related to the TWG RINF CCS;
-- included references and guidelines as in Table 5 of the RINF Application Guide.
-					  
-							  """@en .
+- included references and guidelines as in Table 5 of the RINF Application Guide."""@en .
 
 #################################################################
 #    Annotation properties
@@ -133,6 +138,9 @@ era:appendixD2Index rdf:type owl:AnnotationProperty ;
                     rdfs:range xsd:string .
 
 
+###  http://data.europa.eu/949/appendixD2index
+era:appendixD2index rdf:type owl:AnnotationProperty .
+
 
 ###  http://data.europa.eu/949/appendixD3Index
 era:appendixD3Index rdf:type owl:AnnotationProperty ;
@@ -145,6 +153,8 @@ era:appendixD3Index rdf:type owl:AnnotationProperty ;
                     rdfs:range xsd:string .
 
 
+###  http://data.europa.eu/949/appendixD3index
+era:appendixD3index rdf:type owl:AnnotationProperty .
 
 
 ###  http://data.europa.eu/949/canonicalURI
@@ -1553,6 +1563,7 @@ era:hasOrganisationRole rdf:type owl:ObjectProperty ,
                                  owl:FunctionalProperty ;
                         rdfs:domain era:OrganisationRole ;
                         rdfs:range skos:Concept ;
+                        era:inSkosConceptScheme <http://data.europa.eu/949/concepts/organisation-roles/OrgRoles> ;
                         dcterms:created "2024-06-03"^^xsd:date ;
                         rdfs:comment "The role plays in an n-ary relationship between a Body and a specific concept in the concept scheme of organisation roles"@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -2144,6 +2155,7 @@ era:opType rdf:type owl:ObjectProperty ;
 era:operatingLanguage rdf:type owl:ObjectProperty ;
                       rdfs:range skos:Concept ;
                       era:appendixD2Index "3.5.1" ;
+                      era:inSkosConceptScheme <http://publications.europa.eu/resource/authority/language> ;
                       era:rinfIndex "1.1.0.0.1.2" ,
                                     "1.2.0.0.0.8" ;
                       dcterms:created "2022-10-28"^^xsd:date ;
@@ -2457,6 +2469,29 @@ era:protectionLegacySystem rdf:type owl:ObjectProperty ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "Train protection legacy system"@en ;
                            vs:term_status "stable" .
+
+
+###  http://data.europa.eu/949/qNvdriverAdhes
+era:qNvdriverAdhes rdf:type owl:ObjectProperty ,
+                            owl:FunctionalProperty ;
+                   rdfs:domain era:CCSSubsystem ;
+                   rdfs:range skos:Concept ;
+                   era:XMLName "CPE_QNVDRIVERADHES" ;
+                   era:appendixD3Index "1.5.11" ;
+                   era:inSkosConceptScheme <http://data.europa.eu/949/concepts/adhf-qualifier/AdhesionFactorChange> ;
+                   era:rinfIndex "1.1.1.3.2.16.11" ,
+                                 "1.2.1.1.1.16.11" ;
+                   dcterms:created "2024-04-18"^^xsd:date ;
+                   dcterms:modified "2024-09-20"^^xsd:date ;
+                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
+                   rdfs:comment """Qualifier determining whether the driver is allowed to modify the adhesion factor used by the ETCS on-board to calculate the braking curves. 
+
+See: TSI CCS (Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES)"""@en ;
+                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                   rdfs:label "Q_NVDRIVER_ADHES"@en ;
+                   rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
+                   vs:term_status "stable" ;
+                   skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
 
 
 ###  http://data.europa.eu/949/qNvemrrls
@@ -6921,27 +6956,6 @@ era:publicNetworkRoamingDetails rdf:type owl:DatatypeProperty ,
                                 skos:scopeNote "GSM-R (parameter 1.1.1.3.3.1) must be installed for this parameter to be applicable."@en .
 
 
-###  http://data.europa.eu/949/qNvdriverAdhes
-era:qNvdriverAdhes rdf:type owl:DatatypeProperty ,
-                            owl:FunctionalProperty ;
-                   rdfs:domain era:CCSSubsystem ;
-                   rdfs:range xsd:boolean ;
-                   era:XMLName "CPE_QNVDRIVERADHES" ;
-                   era:appendixD3Index "1.5.11" ;
-                   era:rinfIndex "1.1.1.3.2.16.11" ,
-                                 "1.2.1.1.1.16.11" ;
-                   dcterms:created "2024-04-18"^^xsd:date ;
-                   dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
-                   rdfs:comment """Boolean determining whether the driver is allowed to modify the adhesion factor used by the ETCS on-board to calculate the braking curves. 
-
-See: TSI CCS (Subset 26, chapter 7. 7.5.1.122 Q_NVDRIVER_ADHES)"""@en ;
-                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                   rdfs:label "Q_NVDRIVER_ADHES"@en ;
-                   rdfs:seeAlso <https://www.era.europa.eu/domains/technical-specifications-interoperability/control-command-and-signalling-tsi_en#oe-content-paragraph-1632> ;
-                   vs:term_status "stable" ;
-                   skos:scopeNote "Only applicable when selected value for 1.1.1.3.2.1 (ETCS present)."@en .
-
-
 ###  http://data.europa.eu/949/qNvsbtsmperm
 era:qNvsbtsmperm rdf:type owl:DatatypeProperty ,
                           owl:FunctionalProperty ;
@@ -9199,6 +9213,10 @@ skos:ConceptScheme rdf:type owl:Class .
 time:Instant rdf:type owl:Class .
 
 
+###  http://www.w3.org/2006/time#Interval
+time:Interval rdf:type owl:Class .
+
+
 ###  http://www.w3.org/2006/time#TemporalDuration
 time:TemporalDuration rdf:type owl:Class ;
                       rdfs:comment "Time extent; duration of a time interval separate from its particular start position"@en ;
@@ -9218,8 +9236,8 @@ time:TemporalEntity rdf:type owl:Class ;
                     skos:definition "A temporal interval or instant."@en .
 
 
-###  http://www.w3.org/2006/time#Interval
-<http://www.w3.org/2006/time#Interval> rdf:type owl:Class .
+###  http://www.w3.org/2006/time#:Interval
+<http://www.w3.org/2006/time#:Interval> rdf:type owl:Class .
 
 
 ###  http://www.w3.org/ns/org#Organization
@@ -9267,6 +9285,19 @@ foaf:Person rdf:type owl:Class ;
 foaf:Project rdf:type owl:Class .
 
 
+[ foaf:name "Ghislain Atemezing" ;
+  rdfs:seeAlso <https://orcid.org/0000-0003-1562-6922> ;
+  org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+] .
+
+[ foaf:name "Dragos Patru" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Maarten Duhoux" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
 #################################################################
 #    Annotations
 #################################################################
@@ -9278,12 +9309,7 @@ wgs:lat_long rdfs:comment "A comma-separated representation of a latitude, longi
              rdfs:label "Lat/long" .
 
 
-wgs:location era:rinfIndex "1.1.0.0.1.1" ,
-                           "1.1.1.0.1.1" ,
-                           "1.1.1.3.14.5" ,
-                           "1.2.0.0.0.5" ,
-                           "1.2.1.0.8.5" ;
-             era:usedInRCCCalculations "true"^^xsd:boolean ;
+wgs:location rdfs:label "Location" ;
              rdfs:comment """The relation between something and the point, 
  or other geometrical thing in space, where it is.  For example, the realtionship between
  a radio tower and a Point with a given lat and long.
@@ -9292,7 +9318,12 @@ wgs:location era:rinfIndex "1.1.0.0.1.1" ,
  Clearly in practice there will be limit to the accuracy of any such statement, but one would expect
  an accuracy appropriate for the size of the object and uses such as mapping .
  """ ;
-             rdfs:label "Location" .
+             era:rinfIndex "1.1.0.0.1.1" ,
+                           "1.1.1.3.14.5" ,
+                           "1.2.1.0.8.5" ,
+                           "1.2.0.0.0.5" ;
+             era:usedInRCCCalculations "true"^^xsd:boolean ;
+             era:rinfIndex "1.1.1.0.1.1" .
 
 
 #################################################################
@@ -9315,4 +9346,4 @@ wgs:location era:rinfIndex "1.1.0.0.1.1" ,
 ] .
 
 
-###  Generated by the OWL API (version 4.5.25.2023-02-15T19:15:49Z) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -2944,6 +2944,7 @@ era:temperatureRange rdf:type owl:ObjectProperty ;
                      rdfs:domain era:InfraSubsystem ;
                      rdfs:range skos:Concept ;
                      era:XMLName "IPP_TempRange" ;
+                     era:eratvIndex "4.3.1" ;
                      era:inSkosConceptScheme <http://data.europa.eu/949/concepts/temperature-ranges/TemperatureRanges> ;
                      era:rinfIndex "1.1.1.1.2.6" ;
                      era:usedInRCCCalculations "true"^^xsd:boolean ;
@@ -9474,29 +9475,29 @@ foaf:Person rdf:type owl:Class ;
             vs:term_status "stable" .
 
 
-[ foaf:name "Ghislain Atemezing" ;
-  dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
+[ foaf:name "Dragos Patru" ;
   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
 ] .
+
+[ foaf:name "Maarten Duhoux" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Dragos Patru" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Maarten Duhoux" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
 
 [ foaf:name "Ghislain Atemezing" ;
    dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
  ] .
 
-[ foaf:name "Maarten Duhoux" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Dragos Patru" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Maarten Duhoux" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Dragos Patru" ;
+[ foaf:name "Ghislain Atemezing" ;
+   dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
  ] .
 
@@ -9512,6 +9513,7 @@ wgs:lat_long rdfs:comment "A comma-separated representation of a latitude, longi
 
 
 wgs:location rdfs:label "Location" ;
+             era:rinfIndex "1.1.0.0.1.1" ;
              rdfs:comment """The relation between something and the point, 
  or other geometrical thing in space, where it is.  For example, the realtionship between
  a radio tower and a Point with a given lat and long.
@@ -9520,8 +9522,7 @@ wgs:location rdfs:label "Location" ;
  Clearly in practice there will be limit to the accuracy of any such statement, but one would expect
  an accuracy appropriate for the size of the object and uses such as mapping .
  """ ;
-             era:rinfIndex "1.1.0.0.1.1" ,
-                           "1.1.1.3.14.5" ,
+             era:rinfIndex "1.1.1.3.14.5" ,
                            "1.2.1.0.8.5" ,
                            "1.2.0.0.0.5" ;
              era:usedInRCCCalculations "true"^^xsd:boolean ;

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -47,13 +47,10 @@ owl:priorVersion "https://github.com/Interoperable-data/ERA_vocabulary/releases/
 owl:versionInfo "v3.1.0"@en ;
 owl:versionURI <https://github.com/Interoperable-data/ERA_vocabulary/releases/releases/v3.1.0> ;
 skos:changeNote """Revision 24-09-2024
-- Add annotation in SKOSConceptScheme to era:operationalRegimeType (currently a concept scheme with placeholder, to be developed)
-- Add annotation in SKOSConceptScheme to era:subsidiaryLocationType (currently a concept scheme with placeholder, to be developed)
-- Add annotation in SKOSConceptScheme to era:conditionsUseReflectivePlates (currently a concept scheme with placeholder, to be developed)
-- Add annotation in SKOSConceptScheme to era:standardCombinedTransportRollerUnits (currently a concept scheme with placeholder, to be developed)
-- Add annotation in SKOSConceptScheme to era:linesideDistanceIndicationAppearance (currently a concept scheme with placeholder, to be developed)
+- Add annotation in SKOSConceptScheme to era:operationalRegimeType, era:subsidiaryLocationType, era:conditionsUseReflectivePlates, era:standardCombinedTransportRollerUnit, era:linesideDistanceIndicationAppearance  (currently placeholder concept schemes to be developed)
 - Deleted foaf:Project, no Usage in ontology and the concept is not part of the domain.
 - Fix bug era:direction, change skos:definition to rdfs:label
+- Fix Typo definition NationalRailwayLine, Network
 
 
 Revision 20-09-2024
@@ -8772,7 +8769,7 @@ era:NationalRailwayLine rdf:type owl:Class ;
                         dcterms:created "2021-01-25"^^xsd:date ;
                         dcterms:modified "2021-08-03"^^xsd:date ;
                         rdfs:comment """Railway line within a member state.
-A line is a sequence of one or mores ections of line, which connects operational points and which may consist of several tracks used for regular railway operation."""@en ;
+A line is a sequence of one or mores sections of line, which connects operational points and which may consist of several tracks used for regular railway operation."""@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "National railway line"@en ;
                         vs:term_status "stable" .
@@ -8780,7 +8777,7 @@ A line is a sequence of one or mores ections of line, which connects operational
 
 ###  http://data.europa.eu/949/Network
 era:Network rdf:type owl:Class ;
-            rdfs:comment "A group of network resources for different purposes. It can be group of elements belonging to corridors, to one IM, to high speed lines, etc. There is no restriction on how elements should be groupped, it is the IM to decide the refinement of the information to be provided."@en ;
+            rdfs:comment "A group of network resources for different purposes. It can be a group of elements belonging to corridors, to one IM, to high speed lines, etc. There is no restriction on how elements should be grouped, it is the IM to decide the refinement of the information to be provided."@en ;
             rdfs:label "Network" .
 
 

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -20,39 +20,43 @@
 
 <http://data.europa.eu/949/> rdf:type owl:Ontology ;
                               cc:license <https://creativecommons.org/licenses/by/4.0/> ;
-                              dcterms:contributor [ foaf:name "Maarten Duhoux" ;
-                                                    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                                  ] ,
-                                                  "Designated RINF Topical Working Groups"@en ;
-                              dcterms:creator [ foaf:name "Ghislain Atemezing" ;
-                                                rdfs:seeAlso <https://orcid.org/0000-0003-1562-6922> ;
-                                                org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                              ] ,
-                                              [ foaf:name "Dragos Patru" ;
-                                                org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                              ] ;
-                              dcterms:issued "2024-04-18"^^xsd:date ;
-                              dcterms:modified "2024-04-18"^^xsd:date ,
-                                               "2024-05-24"^^xsd:date ,
-                                               "2024-06-03"^^xsd:date ,
-                                               "2024-06-05"^^xsd:date ,
-                                               "2024-07-05"^^xsd:date ,
-                                               "2024-08-02"^^xsd:date ,
-                                               "2024-08-12"^^xsd:date ,
-                                               "2024-08-13"^^xsd:date ,
-                                               "2024-09-20"^^xsd:date ;
-                              dcterms:publisher "European Union Agency for Railways" ;
-                              dcterms:title "ERA Ontology"@en ;
-                              rdfs:comment """This is the human and machine readable Ontology governed by the European Union Agency for Railways (https://www.era.europa.eu/). It represents the concepts and relationships linked to the sectorial legal framework and the use cases under the AgencyÂ´s remit, as described in the Commission Implementing Regulation (EU) [to be updated after publication] on the common specifications for the register of railway infrastructure [to be updated after publication].
+                              dcterms:contributor [ ] ,
+"Designated RINF Topical Working Groups"@en ;
+dcterms:creator [ ] ,
+[ ] ;
+dcterms:issued "2024-04-18"^^xsd:date ;
+dcterms:modified "2024-04-18"^^xsd:date ,
+                 "2024-05-24"^^xsd:date ,
+                 "2024-06-03"^^xsd:date ,
+                 "2024-06-05"^^xsd:date ,
+                 "2024-07-05"^^xsd:date ,
+                 "2024-08-02"^^xsd:date ,
+                 "2024-08-12"^^xsd:date ,
+                 "2024-08-13"^^xsd:date ,
+                 "2024-09-20"^^xsd:date ,
+                 "2024-09-24"^^xsd:date ;
+dcterms:publisher "European Union Agency for Railways" ;
+dcterms:title "ERA Ontology"@en ;
+rdfs:comment """This is the human and machine readable Ontology governed by the European Union Agency for Railways (https://www.era.europa.eu/). It represents the concepts and relationships linked to the sectorial legal framework and the use cases under the AgencyÂ´s remit, as described in the Commission Implementing Regulation (EU) [to be updated after publication] on the common specifications for the register of railway infrastructure [to be updated after publication].
 
 Currently, this Ontology covers the European railway infrastructure and the vehicles types authorized to operate over it. It is a semantic/browsable representation of the RINF application guide (https://www.era.europa.eu/sites/default/files/registers/docs/rinf_application_guide_for_register_en.pdf) and ERATV application guide (https://www.era.europa.eu/sites/default/files/registers/docs/iu-eratv_application_guide_for_register_2016-797_en.pdf) that were built by domain experts in the RINF and ERATV working parties.
 
 The Ontology also includes the routebook concepts described in appendix D2 \"Elements the infrastructure manager has to provide to the railway undertaking for the Route Book\" as presented in the Commission Implementing Regulation (EU) [to be updated after publication] 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and [to be updated after publication] and the Appendix D3 [to be updated after publication]."""@en ;
-                              rdfs:label "ERA Ontology"@en ;
-                              owl:priorVersion "https://github.com/Interoperable-data/ERA_vocabulary/releases/v3.0.0"^^xsd:anyURI ;
-                              owl:versionInfo "v3.1.0"@en ;
-                              owl:versionURI <https://github.com/Interoperable-data/ERA_vocabulary/releases/releases/v3.1.0> ;
-                              skos:changeNote """Revision 20-08-2024
+rdfs:label "ERA Ontology"@en ;
+owl:priorVersion "https://github.com/Interoperable-data/ERA_vocabulary/releases/v3.0.0"^^xsd:anyURI ;
+owl:versionInfo "v3.1.0"@en ;
+owl:versionURI <https://github.com/Interoperable-data/ERA_vocabulary/releases/releases/v3.1.0> ;
+skos:changeNote """Revision 24-09-2024
+- Add annotation in SKOSConceptScheme to era:operationalRegimeType (currently a concept scheme with placeholder, to be developed)
+- Add annotation in SKOSConceptScheme to era:subsidiaryLocationType (currently a concept scheme with placeholder, to be developed)
+- Add annotation in SKOSConceptScheme to era:conditionsUseReflectivePlates (currently a concept scheme with placeholder, to be developed)
+- Add annotation in SKOSConceptScheme to era:standardCombinedTransportRollerUnits (currently a concept scheme with placeholder, to be developed)
+- Add annotation in SKOSConceptScheme to era:linesideDistanceIndicationAppearance (currently a concept scheme with placeholder, to be developed)
+- Deleted foaf:Project, no Usage in ontology and the concept is not part of the domain.
+- Fix bug era:direction, change skos:definition to rdfs:label
+
+
+Revision 20-09-2024
 - Change era:qNvdriverAdhes to an object property that points to a SKOS concept scheme   (currently a boolean data property)
 - Add era:inSkosConceptScheme for  era:hasOrganisationRole
 - Add era:inSkosConceptScheme for era:operatingLanguage: http://publications.europa.eu/resource/authority/language
@@ -690,8 +694,10 @@ era:condition rdf:type owl:ObjectProperty ;
 era:conditionsUseReflectivePlates rdf:type owl:ObjectProperty ;
                                   rdfs:domain era:InfraSubsystem ;
                                   rdfs:range skos:Concept ;
+                                  era:inSkosConceptScheme <http://data.europa.eu/949/concepts/conditions-use-reflective-plates/ConditionsUseReflectivePlates> ;
                                   era:rinfIndex "1.1.1.1.7.12.1" ;
                                   dcterms:created "2023-03-14"^^xsd:date ;
+                                  dcterms:modified "2024-09-24"^^xsd:date ;
                                   rdfs:comment "Details of any conditions for using the reflective plates on freight corridors. Specific case for Portugal and Spain until 1.1.2025 and Belgium and France until 1.1.2026."@en ;
                                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                   rdfs:label "conditions for use of reflective plates"@en ;
@@ -1766,9 +1772,11 @@ era:linesideDistanceIndicationAppearance rdf:type owl:ObjectProperty ;
                                          rdfs:domain era:TechnicalCharacteristics ;
                                          rdfs:range skos:Concept ;
                                          era:appendixD2Index "3.1.3" ;
+                                         era:inSkosConceptScheme <http://data.europa.eu/949/concepts/lineside-distance-indication-appearance/LinesideDistanceIndicationAppearance> ;
                                          era:rinfIndex "1.1.1.0.0.3" ;
                                          dcterms:created "2022-10-27"^^xsd:date ;
-                                         dcterms:modified "2023-03-14"^^xsd:date ;
+                                         dcterms:modified "2023-03-14"^^xsd:date ,
+                                                          "2024-09-24"^^xsd:date ;
                                          dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                                          rdfs:comment "Indication of types of appearance of track lineside distance indications."@en ;
                                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -2171,9 +2179,10 @@ era:operatingLanguage rdf:type owl:ObjectProperty ;
 era:operationalRegimeType rdf:type owl:ObjectProperty ;
                           rdfs:range skos:Concept ;
                           era:appendixD2Index "3.2.7" ;
+                          era:inSkosConceptScheme <http://data.europa.eu/949/concepts/operational-regime-types/OperationalRegimeTypes> ;
                           era:rinfIndex "1.1.0.0.1.3" ;
                           dcterms:created "2022-10-27"^^xsd:date ;
-                          dcterms:modified "2024-01-08"^^xsd:date ;
+                          dcterms:modified "2024-09-24"^^xsd:date ;
                           dcterms:source <https://eur-lex.europa.eu/eli/reg_impl/2019/773/oj> ;
                           rdfs:comment "Double track type."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -2772,19 +2781,6 @@ era:specialTunnelArea rdf:type owl:ObjectProperty ;
                       vs:term_status "stable" .
 
 
-###  http://data.europa.eu/949/standardCombinedTransporRollerUnits
-era:standardCombinedTransporRollerUnits rdf:type owl:ObjectProperty ;
-                                        rdfs:domain era:InfraSubsystem ;
-                                        rdfs:range skos:Concept ;
-                                        era:rinfIndex "1.1.1.1.3.9" ;
-                                        dcterms:created "2023-03-14"^^xsd:date ;
-                                        rdfs:comment """Coding for combined transport for roller units (for all freight and mixed-traffic lines) in accordance with the specification referenced in Appendix A-1, index [B]. 
-"""@en ;
-                                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                                        rdfs:label "Standard combined transport profile number for roller units"@en ;
-                                        vs:term_status "unstable" .
-
-
 ###  http://data.europa.eu/949/standardCombinedTransportContainers
 era:standardCombinedTransportContainers rdf:type owl:ObjectProperty ;
                                         rdfs:domain era:InfraSubsystem ;
@@ -2796,6 +2792,20 @@ era:standardCombinedTransportContainers rdf:type owl:ObjectProperty ;
                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                                         rdfs:label "Standard combined transport profile number for containers"@en ;
                                         vs:term_status "unstable" .
+
+
+###  http://data.europa.eu/949/standardCombinedTransportRollerUnits
+era:standardCombinedTransportRollerUnits rdf:type owl:ObjectProperty ;
+                                         rdfs:domain era:InfraSubsystem ;
+                                         rdfs:range skos:Concept ;
+                                         era:inSkosConceptScheme <http://data.europa.eu/949/concepts/standard-combined-transport-roller-units/StandardCombinedTransportRollerUnits> ;
+                                         era:rinfIndex "1.1.1.1.3.9" ;
+                                         dcterms:created "2023-03-14"^^xsd:date ;
+                                         rdfs:comment """Coding for combined transport for roller units (for all freight and mixed-traffic lines) in accordance with the specification referenced in Appendix A-1, index [B]. 
+"""@en ;
+                                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                                         rdfs:label "Standard combined transport profile number for roller units"@en ;
+                                         vs:term_status "unstable" .
 
 
 ###  http://data.europa.eu/949/startLocation
@@ -2857,6 +2867,7 @@ era:subsidiaryLocation rdf:type owl:ObjectProperty ;
 era:subsidiaryLocationType rdf:type owl:ObjectProperty ;
                            rdfs:domain era:SubsidiaryLocation ;
                            rdfs:range skos:Concept ;
+                           era:inSkosConceptScheme <http://data.europa.eu/949/concepts/subsidiary-location-types/SubsidiaryLocationTypes> ;
                            dcterms:created "2024-05-24"^^xsd:date ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "subsidiary location type"@en .
@@ -9261,8 +9272,7 @@ foaf:Agent rdf:type owl:Class .
 
 ###  http://xmlns.com/foaf/0.1/Document
 foaf:Document rdf:type owl:Class ;
-              owl:disjointWith foaf:Organization ,
-                               foaf:Project ;
+              owl:disjointWith foaf:Organization ;
               rdfs:comment "A document." ;
               rdfs:isDefinedBy foaf: ;
               rdfs:label "Document" ;
@@ -9281,20 +9291,29 @@ foaf:Person rdf:type owl:Class ;
             vs:term_status "stable" .
 
 
-###  http://xmlns.com/foaf/0.1/Project
-foaf:Project rdf:type owl:Class .
-
-
-[ foaf:name "Ghislain Atemezing" ;
-  rdfs:seeAlso <https://orcid.org/0000-0003-1562-6922> ;
+[ foaf:name "Dragos Patru" ;
   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
 ] .
+
+[ foaf:name "Maarten Duhoux" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
 
 [ foaf:name "Dragos Patru" ;
    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
  ] .
 
 [ foaf:name "Maarten Duhoux" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Ghislain Atemezing" ;
+   rdfs:seeAlso <https://orcid.org/0000-0003-1562-6922> ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Ghislain Atemezing" ;
+   rdfs:seeAlso <https://orcid.org/0000-0003-1562-6922> ;
    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
  ] .
 


### PR DESCRIPTION
- Non-major updates according to points described in issue LD4RAIL-1069.
- Addition of SKOS placeholder concept schemes (issue LD4RAIL-1065)
- Delete owl:deprecated "false" from placeholder SKOS
- New version of organisationRoles SKOS with additional concepts (issue LD4RAIL-1103)