### PR TITLE
Update ontology.ttl

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -19,74 +19,64 @@
 
 <http://data.europa.eu/949/> rdf:type owl:Ontology ;
                               cc:license <https://creativecommons.org/licenses/by/4.0/> ;
-                              dcterms:contributor [ foaf:name "Maarten Duhoux" ;
-                                                    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                                  ] ,
-                                                  [ foaf:name "Marina Aguado" ;
-                                                    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                                  ] ,
-                                                  [ foaf:name "Dragos Patru" ;
-                                                    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                                  ] ,
-                                                  [ foaf:name "Oscar Corcho" ;
-                                                    org:memberOf <https://www.upm.es/>
-                                                  ] ,
-                                                  [ foaf:name "Polymnia Vasilopoulou" ;
-                                                    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                                  ] ,
-                                                  [ foaf:name "Edna Ruckhaus" ;
-                                                    org:memberOf <https://www.upm.es/>
-                                                  ] ,
-                                                  [ foaf:name "Designated RINF Topical Working Groups"@en
-                                                  ] ,
-                                                  [ foaf:name "Ghislain Atemezing" ;
-                                                    dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
-                                                    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                                  ] ;
-                              dcterms:creator [ foaf:name "Ghislain Atemezing" ;
-                                                dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
-                                                org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                              ] ,
-                                              [ foaf:name "Dragos Patru" ;
-                                                org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-                                              ] ;
-                              dcterms:issued "2024-04-18"^^xsd:date ;
-                              dcterms:modified "2024-04-18"^^xsd:date ,
-                                               "2024-05-24"^^xsd:date ,
-                                               "2024-06-03"^^xsd:date ,
-                                               "2024-06-05"^^xsd:date ,
-                                               "2024-07-05"^^xsd:date ,
-                                               "2024-08-02"^^xsd:date ,
-                                               "2024-08-12"^^xsd:date ,
-                                               "2024-08-13"^^xsd:date ,
-                                               "2024-09-19"^^xsd:date ,
-                                               "2024-09-20"^^xsd:date ,
-                                               "2024-09-24"^^xsd:date ,
-                                               "2024-09-25"^^xsd:date ,
-                                               "2024-10-24"^^xsd:date ,
-                                               "2024-10-28"^^xsd:date ,
-                                               "2024-10-29"^^xsd:date ,
-                                               "2024-10-30"^^xsd:date ,
-                                               "2024-10-31"^^xsd:date ,
-                                               "2024-11-04"^^xsd:date ,
-                                               "2024-11-12"^^xsd:date ,
-                                               "2024-11-22"^^xsd:date ,
-                                               "2024-11-20"^^xsd:date ;
-                              dcterms:publisher "European Union Agency for Railways" ;
-                              dcterms:title "ERA Ontology"@en ;
-                              rdfs:comment """This is the human and machine readable Ontology governed by the European Union Agency for Railways (https://www.era.europa.eu/). It represents the concepts and relationships linked to the sectorial legal framework and the use cases under the AgencyÂ´s remit, as described in the Commission Implementing Regulation (EU) [to be updated after publication] on the common specifications for the register of railway infrastructure [to be updated after publication].
+                              dcterms:contributor [ ] ,
+[ ] ,
+[ ] ,
+[ ] ,
+[ ] ,
+[ ] ,
+[ ] ,
+[ ] ;
+dcterms:creator [ ] ,
+[ ] ;
+dcterms:issued "2024-04-18"^^xsd:date ;
+dcterms:modified "2024-04-18"^^xsd:date ,
+                 "2024-05-24"^^xsd:date ,
+                 "2024-06-03"^^xsd:date ,
+                 "2024-06-05"^^xsd:date ,
+                 "2024-07-05"^^xsd:date ,
+                 "2024-08-02"^^xsd:date ,
+                 "2024-08-12"^^xsd:date ,
+                 "2024-08-13"^^xsd:date ,
+                 "2024-09-19"^^xsd:date ,
+                 "2024-09-20"^^xsd:date ,
+                 "2024-09-24"^^xsd:date ,
+                 "2024-09-25"^^xsd:date ,
+                 "2024-10-24"^^xsd:date ,
+                 "2024-10-28"^^xsd:date ,
+                 "2024-10-29"^^xsd:date ,
+                 "2024-10-30"^^xsd:date ,
+                 "2024-10-31"^^xsd:date ,
+                 "2024-11-04"^^xsd:date ,
+                 "2024-11-12"^^xsd:date ,
+                 "2024-11-20"^^xsd:date ,
+                 "2024-11-22"^^xsd:date ,
+                 "2024-11-26"^^xsd:date ;
+dcterms:publisher "European Union Agency for Railways" ;
+dcterms:title "ERA Ontology"@en ;
+rdfs:comment """This is the human and machine readable Ontology governed by the European Union Agency for Railways (https://www.era.europa.eu/). It represents the concepts and relationships linked to the sectorial legal framework and the use cases under the AgencyÂ´s remit, as described in the Commission Implementing Regulation (EU) [to be updated after publication] on the common specifications for the register of railway infrastructure [to be updated after publication].
 
 
 Currently, this Ontology covers the European railway infrastructure and the vehicles types authorized to operate over it. It is a semantic/browsable representation of the RINF application guide (1) and ERATV application guide (2) that were built by domain experts in the RINF and ERATV working parties.
 
 The Ontology also includes the routebook concepts described in appendix D2 \"Elements the infrastructure manager has to provide to the railway undertaking for the Route Book\" as presented in the Commission Implementing Regulation (EU) [to be updated after publication] 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and [to be updated after publication] and the Appendix D3 [to be updated after publication]."""@en ;
-                              rdfs:label "ERA Ontology"@en ;
-                              rdfs:seeAlso "https://www.era.europa.eu/sites/default/files/registers/docs/iu-eratv_application_guide_for_register_2016-797_en.pdf"^^xsd:anyURI ,
-                                           "https://www.era.europa.eu/sites/default/files/registers/docs/rinf_application_guide_for_register_en.pdf"^^xsd:anyURI ;
-                              owl:priorVersion "https://github.com/Interoperable-data/ERA_vocabulary/releases/v3.0.0"^^xsd:anyURI ;
-                              owl:versionInfo "v3.1.0" ;
-                              owl:versionURI <https://github.com/Interoperable-data/ERA_vocabulary/releases/releases/v3.1.0> ;
-                              skos:changeNote """Revision 22-11-2024
+rdfs:label "ERA Ontology"@en ;
+rdfs:seeAlso "https://www.era.europa.eu/sites/default/files/registers/docs/iu-eratv_application_guide_for_register_2016-797_en.pdf"^^xsd:anyURI ,
+             "https://www.era.europa.eu/sites/default/files/registers/docs/rinf_application_guide_for_register_en.pdf"^^xsd:anyURI ;
+owl:priorVersion "https://github.com/Interoperable-data/ERA_vocabulary/releases/v3.0.0"^^xsd:anyURI ;
+owl:versionInfo "v3.1.0" ;
+owl:versionURI <https://github.com/Interoperable-data/ERA_vocabulary/releases/releases/v3.1.0> ;
+skos:changeNote """Revision 26-11-2024
+- Added definitions to object properties that denote relationships among classes
+- Fixes in hierarchies of CCS, Energy and Infra subsystems
+- Added CommonCharacteristicsSubset to domain of parameterApplicability
+- Added functional property axiom to some properties with domain TrainDetectionSystem and ContactLineSystem
+- Added porperty borderPointId to the class ReferenceBorderPoint
+- Fix RINF index 1.1.1.3.14.5 to 1.1.1.3.14.6 for location 
+- Added definition to class Track
+- Renamed the annotation properties era:appendixD2Index and era:appendixD3Index to the corresponding era:tsiOPEappendixD2Index and era:tsiOPEappendixD3Index. Created  annotation properties era:tsiOPEappendixD1Index
+
+Revision 22-11-2024
 - Added two annotation properties: era:applicable and era:legalDeadline
 
 Revision 20-11-2024
@@ -328,34 +318,14 @@ era:affectedProperty rdf:type owl:AnnotationProperty ;
                      rdfs:range xsd:anyURI .
 
 
-###  http://data.europa.eu/949/appendixD2Index
-era:appendixD2Index rdf:type owl:AnnotationProperty ;
-                    dcterms:created "2022-11-04"^^xsd:date ;
-                    dcterms:modified "2024-08-13"^^xsd:date ;
-                    rdfs:comment "The index of a vocabulary term in Appendix D2 Elements the infrastructure manager has to provide to the railway undertaking for the Route Book from the document Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision 2012/757/EU."@en ;
-                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                    rdfs:label "Appendix D2 index"@en ;
-                    skos:definition "The index of a vocabulary term in Appendix D2 Elements the infrastructure manager has to provide to the railway undertaking for the Route Book from the document Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision 2012/757/EU."@en ;
-                    rdfs:range xsd:string .
-
 ###  http://data.europa.eu/949/applicable
 era:applicable rdf:type owl:AnnotationProperty ;
-                        dcterms:created "2024-11-22"^^xsd:date ;
-                        rdfs:comment "Annotation used to point to the applicability of a parameter in RINF. Values are Y/N/NYA"@en ;
-                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                        rdfs:label "applicable"@en ;
-                        vs:term_status "stable" ;
-                        rdfs:range xsd:string.
-
-###  http://data.europa.eu/949/appendixD3Index
-era:appendixD3Index rdf:type owl:AnnotationProperty ;
-                    dcterms:created "2022-11-04"^^xsd:date ;
-                    dcterms:modified "2024-08-13"^^xsd:date ;
-                    rdfs:comment "The index of a vocabulary term in Appendix D3 ERTMS trackside engineering information relevant to operation that the infrastructure manager shall provide to the railway undertaking."@en ;
-                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                    rdfs:label "Appendix D3 index"@en ;
-                    vs:term_status "stable" ;
-                    rdfs:range xsd:string .
+               dcterms:created "2024-11-22"^^xsd:date ;
+               rdfs:comment "Annotation used to point to the applicability of a parameter in RINF. Values are Y/N/NYA"@en ;
+               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+               rdfs:label "applicable"@en ;
+               vs:term_status "stable" ;
+               rdfs:range xsd:string .
 
 
 ###  http://data.europa.eu/949/canonicalURI
@@ -410,14 +380,16 @@ era:inSkosConceptScheme rdf:type owl:AnnotationProperty ;
                         rdfs:range skos:ConceptScheme ;
                         rdfs:domain owl:ObjectProperty .
 
+
 ###  http://data.europa.eu/949/legalDeadline
 era:legalDeadline rdf:type owl:AnnotationProperty ;
-                        dcterms:created "2024-11-22"^^xsd:date ;
-                        rdfs:comment "Annotation used to point to legal obligation of a parameter in RINF"@en ;
-                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                        rdfs:label "legal deadline"@en ;
-                        vs:term_status "stable" ;
-                        rdfs:range xsd:string.                  
+                  dcterms:created "2024-11-22"^^xsd:date ;
+                  rdfs:comment "Annotation used to point to legal obligation of a parameter in RINF"@en ;
+                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                  rdfs:label "legal deadline"@en ;
+                  vs:term_status "stable" ;
+                  rdfs:range xsd:string .
+
 
 ###  http://data.europa.eu/949/rinfIndex
 era:rinfIndex rdf:type owl:AnnotationProperty ;
@@ -451,6 +423,53 @@ era:shaclShapeValidationRule rdf:type owl:AnnotationProperty ;
 ###  http://data.europa.eu/949/startLocation
 era:startLocation rdf:type owl:AnnotationProperty ;
                   rdfs:subPropertyOf wgs:location .
+
+
+###  http://data.europa.eu/949/tenTreference
+era:tenTreference rdf:type owl:AnnotationProperty ;
+                  dcterms:created "2024-11-26"^^xsd:date ;
+                  rdfs:comment "Used to annotate properties coming from the TenT regulations, to be used for monitoring the provision of the data."@en ;
+                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                  rdfs:label "TenT reference"@en ;
+                  vs:term_status "stable" ;
+                  rdfs:range xsd:string .
+
+
+###  http://data.europa.eu/949/tsiOPEAppendixD1Index
+era:tsiOPEAppendixD1Index rdf:type owl:AnnotationProperty ;
+                          dcterms:created "2024-11-26"^^xsd:date ;
+                          rdfs:comment "The index of a vocabulary term in Appendix D2 Vehicle and train Route compatibility checks."@en ;
+                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                          rdfs:label "TSI operation appendix D1 index"@en ;
+                          vs:term_status "stable" ;
+                          skos:altLabel "Appendix D1 index"@en ;
+                          rdfs:range xsd:string .
+
+
+###  http://data.europa.eu/949/tsiOPEappendixD2Index
+era:tsiOPEappendixD2Index rdf:type owl:AnnotationProperty ;
+                          dcterms:created "2022-11-04"^^xsd:date ;
+                          dcterms:modified "2024-08-13"^^xsd:date ,
+                                           "2024-11-26"^^xsd:date ;
+                          rdfs:comment "The index of a vocabulary term in Appendix D2 Elements the infrastructure manager has to provide to the railway undertaking for the Route Book from the document Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision 2012/757/EU."@en ;
+                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                          rdfs:label "TSI operation appendix D2 index"@en ;
+                          skos:altLabel "Appendix D2 index"@en ;
+                          skos:definition "The index of a vocabulary term in Appendix D2 Elements the infrastructure manager has to provide to the railway undertaking for the Route Book from the document Commission Implementing Regulation (EU) 2019/773 of 16 May 2019 on the technical specification for interoperability relating to the operation and traffic management subsystem of the rail system within the European Union and repealing Decision 2012/757/EU."@en ;
+                          rdfs:range xsd:string .
+
+
+###  http://data.europa.eu/949/tsiOPEappendixD3Index
+era:tsiOPEappendixD3Index rdf:type owl:AnnotationProperty ;
+                          dcterms:created "2022-11-04"^^xsd:date ;
+                          dcterms:modified "2024-08-13"^^xsd:date ,
+                                           "2024-11-26"^^xsd:date ;
+                          rdfs:comment "The index of a vocabulary term in Appendix D3 ERTMS trackside engineering information relevant to operation that the infrastructure manager shall provide to the railway undertaking."@en ;
+                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                          rdfs:label "TSI operation appendix D3 index"@en ;
+                          vs:term_status "stable" ;
+                          skos:altLabel "Appendix D3 index"@en ;
+                          rdfs:range xsd:string .
 
 
 ###  http://data.europa.eu/949/unitOfMeasure
@@ -557,7 +576,7 @@ wgs:lat rdf:type owl:AnnotationProperty ;
 wgs:location rdf:type owl:AnnotationProperty ;
              era:rinfIndex "1.1.0.0.1.1" ,
                            "1.1.1.0.1.1" ,
-                           "1.1.1.3.14.5" ,
+                           "1.1.1.3.14.6" ,
                            "1.2.0.0.0.5" ,
                            "1.2.1.0.8.5" ;
              era:usedInRCCCalculations "true"^^xsd:boolean ;
@@ -747,10 +766,10 @@ era:atoCommunicationSystem rdf:type owl:ObjectProperty ;
                                        ] ;
                            rdfs:range skos:Concept ;
                            era:XMLName "ATO_CommSystem" ;
-                           era:appendixD2Index "3.4.9" ;
                            era:inSkosConceptScheme <http://data.europa.eu/949/concepts/ato-commsys/ATOCommSystem> ;
                            era:rinfIndex "1.1.1.3.13.3" ,
                                          "1.2.1.1.10.3" ;
+                           era:tsiOPEappendixD2Index "3.4.9" ;
                            dcterms:created "2023-03-14"^^xsd:date ;
                            dcterms:modified "2024-04-18"^^xsd:date ;
                            dcterms:relation era:etcsBaseline ;
@@ -771,10 +790,10 @@ era:atoGradeAutomation rdf:type owl:ObjectProperty ;
                                    ] ;
                        rdfs:range skos:Concept ;
                        era:XMLName "ATO_GradeAutomation" ;
-                       era:appendixD2Index "3.4.8" ;
                        era:inSkosConceptScheme <http://data.europa.eu/949/concepts/ato-grades-automation/ATOGradeOfAutomation> ;
                        era:rinfIndex "1.1.1.3.13.1" ,
                                      "1.2.1.1.10.1" ;
+                       era:tsiOPEappendixD2Index "3.4.8" ;
                        dcterms:created "2023-03-14"^^xsd:date ;
                        dcterms:modified "2024-04-18"^^xsd:date ;
                        dcterms:relation era:etcsBaseline ;
@@ -795,10 +814,10 @@ era:atoSystemVersion rdf:type owl:ObjectProperty ;
                                  ] ;
                      rdfs:range skos:Concept ;
                      era:XMLName "ATO_GradeAutomation" ;
-                     era:appendixD2Index "3.4.8" ;
                      era:inSkosConceptScheme <http://data.europa.eu/949/concepts/ato-s-versions/ATOSystemVersions> ;
                      era:rinfIndex "1.1.1.3.13.2" ,
                                    "1.2.1.1.10.2" ;
+                     era:tsiOPEappendixD2Index "3.4.8" ;
                      dcterms:created "2023-03-14"^^xsd:date ;
                      dcterms:modified "2024-04-18"^^xsd:date ,
                                       "2024-09-19"^^xsd:date ;
@@ -857,6 +876,7 @@ era:belongsTo rdf:type owl:ObjectProperty ;
               rdfs:range era:CommonCharacteristicsSubset ;
               dcterms:created "2024-05-24"^^xsd:date ;
               dcterms:modified "2024-10-24"^^xsd:date ;
+              rdfs:comment "Indicates that an infrastructure element belongs to a certain subset that contains common characteristics."@en ;
               rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "belongs to"@en .
 
@@ -897,10 +917,10 @@ era:cantDeficiencyBasicSSP rdf:type owl:ObjectProperty ;
                                        ] ;
                            rdfs:range skos:Concept ;
                            era:XMLName "CPE_SSPUsesCantDef" ;
-                           era:appendixD3Index "1.3" ;
                            era:inSkosConceptScheme <http://data.europa.eu/949/concepts/cant-deficiencies/CantDeficiencies> ;
                            era:rinfIndex "1.1.1.3.2.14" ,
                                          "1.2.1.1.1.14" ;
+                           era:tsiOPEappendixD3Index "1.3" ;
                            dcterms:created "2023-03-14"^^xsd:date ;
                            dcterms:modified "2024-01-08"^^xsd:date ,
                                             "2024-04-18"^^xsd:date ,
@@ -1016,12 +1036,13 @@ era:condition rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/conditionsAppliedRegenerativeBraking
-era:conditionsAppliedRegenerativeBraking rdf:type owl:ObjectProperty ;
+era:conditionsAppliedRegenerativeBraking rdf:type owl:ObjectProperty ,
+                                                  owl:FunctionalProperty ;
                                          rdfs:domain era:ContactLineSystem ;
                                          rdfs:range era:Document ;
                                          era:XMLName "ECS_RegBrakingConditions" ;
-                                         era:appendixD2Index "3.3.7" ;
                                          era:rinfIndex "1.1.1.2.2.4.1" ;
+                                         era:tsiOPEappendixD2Index "3.3.7" ;
                                          dcterms:created "2022-11-10"^^xsd:date ;
                                          dcterms:modified "2023-03-14"^^xsd:date ,
                                                           "2024-04-18"^^xsd:date ,
@@ -1047,9 +1068,9 @@ era:conditionsSwitchClassBSystems rdf:type owl:ObjectProperty ;
                                               ] ;
                                   rdfs:range era:Document ;
                                   era:XMLName "CTS_SwitchProtectAB" ;
-                                  era:appendixD2Index "3.4.3" ;
                                   era:rinfIndex "1.1.1.3.8.3" ,
                                                 "1.2.1.1.7.3" ;
+                                  era:tsiOPEappendixD2Index "3.4.3" ;
                                   dcterms:created "2022-10-28"^^xsd:date ;
                                   dcterms:modified "2023-03-14"^^xsd:date ,
                                                    "2024-04-18"^^xsd:date ,
@@ -1108,6 +1129,7 @@ era:contactLineSystemObjParameter rdf:type owl:ObjectProperty ;
 ###  http://data.europa.eu/949/contactLineSystemType
 era:contactLineSystemType rdf:type owl:ObjectProperty ;
                           rdfs:subPropertyOf era:contactLineSystemObjParameter ;
+                          rdf:type owl:FunctionalProperty ;
                           rdfs:domain era:ContactLineSystem ;
                           rdfs:range skos:Concept ;
                           era:XMLName "ECS_SystemType" ;
@@ -1152,6 +1174,8 @@ era:contains rdf:type owl:ObjectProperty ;
              rdfs:domain era:CommonCharacteristicsSubset ;
              rdfs:range era:InfrastructureElement ;
              dcterms:created "2024-10-31"^^xsd:date ;
+             rdfs:comment "Indicates that a subset with common characteristics contains a certain. infrastructure element."@en ;
+             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "contains"@en .
 
 
@@ -1227,6 +1251,7 @@ era:direction rdf:type owl:ObjectProperty ;
 
 ###  http://data.europa.eu/949/documentRestrictionPositionContactLineSeparation
 era:documentRestrictionPositionContactLineSeparation rdf:type owl:ObjectProperty ;
+                                                     rdfs:subPropertyOf era:requirementsRollingStockObjParameter ;
                                                      rdfs:domain [ rdf:type owl:Class ;
                                                                    owl:unionOf ( era:CommonCharacteristicsSubset
                                                                                  era:RunningTrack
@@ -1244,6 +1269,7 @@ era:documentRestrictionPositionContactLineSeparation rdf:type owl:ObjectProperty
 
 ###  http://data.europa.eu/949/documentRestrictionPowerConsumption
 era:documentRestrictionPowerConsumption rdf:type owl:ObjectProperty ;
+                                        rdfs:subPropertyOf era:requirementsRollingStockObjParameter ;
                                         rdfs:domain [ rdf:type owl:Class ;
                                                       owl:unionOf ( era:CommonCharacteristicsSubset
                                                                     era:RunningTrack
@@ -1271,10 +1297,10 @@ era:eddyCurrentBraking rdf:type owl:ObjectProperty ;
                                    ] ;
                        rdfs:range skos:Concept ;
                        era:XMLName "ILR_EddyCurrentBrakes" ;
-                       era:appendixD2Index "3.4.5" ;
                        era:inSkosConceptScheme <http://data.europa.eu/949/concepts/eddy-current-braking/EddyCurrentBraking> ;
                        era:rinfIndex "1.1.1.1.6.2" ,
                                      "1.2.1.0.4.2" ;
+                       era:tsiOPEappendixD2Index "3.4.5" ;
                        era:usedInRCCCalculations "true"^^xsd:boolean ;
                        dcterms:created "2020-08-24"^^xsd:date ;
                        dcterms:modified "2022-09-06"^^xsd:date ,
@@ -1298,8 +1324,8 @@ era:eddyCurrentBrakingConditionsDocument rdf:type owl:ObjectProperty ;
                                                      ] ;
                                          rdfs:range era:Document ;
                                          era:XMLName "ILR_ECBDocRef" ;
-                                         era:appendixD2Index "3.4.5" ;
                                          era:rinfIndex "1.1.1.1.6.4" ;
+                                         era:tsiOPEappendixD2Index "3.4.5" ;
                                          era:usedInRCCCalculations "true"^^xsd:boolean ;
                                          dcterms:created "2020-08-24"^^xsd:date ;
                                          dcterms:modified "2021-09-10"^^xsd:date ,
@@ -1359,6 +1385,7 @@ era:elementPartOf rdf:type owl:ObjectProperty ;
                   rdfs:domain era:TopologicalObject ;
                   rdfs:range era:TopologicalObject ;
                   rdfs:comment "References the topology object of a lower-granularity level which is part of a higher-granularity topology object."@en ;
+                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                   rdfs:label "element part of"@en .
 
 
@@ -1412,6 +1439,7 @@ era:energySubsystemObjParameter rdf:type owl:ObjectProperty ;
 era:energySupplySystem rdf:type owl:ObjectProperty ;
                        rdfs:subPropertyOf era:contactLineSystemObjParameter ,
                                           era:vehicleTypeTechnicalObjectCharacteristic ;
+                       rdf:type owl:FunctionalProperty ;
                        rdfs:domain [ rdf:type owl:Class ;
                                      owl:unionOf ( era:ContactLineSystem
                                                    era:VehicleType
@@ -1419,10 +1447,10 @@ era:energySupplySystem rdf:type owl:ObjectProperty ;
                                    ] ;
                        rdfs:range skos:Concept ;
                        era:XMLName "ECS_VoltFreq" ;
-                       era:appendixD2Index "3.3.1" ;
                        era:eratvIndex "4.10.1" ;
                        era:inSkosConceptScheme <http://data.europa.eu/949/concepts/energy-supply-systems/EnergySupplySystems> ;
                        era:rinfIndex "1.1.1.2.2.1.2" ;
+                       era:tsiOPEappendixD2Index "3.3.1" ;
                        era:usedInRCCCalculations "true"^^xsd:boolean ;
                        dcterms:created "2020-08-24"^^xsd:date ;
                        dcterms:modified "2024-01-08"^^xsd:date ,
@@ -1486,11 +1514,11 @@ era:etcsBaseline rdf:type owl:ObjectProperty ;
                              ] ;
                  rdfs:range skos:Concept ;
                  era:XMLName "CPE_Baseline" ;
-                 era:appendixD2Index "3.2.7" ;
                  era:eratvIndex "4.13.1.2" ;
                  era:inSkosConceptScheme <http://data.europa.eu/949/concepts/etcs-baselines/ETCSBaselines> ;
                  era:rinfIndex "1.1.1.3.2.2" ,
                                "1.2.1.1.1.2" ;
+                 era:tsiOPEappendixD2Index "3.2.7" ;
                  dcterms:created "2021-08-07"^^xsd:date ;
                  dcterms:description "The ETCS baseline needs to be provided for each available ETCS Level. See: TSI CCS (Table A2)"@en ;
                  dcterms:modified "2021-08-31"^^xsd:date ,
@@ -1514,10 +1542,10 @@ era:etcsDegradedSituation rdf:type owl:ObjectProperty ;
                                       ] ;
                           rdfs:range skos:Concept ;
                           era:XMLName "CLD_ETCSSituation" ;
-                          era:appendixD2Index "3.4.1" ;
                           era:inSkosConceptScheme <http://data.europa.eu/949/concepts/etcs-situation/ETCSSituations> ;
                           era:rinfIndex "1.1.1.3.10.1" ,
                                         "1.2.1.1.9.1" ;
+                          era:tsiOPEappendixD2Index "3.4.1" ;
                           dcterms:created "2021-08-09"^^xsd:date ;
                           dcterms:description """System for degraded situation. 
 
@@ -1590,10 +1618,10 @@ era:etcsLevelType rdf:type owl:ObjectProperty ;
                   rdfs:domain era:ETCS ;
                   rdfs:range skos:Concept ;
                   era:XMLName "CPE_Level" ;
-                  era:appendixD2Index "3.2.7" ;
                   era:inSkosConceptScheme <http://data.europa.eu/949/concepts/etcs-levels/ETCSLevels> ;
                   era:rinfIndex "1.1.1.3.2.1" ,
                                 "1.2.1.1.1.1" ;
+                  era:tsiOPEappendixD2Index "3.2.7" ;
                   dcterms:created "2021-08-07"^^xsd:date ;
                   dcterms:description """The different ERTMS / ETCS application levels are a way to express the possible operating relationships between track and train. 
   
@@ -1688,8 +1716,9 @@ era:etcsNationalValuesObjParameter rdf:type owl:ObjectProperty ;
 
 
 ###  http://data.europa.eu/949/etcsRestrictionsConditionsDoc
-era:etcsRestrictionsConditionsDoc rdf:type owl:ObjectProperty ,
-                                           owl:FunctionalProperty ;
+era:etcsRestrictionsConditionsDoc rdf:type owl:ObjectProperty ;
+                                  rdfs:subPropertyOf era:tsiCompliantTrainProtectionSystemObjParameter ;
+                                  rdf:type owl:FunctionalProperty ;
                                   rdfs:domain [ rdf:type owl:Class ;
                                                 owl:unionOf ( era:CommonCharacteristicsSubset
                                                               era:Track
@@ -1760,10 +1789,10 @@ era:etcsTransmittedTrackConditions rdf:type owl:ObjectProperty ;
                                    rdfs:domain era:ETCS ;
                                    rdfs:range skos:Concept ;
                                    era:XMLName "CPE_TransmittedTCs" ;
-                                   era:appendixD3Index "1.1" ;
                                    era:inSkosConceptScheme <http://data.europa.eu/949/concepts/etcs-transmitted-tcs/TransmittedTrackConditions> ;
                                    era:rinfIndex "1.1.1.3.2.12.1" ,
                                                  "1.2.1.1.1.12.1" ;
+                                   era:tsiOPEappendixD3Index "1.1" ;
                                    dcterms:created "2022-11-16"^^xsd:date ;
                                    dcterms:modified "2023-03-14"^^xsd:date ,
                                                     "2023-04-18"^^xsd:date ;
@@ -1870,6 +1899,7 @@ Sections with:
 ###  http://data.europa.eu/949/frequencyBandsForDetection
 era:frequencyBandsForDetection rdf:type owl:ObjectProperty ;
                                rdfs:subPropertyOf era:trainDetectionSystemBasedFrequencyBandsObjParameter ;
+                               rdf:type owl:FunctionalProperty ;
                                rdfs:domain era:TrainDetectionSystem ;
                                rdfs:range skos:Concept ;
                                era:XMLName "CCD_TSIFreqBandsDet" ;
@@ -1898,6 +1928,7 @@ era:from rdf:type owl:ObjectProperty ;
          rdfs:domain era:LinearElementLink ;
          rdfs:range era:LinearElement ;
          rdfs:comment "the linear element from which there is a directed link towards era:to"@en ;
+         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
          rdfs:label "from"@en .
 
 
@@ -2090,12 +2121,12 @@ era:gsmRVersion rdf:type owl:ObjectProperty ;
                             ] ;
                 rdfs:range skos:Concept ;
                 era:XMLName "CRG_Version" ;
-                era:appendixD2Index "3.1.7" ,
-                                    "3.4.4" ;
                 era:eratvIndex "4.13.2.1" ;
                 era:inSkosConceptScheme <http://data.europa.eu/949/concepts/gsmr-versions/GSMRVersions> ;
                 era:rinfIndex "1.1.1.3.3.1" ,
                               "1.2.1.1.2.1" ;
+                era:tsiOPEappendixD2Index "3.1.7" ,
+                                          "3.4.4" ;
                 dcterms:created "2021-08-08"^^xsd:date ;
                 dcterms:modified "2021-09-12"^^xsd:date ,
                                  "2024-04-18"^^xsd:date ;
@@ -2119,9 +2150,9 @@ era:gsmrConstraintsOperateOnlyInCircuitSwitch rdf:type owl:ObjectProperty ;
                                                           ] ;
                                               rdfs:range skos:Concept ;
                                               era:XMLName "CRG_ConstraintsCS" ;
-                                              era:appendixD3Index "2.2" ;
                                               era:inSkosConceptScheme <http://data.europa.eu/949/concepts/gsmr-cs-constraints/GSMRConstraints> ;
                                               era:rinfIndex "1.2.1.1.2.12" ;
+                                              era:tsiOPEappendixD3Index "2.2" ;
                                               dcterms:created "2023-03-14"^^xsd:date ;
                                               dcterms:modified "2024-04-18"^^xsd:date ;
                                               rdfs:comment "These constraints, where applicable, are meant to manage the limited number of circuit-switched radio connections that can be handled simultaneously by a Radio Block Center."@en ;
@@ -2192,7 +2223,7 @@ era:hasOrganisationRole rdf:type owl:ObjectProperty ,
                         rdfs:range skos:Concept ;
                         era:inSkosConceptScheme <http://data.europa.eu/949/concepts/organisation-roles/OrgRoles> ;
                         dcterms:created "2024-06-03"^^xsd:date ;
-                        rdfs:comment "The role plays in an n-ary relationship between a Body and a specific concept in the concept scheme of organisation roles"@en ;
+                        rdfs:comment "Relates the Organisation role instance (the role played by an Organisation)  with the specific role in the taxonomy of organisation roles."@en ;
                         rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                         rdfs:label "has organisation role"@en .
 
@@ -2212,6 +2243,7 @@ era:hasPart rdf:type owl:ObjectProperty ;
             rdfs:domain era:AggregatedElement ;
             rdfs:range era:BasicElement ;
             dcterms:created "2024-05-24"^^xsd:date ;
+            rdfs:comment "Indicates that an aggregated element has a part that is a basic element."@en ;
             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
             rdfs:label "has part"@en .
 
@@ -2316,6 +2348,7 @@ era:infrastructureManager rdf:type owl:ObjectProperty ;
                           rdfs:range era:OrganisationRole ;
                           dcterms:created "2024-10-24"^^xsd:date ;
                           dcterms:replaces era:infrastructureMgr ;
+                          rdfs:comment "Relates a subset with common characteristics with its IM, represented by an instance of organisation role that points to the \"infrastructure manager\" concept in the taxonomy."@en ;
                           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                           rdfs:label "infrastructure manager"@en ;
                           vs:term_status "stable" .
@@ -2344,9 +2377,9 @@ era:instructionsSwitchRadioSystems rdf:type owl:ObjectProperty ;
                                                ] ;
                                    rdfs:range era:Document ;
                                    era:XMLName "CTS_SwitchRadioConditions" ;
-                                   era:appendixD2Index "3.4.4" ;
                                    era:rinfIndex "1.1.1.3.8.2.1" ,
                                                  "1.2.1.1.7.2.1" ;
+                                   era:tsiOPEappendixD2Index "3.4.4" ;
                                    dcterms:created "2022-10-28"^^xsd:date ;
                                    dcterms:modified "2023-03-14"^^xsd:date ,
                                                     "2024-04-18"^^xsd:date ,
@@ -2363,6 +2396,7 @@ era:isPartOf rdf:type owl:ObjectProperty ;
              rdfs:domain era:BasicElement ;
              rdfs:range era:AggregatedElement ;
              dcterms:created "2024-05-24"^^xsd:date ;
+             rdfs:comment "Indicates that a basic element is part of an aggregated element."@en ;
              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "is part of"@en .
 
@@ -2378,12 +2412,12 @@ era:legacyRadioSystem rdf:type owl:ObjectProperty ;
                                   ] ;
                       rdfs:range skos:Concept ;
                       era:XMLName "CRS_Installed" ;
-                      era:appendixD2Index "3.1.7" ,
-                                          "3.4.4" ;
                       era:eratvIndex "4.13.2.3" ;
                       era:inSkosConceptScheme <http://data.europa.eu/949/concepts/legacy-radio-systems/LegacyRadioSystems> ;
                       era:rinfIndex "1.1.1.3.6.1" ,
                                     "1.2.1.1.5.1" ;
+                      era:tsiOPEappendixD2Index "3.1.7" ,
+                                                "3.4.4" ;
                       era:usedInRCCCalculations "true"^^xsd:boolean ;
                       dcterms:created "2020-08-31"^^xsd:date ;
                       dcterms:description "The list is in line with ERA/TD/2011-09/INT (v1.13), Table 4."@en ;
@@ -2443,8 +2477,8 @@ era:lineNationalId rdf:type owl:ObjectProperty ;
                                ] ;
                    rdfs:range era:NationalRailwayLine ;
                    era:XMLName "SOLLineIdentification" ;
-                   era:appendixD2Index "2.2.1.1" ;
                    era:rinfIndex "1.1.0.0.0.2" ;
+                   era:tsiOPEappendixD2Index "2.2.1.1" ;
                    dcterms:created "2020-09-30"^^xsd:date ;
                    dcterms:description """Each SoL can belong to only one national line.
 
@@ -2537,9 +2571,9 @@ era:linesideDistanceIndicationAppearance rdf:type owl:ObjectProperty ;
                                                                    )
                                                      ] ;
                                          rdfs:range skos:Concept ;
-                                         era:appendixD2Index "3.1.3" ;
                                          era:inSkosConceptScheme <http://data.europa.eu/949/concepts/lineside-distance-indication-appearance/LinesideDistanceIndicationAppearance> ;
                                          era:rinfIndex "1.1.1.0.0.3" ;
+                                         era:tsiOPEappendixD2Index "3.1.3" ;
                                          dcterms:created "2022-10-27"^^xsd:date ;
                                          dcterms:modified "2023-03-14"^^xsd:date ,
                                                           "2024-09-19"^^xsd:date ,
@@ -2559,8 +2593,8 @@ era:linesideDistanceIndicationPositioning rdf:type owl:ObjectProperty ;
                                                                     )
                                                       ] ;
                                           rdfs:range skos:Concept ;
-                                          era:appendixD2Index "3.1.3" ;
                                           era:rinfIndex "1.1.1.0.0.3" ;
+                                          era:tsiOPEappendixD2Index "3.1.3" ;
                                           dcterms:created "2023-03-14"^^xsd:date ,
                                                           "2024-09-19"^^xsd:date ;
                                           dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -2575,6 +2609,7 @@ era:linkedToPrimaryLocation rdf:type owl:ObjectProperty ;
                             rdfs:domain era:SubsidiaryLocation ;
                             rdfs:range era:PrimaryLocation ;
                             dcterms:created "2024-10-28"^^xsd:date ;
+                            rdfs:comment "Relates a subsidiary location with a primary location."@en ;
                             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                             rdfs:label "linked to primary location"@en .
 
@@ -2669,6 +2704,7 @@ era:lrsMethod rdf:type owl:ObjectProperty ;
               era:inSkosConceptScheme <http://data.europa.eu/949/concepts/lines/ReferenceSystems> ;
               dcterms:created "2024-04-18"^^xsd:date ;
               rdfs:comment "The preferred line referencing system. TODO: provide example"@en ;
+              rdfs:isDefinedBy <http://data.europa.eu/949/> ;
               rdfs:label "line referencing system"@en .
 
 
@@ -2683,10 +2719,10 @@ era:mNvcontact rdf:type owl:ObjectProperty ;
                            ] ;
                rdfs:range skos:Concept ;
                era:XMLName "CPE_MNVCONTACT" ;
-               era:appendixD3Index "1.5.9" ;
                era:inSkosConceptScheme <http://data.europa.eu/949/concepts/etcs-reactions-contact/ETCSReactionsNVContact> ;
                era:rinfIndex "1.1.1.3.2.16.9" ,
                              "1.2.1.1.1.16.9" ;
+               era:tsiOPEappendixD3Index "1.5.9" ;
                dcterms:created "2022-11-07"^^xsd:date ;
                dcterms:modified "2023-03-14"^^xsd:date ,
                                 "2024-04-18"^^xsd:date ;
@@ -2712,10 +2748,10 @@ era:magneticBraking rdf:type owl:ObjectProperty ;
                                 ] ;
                     rdfs:range skos:Concept ;
                     era:XMLName "ILR_MagneticBrakes" ;
-                    era:appendixD2Index "3.4.6" ;
                     era:inSkosConceptScheme <http://data.europa.eu/949/concepts/magnetic-braking/MagneticBraking> ;
                     era:rinfIndex "1.1.1.1.6.3" ,
                                   "1.2.1.0.4.3" ;
+                    era:tsiOPEappendixD2Index "3.4.6" ;
                     era:usedInRCCCalculations "true"^^xsd:boolean ;
                     dcterms:created "2020-08-24"^^xsd:date ;
                     dcterms:modified "2022-09-12"^^xsd:date ,
@@ -2739,8 +2775,8 @@ era:magneticBrakingConditionsDocument rdf:type owl:ObjectProperty ;
                                                   ] ;
                                       rdfs:range era:Document ;
                                       era:XMLName "ILR_MBDocRef" ;
-                                      era:appendixD2Index "3.4.6" ;
                                       era:rinfIndex "1.1.1.1.6.5" ;
+                                      era:tsiOPEappendixD2Index "3.4.6" ;
                                       era:usedInRCCCalculations "true"^^xsd:boolean ;
                                       dcterms:created "2020-08-24"^^xsd:date ;
                                       dcterms:modified "2021-09-11"^^xsd:date ,
@@ -2825,6 +2861,7 @@ Deprecated according to the amendment to the Regulation (EU) 2019/777."""@en ;
 ###  http://data.europa.eu/949/minVehicleImpedance
 era:minVehicleImpedance rdf:type owl:ObjectProperty ;
                         rdfs:subPropertyOf era:trainDetectionSystemBasedFrequencyBandsObjParameter ;
+                        rdf:type owl:FunctionalProperty ;
                         rdfs:domain era:TrainDetectionSystem ;
                         rdfs:range era:MinVehicleImpedance ;
                         era:rinfIndex "1.1.1.3.4.2.2" ;
@@ -2938,6 +2975,7 @@ era:ofParameter rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf owl:topObjectProperty ;
                 rdfs:domain era:ParameterApplicability ;
                 dcterms:created "2024-10-28"^^xsd:date ;
+                rdfs:comment "Indicates the parameter (object or datatype property) for which an applicability is being defined."@en ;
                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                 rdfs:label "of parameter"@en .
 
@@ -2947,6 +2985,7 @@ era:onGrid rdf:type owl:ObjectProperty ;
            rdfs:domain era:Signal ;
            rdfs:range era:SignalsGrid ;
            dcterms:created "2024-05-24"^^xsd:date ;
+           rdfs:comment "Relates a signal with a signal grid."@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "on signal grid"@en .
 
@@ -2957,8 +2996,8 @@ era:opEnd rdf:type owl:ObjectProperty ,
           rdfs:domain era:SectionOfLine ;
           rdfs:range era:OperationalPoint ;
           era:XMLName "SOLOPEnd" ;
-          era:appendixD2Index "3.1.2" ;
           era:rinfIndex "1.1.0.0.0.4" ;
+          era:tsiOPEappendixD2Index "3.1.2" ;
           dcterms:created "2021-09-09"^^xsd:date ;
           dcterms:modified "2024-01-08"^^xsd:date ,
                            "2024-09-19"^^xsd:date ;
@@ -2990,8 +3029,8 @@ era:opStart rdf:type owl:ObjectProperty ,
             rdfs:domain era:SectionOfLine ;
             rdfs:range era:OperationalPoint ;
             era:XMLName "SOLOPStart" ;
-            era:appendixD2Index "3.1.1" ;
             era:rinfIndex "1.1.0.0.0.3" ;
+            era:tsiOPEappendixD2Index "3.1.1" ;
             dcterms:created "2021-09-09"^^xsd:date ;
             dcterms:modified "2024-01-08"^^xsd:date ,
                              "2024-09-19"^^xsd:date ;
@@ -3008,10 +3047,10 @@ era:opType rdf:type owl:ObjectProperty ,
            rdfs:domain era:OperationalPoint ;
            rdfs:range skos:Concept ;
            era:XMLName "OPType" ;
-           era:appendixD2Index "2.2.2" ,
-                               "2.3.2" ;
            era:inSkosConceptScheme <http://data.europa.eu/949/concepts/op-types/OperationalPointTypes> ;
            era:rinfIndex "1.2.0.0.0.4" ;
+           era:tsiOPEappendixD2Index "2.2.2" ,
+                                     "2.3.2" ;
            dcterms:created "2020-07-29"^^xsd:date ;
            dcterms:modified "2021-08-03"^^xsd:date ,
                             "2024-09-19"^^xsd:date ;
@@ -3025,10 +3064,10 @@ era:opType rdf:type owl:ObjectProperty ,
 ###  http://data.europa.eu/949/operatingLanguage
 era:operatingLanguage rdf:type owl:ObjectProperty ;
                       rdfs:range skos:Concept ;
-                      era:appendixD2Index "3.5.1" ;
                       era:inSkosConceptScheme <http://publications.europa.eu/resource/authority/language> ;
                       era:rinfIndex "1.1.0.0.1.2" ,
                                     "1.2.0.0.0.8" ;
+                      era:tsiOPEappendixD2Index "3.5.1" ;
                       dcterms:created "2022-10-28"^^xsd:date ;
                       dcterms:modified "2023-03-14"^^xsd:date ,
                                        "2024-09-19"^^xsd:date ;
@@ -3042,9 +3081,9 @@ era:operatingLanguage rdf:type owl:ObjectProperty ;
 ###  http://data.europa.eu/949/operationalRegimeType
 era:operationalRegimeType rdf:type owl:ObjectProperty ;
                           rdfs:range skos:Concept ;
-                          era:appendixD2Index "3.2.7" ;
                           era:inSkosConceptScheme <http://data.europa.eu/949/concepts/operational-regime-types/OperationalRegimeTypes> ;
                           era:rinfIndex "1.1.0.0.1.3" ;
+                          era:tsiOPEappendixD2Index "3.2.7" ;
                           dcterms:created "2022-10-27"^^xsd:date ;
                           dcterms:modified "2024-01-08"^^xsd:date ,
                                            "2024-09-19"^^xsd:date ,
@@ -3109,10 +3148,10 @@ era:otherCantDeficiencyBasicSSP rdf:type owl:ObjectProperty ;
                                             ] ;
                                 rdfs:range skos:Concept ;
                                 era:XMLName "CPE_OtherCantDef" ;
-                                era:appendixD3Index "1.3" ;
                                 era:inSkosConceptScheme <http://data.europa.eu/949/concepts/cant-deficiencies/CantDeficiencies> ;
                                 era:rinfIndex "1.1.1.3.2.14.1" ,
                                               "1.2.1.1.1.14.1" ;
+                                era:tsiOPEappendixD3Index "1.3" ;
                                 dcterms:created "2023-03-14"^^xsd:date ;
                                 dcterms:modified "2024-04-18"^^xsd:date ,
                                                  "2024-09-19"^^xsd:date ;
@@ -3179,10 +3218,10 @@ era:otherTrainProtection rdf:type owl:ObjectProperty ;
                                      ] ;
                          rdfs:range skos:Concept ;
                          era:XMLName "CLD_OtherProtectControlWarn" ;
-                         era:appendixD2Index "3.4.1" ;
                          era:inSkosConceptScheme <http://data.europa.eu/949/concepts/other-protection-control-warning/OtherProtectionControlWarnings> ;
                          era:rinfIndex "1.1.1.3.10.2" ,
                                        "1.2.1.1.9.2" ;
+                         era:tsiOPEappendixD2Index "3.4.1" ;
                          dcterms:created "2021-08-09"^^xsd:date ;
                          dcterms:description "Selected value shall answer the question whether any other system than ETCS exists on the respective track. The list is in line with ERA/TD/2011-09/INT (v1.13), Table 3."@en ;
                          dcterms:modified "2021-09-12"^^xsd:date ,
@@ -3209,10 +3248,15 @@ era:pantographObjParameter rdf:type owl:ObjectProperty ;
 
 ###  http://data.europa.eu/949/parameterApplicability
 era:parameterApplicability rdf:type owl:ObjectProperty ;
-                           rdfs:domain era:InfrastructureElement ;
+                           rdfs:domain [ rdf:type owl:Class ;
+                                         owl:unionOf ( era:CommonCharacteristicsSubset
+                                                       era:InfrastructureElement
+                                                     )
+                                       ] ;
                            rdfs:range era:ParameterApplicability ;
                            dcterms:created "2024-05-24"^^xsd:date ;
                            dcterms:modified "2024-10-28"^^xsd:date ;
+                           rdfs:comment "Relates an infrastructure element or a common characteristics subset with the applicability of a certain parameter."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "parameter applicability"@en .
 
@@ -3285,9 +3329,9 @@ era:platformHeight rdf:type owl:ObjectProperty ,
                                ] ;
                    rdfs:range skos:Concept ;
                    era:XMLName "IPL_Height" ;
-                   era:appendixD2Index "2.3.7" ;
                    era:inSkosConceptScheme <http://data.europa.eu/949/concepts/platform-heights/PlatformHeights> ;
                    era:rinfIndex "1.2.1.0.6.5" ;
+                   era:tsiOPEappendixD2Index "2.3.7" ;
                    era:usedInRCCCalculations "true"^^xsd:boolean ;
                    dcterms:created "2021-08-02"^^xsd:date ;
                    dcterms:modified "2021-08-02"^^xsd:date ,
@@ -3349,6 +3393,8 @@ era:previousVehicleType rdf:type owl:ObjectProperty ;
 era:primaryLocation rdf:type owl:ObjectProperty ;
                     rdfs:domain era:OperationalPoint ;
                     rdfs:range era:PrimaryLocation ;
+                    rdfs:comment "Relates an operational point with its primary location."@en ;
+                    rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                     rdfs:label "primary location"@en .
 
 
@@ -3431,10 +3477,10 @@ era:qNvdriverAdhes rdf:type owl:ObjectProperty ;
                                ] ;
                    rdfs:range skos:Concept ;
                    era:XMLName "CPE_QNVDRIVERADHES" ;
-                   era:appendixD3Index "1.5.11" ;
                    era:inSkosConceptScheme <http://data.europa.eu/949/concepts/adhf-qualifier/AdhesionFactorChange> ;
                    era:rinfIndex "1.1.1.3.2.16.11" ,
                                  "1.2.1.1.1.16.11" ;
+                   era:tsiOPEappendixD3Index "1.5.11" ;
                    dcterms:created "2024-04-18"^^xsd:date ;
                    dcterms:modified "2024-09-20"^^xsd:date ;
                    dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ,
@@ -3459,10 +3505,10 @@ era:qNvemrrls rdf:type owl:ObjectProperty ;
                           ] ;
               rdfs:range skos:Concept ;
               era:XMLName "CPE_QNVEMRRLS" ;
-              era:appendixD3Index "1.5.2" ;
               era:inSkosConceptScheme <http://data.europa.eu/949/concepts/ebr-qualifier/EBReleaseQualifier> ;
               era:rinfIndex "1.1.1.3.2.16.2" ,
                             "1.2.1.1.1.16.2" ;
+              era:tsiOPEappendixD3Index "1.5.2" ;
               dcterms:created "2023-03-14"^^xsd:date ;
               dcterms:modified "2024-04-18"^^xsd:date ;
               rdfs:comment """
@@ -3526,10 +3572,10 @@ era:reasonsEtcsRadioBlockCenterReject rdf:type owl:ObjectProperty ;
                                                   ] ;
                                       rdfs:range skos:Concept ;
                                       era:XMLName "CPE_RBCRejectReasons" ;
-                                      era:appendixD3Index "1.4" ;
                                       era:inSkosConceptScheme <http://data.europa.eu/949/concepts/etcs-rbc-reject-reasons/ETCSRBCRejectionReasons> ;
                                       era:rinfIndex "1.1.1.3.2.15" ,
                                                     "1.2.1.1.1.15" ;
+                                      era:tsiOPEappendixD3Index "1.4" ;
                                       dcterms:created "2022-11-07"^^xsd:date ;
                                       dcterms:modified "2023-03-14"^^xsd:date ,
                                                        "2024-04-18"^^xsd:date ,
@@ -3549,6 +3595,7 @@ era:referenceBorderPoint rdf:type owl:ObjectProperty ;
                          rdfs:domain era:OperationalPoint ;
                          rdfs:range era:ReferenceBorderPoint ;
                          dcterms:created "2024-10-24"^^xsd:date ;
+                         rdfs:comment "Relates an operational point that is a border point with an instance of the list of reference border points that are specified in the RINF Application Guide."@en ;
                          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                          rdfs:label "reference border point"@en .
 
@@ -3590,7 +3637,7 @@ era:role rdf:type owl:ObjectProperty ;
          rdfs:range era:OrganisationRole ;
          dcterms:created "2024-06-03"^^xsd:date ;
          dcterms:modified "2024-10-24"^^xsd:date ;
-         rdfs:comment "Indicates the n-ary relationship from the Body"@en ;
+         rdfs:comment "Indicates the relationship of a Body to the organisation roles that it can play."@en ;
          rdfs:isDefinedBy <http://data.europa.eu/949/> ;
          rdfs:label "role"@en .
 
@@ -3601,6 +3648,7 @@ era:roleOf rdf:type owl:ObjectProperty ,
            rdfs:domain era:OrganisationRole ;
            rdfs:range era:Body ;
            dcterms:created "2024-10-24"^^xsd:date ;
+           rdfs:comment "Indicates the corresponding Body that plays a certain organisation role."@en ;
            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
            rdfs:label "role of"@en .
 
@@ -3616,11 +3664,11 @@ era:rollingStockFireCategory rdf:type owl:ObjectProperty ;
                                          ] ;
                              rdfs:range skos:Concept ;
                              era:XMLName "ITU_FireCatReq" ;
-                             era:appendixD2Index "3.2.3" ;
                              era:inSkosConceptScheme <http://data.europa.eu/949/concepts/rolling-stock-fire/Categories> ;
                              era:rinfIndex "1.1.1.1.8.10" ,
                                            "1.2.1.0.5.7" ,
                                            "1.2.2.0.5.7" ;
+                             era:tsiOPEappendixD2Index "3.2.3" ;
                              era:usedInRCCCalculations "true"^^xsd:boolean ;
                              dcterms:created "2020-07-29"^^xsd:date ;
                              dcterms:description "Wherever category B is not needed, generally the category A has to be understood as the default value. ‘None’ shall be selected when none of A or B fire category is applied for a specific tunnel."@en ;
@@ -3713,11 +3761,11 @@ era:signalOrientation rdf:type owl:ObjectProperty ;
                                   ] ;
                       rdfs:range skos:Concept ;
                       era:XMLName "SIG_LocDir" ;
-                      era:appendixD2Index "2.2.3" ,
-                                          "2.3.3" ;
                       era:inSkosConceptScheme <http://data.europa.eu/949/concepts/track-running-directions/TrackRunningDirections> ;
                       era:rinfIndex "1.1.1.3.14.3" ,
                                     "1.2.1.0.8.3" ;
+                      era:tsiOPEappendixD2Index "2.2.3" ,
+                                                "2.3.3" ;
                       dcterms:created "2023-03-14"^^xsd:date ;
                       dcterms:modified "2024-04-18"^^xsd:date ;
                       rdfs:comment "Indication if the signal (on the track or in OP) is applicable for operation on normal, opposite track direction or if it contains bidirectionally valid information (radio-based system only)."@en ;
@@ -3736,11 +3784,11 @@ era:signalType rdf:type owl:ObjectProperty ;
                            ] ;
                rdfs:range skos:Concept ;
                era:XMLName "SIG_Type" ;
-               era:appendixD2Index "2.2.3" ,
-                                   "2.3.3" ;
                era:inSkosConceptScheme <http://data.europa.eu/949/concepts/signal-types/SignalTypes> ;
                era:rinfIndex "1.1.1.3.14.2" ,
                              "1.2.1.0.8.2" ;
+               era:tsiOPEappendixD2Index "2.2.3" ,
+                                         "2.3.3" ;
                dcterms:created "2022-10-27"^^xsd:date ;
                dcterms:description "Indicates what function the signal (on the track or in OP) executes in relation to the track/switches."@en ;
                dcterms:modified "2024-01-08"^^xsd:date ,
@@ -3756,8 +3804,8 @@ era:signalType rdf:type owl:ObjectProperty ;
 ###  http://data.europa.eu/949/signallingSystemType
 era:signallingSystemType rdf:type owl:ObjectProperty ;
                          rdfs:range skos:Concept ;
-                         era:appendixD2Index "3.2.7" ;
                          era:rinfIndex "1.1.0.0.1.3" ;
+                         era:tsiOPEappendixD2Index "3.2.7" ;
                          dcterms:created "2023-03-14"^^xsd:date ;
                          dcterms:modified "2024-09-19"^^xsd:date ;
                          dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -3804,14 +3852,14 @@ era:solNature rdf:type owl:ObjectProperty ,
 era:specialAreaType rdf:type owl:ObjectProperty ;
                     rdfs:domain era:SpecialArea ;
                     rdfs:range skos:Concept ;
-                    era:appendixD2Index "3.2.3" ,
-                                        "3.2.4" ,
-                                        "3.2.5" ,
-                                        "3.2.6" ,
-                                        "3.3.5" ,
-                                        "3.3.6" ;
                     era:inSkosConceptScheme <http://data.europa.eu/949/concepts/special-area-types/SpecialAreaTypes> ;
                     era:rinfIndex "1.1.0.0.1.1" ;
+                    era:tsiOPEappendixD2Index "3.2.3" ,
+                                              "3.2.4" ,
+                                              "3.2.5" ,
+                                              "3.2.6" ,
+                                              "3.3.5" ,
+                                              "3.3.6" ;
                     dcterms:created "2022-10-27"^^xsd:date ;
                     dcterms:modified "2023-03-14"^^xsd:date ,
                                      "2024-04-18"^^xsd:date ;
@@ -3825,7 +3873,7 @@ era:specialAreaType rdf:type owl:ObjectProperty ;
 era:specialTunnelArea rdf:type owl:ObjectProperty ;
                       rdfs:domain era:Tunnel ;
                       rdfs:range era:SpecialTunnelArea ;
-                      era:appendixD2Index "3.2.3" ;
+                      era:tsiOPEappendixD2Index "3.2.3" ;
                       dcterms:created "2022-10-27"^^xsd:date ;
                       dcterms:modified "2024-09-19"^^xsd:date ;
                       dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -3921,6 +3969,8 @@ era:subsetOf rdf:type owl:ObjectProperty ,
              rdfs:domain era:CommonCharacteristicsSubset ;
              rdfs:range era:CommonCharacteristicsSubset ;
              dcterms:created "2024-10-31"^^xsd:date ;
+             rdfs:comment "Relates a subset with common chatacteristics with another subset with common characteristics."@en ;
+             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "subset of"@en .
 
 
@@ -3929,6 +3979,7 @@ era:subsidiaryLocation rdf:type owl:ObjectProperty ;
                        rdfs:domain era:InfrastructureElement ;
                        rdfs:range era:SubsidiaryLocation ;
                        dcterms:created "2024-05-24"^^xsd:date ;
+                       rdfs:comment "Relates an infrastructure element with a subsidiary location."@en ;
                        rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                        rdfs:label "has subsidiary location"@en .
 
@@ -3939,6 +3990,7 @@ era:subsidiaryLocationType rdf:type owl:ObjectProperty ;
                            rdfs:range skos:Concept ;
                            era:inSkosConceptScheme <http://data.europa.eu/949/concepts/subsidiary-location-types/SubsidiaryLocationTypes> ;
                            dcterms:created "2024-05-24"^^xsd:date ;
+                           rdfs:comment "Indicates the subsidiary location type that belongs to a taxonomy."@en ;
                            rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                            rdfs:label "subsidiary location type"@en .
 
@@ -3970,6 +4022,7 @@ era:switchesAndCrossingsObjParameter rdf:type owl:ObjectProperty ;
 ###  http://data.europa.eu/949/tdsFrenchTrainDetectionSystemLimitation
 era:tdsFrenchTrainDetectionSystemLimitation rdf:type owl:ObjectProperty ;
                                             rdfs:subPropertyOf era:otherTrainDetectionSystemsObjParameter ;
+                                            rdf:type owl:FunctionalProperty ;
                                             rdfs:domain era:TrainDetectionSystem ;
                                             rdfs:range era:FrenchTrainDetectionSystemLimitation ;
                                             era:XMLName "CTD_TCLimitation" ;
@@ -3988,6 +4041,7 @@ Specific for route compatibility check on French network."""@en ;
 ###  http://data.europa.eu/949/tdsMaximumMagneticField
 era:tdsMaximumMagneticField rdf:type owl:ObjectProperty ;
                             rdfs:subPropertyOf era:trainDetectionSystemBasedFrequencyBandsObjParameter ;
+                            rdf:type owl:FunctionalProperty ;
                             rdfs:domain era:TrainDetectionSystem ;
                             rdfs:range era:MaximumMagneticField ;
                             era:XMLName "CCD_ACMagFieldMax" ;
@@ -4137,9 +4191,9 @@ era:trackDirection rdf:type owl:ObjectProperty ,
                    rdfs:domain era:RunningTrack ;
                    rdfs:range skos:Concept ;
                    era:XMLName "SOLTrackDirection" ;
-                   era:appendixD2Index "2.2.1.1" ;
                    era:inSkosConceptScheme <http://data.europa.eu/949/concepts/track-running-directions/TrackRunningDirections> ;
                    era:rinfIndex "1.1.1.0.0.2" ;
+                   era:tsiOPEappendixD2Index "2.2.1.1" ;
                    dcterms:created "2021-09-09"^^xsd:date ;
                    dcterms:modified "2024-01-08"^^xsd:date ;
                    rdfs:comment """The normal running direction is:
@@ -4273,6 +4327,7 @@ era:trainDetectionSystemBasedFrequencyBandsObjParameter rdf:type owl:ObjectPrope
 ###  http://data.europa.eu/949/trainDetectionSystemSpecificCheck
 era:trainDetectionSystemSpecificCheck rdf:type owl:ObjectProperty ;
                                       rdfs:subPropertyOf era:otherTrainDetectionSystemsObjParameter ;
+                                      rdf:type owl:FunctionalProperty ;
                                       rdfs:domain era:TrainDetectionSystem ;
                                       rdfs:range skos:Concept ;
                                       era:XMLName "CTD_TCCheck" ;
@@ -4301,6 +4356,7 @@ era:trainDetectionSystemSpecificCheck rdf:type owl:ObjectProperty ;
 ###  http://data.europa.eu/949/trainDetectionSystemSpecificCheckDocument
 era:trainDetectionSystemSpecificCheckDocument rdf:type owl:ObjectProperty ;
                                               rdfs:subPropertyOf era:otherTrainDetectionSystemsObjParameter ;
+                                              rdf:type owl:FunctionalProperty ;
                                               rdfs:domain era:TrainDetectionSystem ;
                                               rdfs:range era:Document ;
                                               era:XMLName "CTD_TCCheckDocRef" ;
@@ -4326,6 +4382,7 @@ era:trainDetectionSystemSpecificCheckDocument rdf:type owl:ObjectProperty ;
 era:trainDetectionSystemType rdf:type owl:ObjectProperty ;
                              rdfs:subPropertyOf era:otherTrainDetectionSystemsObjParameter ,
                                                 era:vehicleTypeTechnicalObjectCharacteristic ;
+                             rdf:type owl:FunctionalProperty ;
                              rdfs:domain [ rdf:type owl:Class ;
                                            owl:unionOf ( era:TrainDetectionSystem
                                                          era:VehicleType
@@ -4623,6 +4680,7 @@ era:validity rdf:type owl:ObjectProperty ;
                                        )
                          ] ;
              rdfs:range era:TemporalFeature ;
+             rdfs:isDefinedBy <http://data.europa.eu/949/> ;
              rdfs:label "validity"@en .
 
 
@@ -4803,7 +4861,7 @@ geo:hasGeometry rdf:type owl:ObjectProperty ;
                 era:XMLName "OPGeographicLocation" ;
                 era:rinfIndex "1.1.0.0.1.1" ,
                               "1.1.1.0.1.1" ,
-                              "1.1.1.3.14.5" ,
+                              "1.1.1.3.14.6" ,
                               "1.2.0.0.0.5" ,
                               "1.2.1.0.8.5" ;
                 era:usedInRCCCalculations "true"^^xsd:boolean ;
@@ -5026,9 +5084,9 @@ era:bigMetalMass rdf:type owl:DatatypeProperty ;
                              ] ;
                  rdfs:range xsd:boolean ;
                  era:XMLName "CPE_BigMetalMass" ;
-                 era:appendixD2Index "3.4.10" ;
                  era:rinfIndex "1.1.1.3.2.18" ,
                                "1.2.1.1.1.18" ;
+                 era:tsiOPEappendixD2Index "3.4.10" ;
                  dcterms:created "2023-03-14"^^xsd:date ;
                  dcterms:modified "2024-01-08"^^xsd:date ,
                                   "2024-04-18"^^xsd:date ;
@@ -5052,6 +5110,18 @@ era:boardingAids rdf:type owl:DatatypeProperty ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:label "Boarding aids"@en ;
                  vs:term_status "stable" .
+
+
+###  http://data.europa.eu/949/borderPointId
+era:borderPointId rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf dcterms:identifier ;
+                  rdfs:domain era:ReferenceBorderPoint ;
+                  rdfs:range xsd:string ;
+                  dcterms:created "2024-11-26"@en ;
+                  rdfs:comment "Border point identification in the list of reference border points in the RINF application guide."@en ;
+                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                  rdfs:label "Border point identification"@en ;
+                  vs:term_status "stable" .
 
 
 ###  http://data.europa.eu/949/brakeRelatedDataParameter
@@ -5205,8 +5275,8 @@ era:conditionalRegenerativeBrake rdf:type owl:DatatypeProperty ;
                                  rdfs:domain era:ContactLineSystem ;
                                  rdfs:range xsd:boolean ;
                                  era:XMLName "ECS_RegenerativeBraking" ;
-                                 era:appendixD2Index "3.3.7" ;
                                  era:rinfIndex "1.1.1.2.2.4" ;
+                                 era:tsiOPEappendixD2Index "3.3.7" ;
                                  era:usedInRCCCalculations "true"^^xsd:boolean ;
                                  dcterms:created "2020-08-24"^^xsd:date ;
                                  dcterms:modified "2023-01-20"^^xsd:date ;
@@ -5219,6 +5289,7 @@ era:conditionalRegenerativeBrake rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/conditionsChargingElectricEnergyStorage
 era:conditionsChargingElectricEnergyStorage rdf:type owl:DatatypeProperty ;
                                             rdfs:subPropertyOf era:contactLineSystemDataParameter ;
+                                            rdf:type owl:FunctionalProperty ;
                                             rdfs:domain era:ContactLineSystem ;
                                             rdfs:range xsd:anyURI ;
                                             era:rinfIndex "1.2.1.0.7.2" ;
@@ -5240,9 +5311,9 @@ era:conditionsSwitchTrainProtectionSystems rdf:type owl:DatatypeProperty ;
                                                        ] ;
                                            rdfs:range xsd:string ;
                                            era:XMLName "CTS_SwitchProtectConditions" ;
-                                           era:appendixD2Index "3.4.2" ;
                                            era:rinfIndex "1.1.1.3.8.1.1" ,
                                                          "1.2.1.1.7.1.1" ;
+                                           era:tsiOPEappendixD2Index "3.4.2" ;
                                            dcterms:created "2022-10-28"^^xsd:date ;
                                            dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
                                            rdfs:comment "Conditions to switch over between different class B train protection, control and warning systems."@en ;
@@ -5373,9 +5444,9 @@ era:dNvovtrp rdf:type owl:DatatypeProperty ;
                          ] ;
              rdfs:range xsd:double ;
              era:XMLName "CPE_DNVOVTRP" ;
-             era:appendixD3Index "1.5.5" ;
              era:rinfIndex "1.1.1.3.2.16.5" ,
                            "1.2.1.1.1.16.5" ;
+             era:tsiOPEappendixD3Index "1.5.5" ;
              era:unitOfMeasure unit:M ;
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2024-01-08"^^xsd:date ,
@@ -5403,9 +5474,9 @@ era:dNvpotrp rdf:type owl:DatatypeProperty ;
                          ] ;
              rdfs:range xsd:double ;
              era:XMLName "CPE_DNVPOTRP" ;
-             era:appendixD3Index "1.5.7" ;
              era:rinfIndex "1.1.1.3.2.16.7" ,
                            "1.2.1.1.1.16.7" ;
+             era:tsiOPEappendixD3Index "1.5.7" ;
              era:unitOfMeasure unit:M ;
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2023-03-14"^^xsd:date ,
@@ -5434,9 +5505,9 @@ era:dNvroll rdf:type owl:DatatypeProperty ;
                         ] ;
             rdfs:range xsd:double ;
             era:XMLName "CPE_DNVROLL" ;
-            era:appendixD3Index "1.5.1" ;
             era:rinfIndex "1.1.1.3.2.16.1" ,
                           "1.2.1.1.1.16.1" ;
+            era:tsiOPEappendixD3Index "1.5.1" ;
             era:unitOfMeasure unit:M ;
             dcterms:created "2022-11-07"^^xsd:date ;
             dcterms:modified "2023-03-14"^^xsd:date ,
@@ -5781,6 +5852,7 @@ era:energySupplyMaxPower rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/energySupplySystemTSICompliant
 era:energySupplySystemTSICompliant rdf:type owl:DatatypeProperty ;
                                    rdfs:subPropertyOf era:contactLineSystemDataParameter ;
+                                   rdf:type owl:FunctionalProperty ;
                                    rdfs:domain era:ContactLineSystem ;
                                    rdfs:range xsd:boolean ;
                                    era:XMLName "ECS_TSIVoltFreq" ;
@@ -5867,9 +5939,9 @@ era:etcsImplementsLevelCrossingProcedure rdf:type owl:DatatypeProperty ;
                                                      ] ;
                                          rdfs:range xsd:boolean ;
                                          era:XMLName "CPE_LXProcedure" ;
-                                         era:appendixD3Index "1.2" ;
                                          era:rinfIndex "1.1.1.3.2.13" ,
                                                        "1.2.1.1.1.13" ;
+                                         era:tsiOPEappendixD3Index "1.2" ;
                                          dcterms:created "2022-11-04"^^xsd:date ;
                                          dcterms:modified "2024-04-18"^^xsd:date ;
                                          dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -6019,9 +6091,9 @@ era:etcsTransmitsTrackConditions rdf:type owl:DatatypeProperty ;
                                  rdfs:domain era:ETCS ;
                                  rdfs:range xsd:boolean ;
                                  era:XMLName "CPE_CanTransmitTCs" ;
-                                 era:appendixD3Index "1.1" ;
                                  era:rinfIndex "1.1.1.3.2.12" ,
                                                "1.2.1.1.1.12" ;
+                                 era:tsiOPEappendixD3Index "1.1" ;
                                  dcterms:created "2022-11-04"^^xsd:date ;
                                  dcterms:modified "2023-03-14"^^xsd:date ,
                                                   "2024-04-18"^^xsd:date ;
@@ -6250,9 +6322,9 @@ era:gradientProfile rdf:type owl:DatatypeProperty ;
                                 ] ;
                     rdfs:range xsd:string ;
                     era:XMLName "ILL_GradProfile" ;
-                    era:appendixD2Index "3.2.1" ,
-                                        "3.2.2" ;
                     era:rinfIndex "1.1.1.1.3.6" ;
+                    era:tsiOPEappendixD2Index "3.2.1" ,
+                                              "3.2.2" ;
                     era:usedInRCCCalculations "true"^^xsd:boolean ;
                     dcterms:created "2020-08-24"^^xsd:date ;
                     dcterms:description """Data on the values of gradient along a SoL is given as a chain of information:
@@ -6343,9 +6415,9 @@ era:gsmrForcedDeregistrationFunctionalNumber rdf:type owl:DatatypeProperty ;
                                                          ] ;
                                              rdfs:range xsd:boolean ;
                                              era:XMLName "CRG_ForcedDeReg" ;
-                                             era:appendixD3Index "2.1" ;
                                              era:rinfIndex "1.1.1.3.3.11" ,
                                                            "1.2.1.1.2.11" ;
+                                             era:tsiOPEappendixD3Index "2.1" ;
                                              dcterms:created "2022-11-07"^^xsd:date ;
                                              dcterms:modified "2023-03-14"^^xsd:date ,
                                                               "2024-04-18"^^xsd:date ;
@@ -6571,10 +6643,10 @@ era:hasEvacuationAndRescuePoints rdf:type owl:DatatypeProperty ;
                                                            )
                                              ] ;
                                  rdfs:range xsd:boolean ;
-                                 era:appendixD2Index "3.2.3" ;
                                  era:rinfIndex "1.1.1.1.8.13" ,
                                                "1.2.1.0.5.11" ,
                                                "1.2.2.0.5.10" ;
+                                 era:tsiOPEappendixD2Index "3.2.3" ;
                                  dcterms:created "2022-10-27"^^xsd:date ;
                                  dcterms:modified "2023-03-14"^^xsd:date ,
                                                   "2024-09-19"^^xsd:date ;
@@ -6717,8 +6789,8 @@ era:hasPlatformCurvature rdf:type owl:DatatypeProperty ;
                                                    )
                                      ] ;
                          rdfs:range xsd:boolean ;
-                         era:appendixD2Index "2.3.8" ;
                          era:rinfIndex "1.2.1.0.6.8" ;
+                         era:tsiOPEappendixD2Index "2.3.8" ;
                          dcterms:created "2022-10-27"^^xsd:date ;
                          dcterms:modified "2023-03-14"^^xsd:date ;
                          dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -6938,10 +7010,10 @@ era:hasWalkway rdf:type owl:DatatypeProperty ;
                                          )
                            ] ;
                rdfs:range xsd:boolean ;
-               era:appendixD2Index "3.2.3" ;
                era:rinfIndex "1.1.1.1.8.12" ,
                              "1.2.1.0.5.10" ,
                              "1.2.2.0.5.9" ;
+               era:tsiOPEappendixD2Index "3.2.3" ;
                dcterms:created "2022-10-27"^^xsd:date ;
                dcterms:modified "2023-03-14"^^xsd:date ,
                                 "2024-09-19"^^xsd:date ;
@@ -7112,9 +7184,9 @@ Trackside hot axle box detector TSI compliant."""@en ;
 ###  http://data.europa.eu/949/idPhoneErtmsRadioBlockCenter
 era:idPhoneErtmsRadioBlockCenter rdf:type owl:DatatypeProperty ;
                                  rdfs:range xsd:string ;
-                                 era:appendixD2Index "3.4.7" ;
                                  era:rinfIndex "1.1.1.3.2.17" ,
                                                "1.2.1.1.1.17" ;
+                                 era:tsiOPEappendixD2Index "3.4.7" ;
                                  dcterms:created "2023-03-14"^^xsd:date ;
                                  dcterms:isReplacedBy era:rbcID ,
                                                       era:rbcPhone ;
@@ -7139,7 +7211,6 @@ era:imCode rdf:type owl:DatatypeProperty ;
                        "OPTrackTunnelIMCode" ,
                        "SOLIMCode" ,
                        "SOLTunnelIMCode" ;
-           era:appendixD2Index "1.1" ;
            era:rinfIndex "1.1.0.0.0.1" ,
                          "1.1.1.1.8.1" ,
                          "1.2.1.0.0.1" ,
@@ -7147,6 +7218,7 @@ era:imCode rdf:type owl:DatatypeProperty ;
                          "1.2.1.0.6.1" ,
                          "1.2.2.0.0.1" ,
                          "1.2.2.0.5.1" ;
+           era:tsiOPEappendixD2Index "1.1" ;
            dcterms:created "2021-08-02"^^xsd:date ;
            dcterms:description """The Code is a unique identifier for the Infrastructure Manager and it shall be verified on national level. 
 - If the IM is subject to TAF/TAP TSIs, it corresponds to the code used in TAF/TAP TSIs. 
@@ -7215,7 +7287,6 @@ era:kilometer rdf:type owl:DatatypeProperty ;
               rdfs:domain era:Position ;
               rdfs:range xsd:double ;
               era:XMLName "OPRailwayLocation" ;
-              era:appendixD2Index "2.2.2" ;
               era:rinfIndex "1.1.1.1.8.12.1" ,
                             "1.1.1.1.8.13.1" ,
                             "1.1.1.3.14.3" ,
@@ -7226,6 +7297,7 @@ era:kilometer rdf:type owl:DatatypeProperty ;
                             "1.2.1.0.8.3" ,
                             "1.2.2.0.5.10.1" ,
                             "1.2.2.0.5.9.1" ;
+              era:tsiOPEappendixD2Index "2.2.2" ;
               dcterms:created "2021-01-29"^^xsd:date ;
               dcterms:description """For walkways: Value provided in Kilometric point of the start of the walkway and the length in m. Repeatable values for each location.
 For rescue points: Value provided in Kilometric point of the start of the point of evacuation and rescue point and the length in m. Repeatable values for each location."""@en ;
@@ -7281,8 +7353,8 @@ era:lengthOfPlatform rdf:type owl:DatatypeProperty ;
                      rdfs:domain era:PlatformEdge ;
                      rdfs:range xsd:double ;
                      era:XMLName "IPL_Length" ;
-                     era:appendixD2Index "2.3.6" ;
                      era:rinfIndex "1.2.1.0.6.4" ;
+                     era:tsiOPEappendixD2Index "2.3.6" ;
                      era:unitOfMeasure unit:M ;
                      era:usedInRCCCalculations "true"^^xsd:boolean ;
                      dcterms:created "2024-05-16"^^xsd:date ;
@@ -7339,10 +7411,10 @@ era:lengthOfTunnel rdf:type owl:DatatypeProperty ;
                    rdfs:domain era:Tunnel ;
                    rdfs:range xsd:double ;
                    era:XMLName "ITU_Length" ;
-                   era:appendixD2Index "3.2.3" ;
                    era:rinfIndex "1.1.1.1.8.7" ,
                                  "1.2.1.0.5.5" ,
                                  "1.2.2.0.5.5" ;
+                   era:tsiOPEappendixD2Index "3.2.3" ;
                    era:unitOfMeasure unit:M ;
                    era:usedInRCCCalculations "true"^^xsd:boolean ;
                    dcterms:created "2024-05-16"^^xsd:date ;
@@ -7361,12 +7433,11 @@ era:lengthOfVehicle rdf:type owl:DatatypeProperty ;
                     rdf:type owl:FunctionalProperty ;
                     rdfs:domain era:Vehicle ;
                     rdfs:range xsd:double ;
+                    era:eratvIndex "4.8.1" ;
                     era:unitOfMeasure unit:M ;
                     dcterms:created "2024-11-04"^^xsd:date ;
                     rdfs:isDefinedBy <http://data.europa.eu/949/> ;
-                    era:eratvIndex "4.8.1" ;
                     rdfs:label "Vehicle length" .
-                                
 
 
 ###  http://data.europa.eu/949/letterMarking
@@ -7425,8 +7496,8 @@ era:linesideDistanceIndicationFrequency rdf:type owl:DatatypeProperty ;
                                                                   )
                                                     ] ;
                                         rdfs:range xsd:integer ;
-                                        era:appendixD2Index "3.1.3" ;
                                         era:rinfIndex "1.1.1.0.0.3" ;
+                                        era:tsiOPEappendixD2Index "3.1.3" ;
                                         dcterms:created "2022-10-27"^^xsd:date ;
                                         dcterms:modified "2023-03-14"^^xsd:date ;
                                         dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -7503,9 +7574,9 @@ era:mNvderun rdf:type owl:DatatypeProperty ;
                          ] ;
              rdfs:range xsd:boolean ;
              era:XMLName "CPE_MNVDERUN" ;
-             era:appendixD3Index "1.5.10" ;
              era:rinfIndex "1.1.1.3.2.16.10" ,
                            "1.2.1.1.1.16.10" ;
+             era:tsiOPEappendixD3Index "1.5.10" ;
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2023-03-14"^^xsd:date ,
                               "2023-04-18"^^xsd:date ;
@@ -7565,6 +7636,7 @@ era:massPerWheel rdf:type owl:DatatypeProperty ;
 era:maxCurrentStandstillPantograph rdf:type owl:DatatypeProperty ;
                                    rdfs:subPropertyOf era:contactLineSystemDataParameter ,
                                                       era:vehicleTypeTechnicalDataCharacteristic ;
+                                   rdf:type owl:FunctionalProperty ;
                                    rdfs:domain [ rdf:type owl:Class ;
                                                  owl:unionOf ( era:ContactLineSystem
                                                                era:Siding
@@ -7573,10 +7645,10 @@ era:maxCurrentStandstillPantograph rdf:type owl:DatatypeProperty ;
                                                ] ;
                                    rdfs:range xsd:double ;
                                    era:XMLName "ECS_MaxStandstillCurrent" ;
-                                   era:appendixD2Index "3.3.8" ;
                                    era:eratvIndex "4.10.4" ;
                                    era:rinfIndex "1.1.1.2.2.3" ,
                                                  "1.2.2.0.6.1" ;
+                                   era:tsiOPEappendixD2Index "3.3.8" ;
                                    era:unitOfMeasure unit:A ;
                                    era:usedInRCCCalculations "true"^^xsd:boolean ;
                                    dcterms:created "2020-08-25"^^xsd:date ;
@@ -7673,11 +7745,12 @@ era:maxLengthVehicleNose rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/maxTrainCurrent
 era:maxTrainCurrent rdf:type owl:DatatypeProperty ;
                     rdfs:subPropertyOf era:contactLineSystemDataParameter ;
+                    rdf:type owl:FunctionalProperty ;
                     rdfs:domain era:ContactLineSystem ;
                     rdfs:range xsd:integer ;
                     era:XMLName "ECS_MaxTrainCurrent" ;
-                    era:appendixD2Index "3.3.2" ;
                     era:rinfIndex "1.1.1.2.2.2" ;
+                    era:tsiOPEappendixD2Index "3.3.2" ;
                     era:unitOfMeasure unit:A ;
                     dcterms:created "2021-08-06"^^xsd:date ;
                     dcterms:modified "2021-08-06"^^xsd:date ;
@@ -7809,6 +7882,7 @@ era:maximumDesignSpeed rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/maximumInterferenceCurrent
 era:maximumInterferenceCurrent rdf:type owl:DatatypeProperty ;
                                rdfs:subPropertyOf era:trainDetectionSystemBasedFrequencyBandsDataParameter ;
+                               rdf:type owl:FunctionalProperty ;
                                rdfs:domain era:TrainDetectionSystem ;
                                rdfs:range xsd:double ;
                                era:XMLName "CCD_IInterferenceMax" ;
@@ -7921,8 +7995,8 @@ era:maximumPermittedSpeed rdf:type owl:DatatypeProperty ;
                                       ] ;
                           rdfs:range xsd:integer ;
                           era:XMLName "IPP_MaxSpeed" ;
-                          era:appendixD2Index "3.1.4" ;
                           era:rinfIndex "1.1.1.1.2.5" ;
+                          era:tsiOPEappendixD2Index "3.1.4" ;
                           era:unitOfMeasure unit:KiloM-PER-HR ;
                           era:usedInRCCCalculations "true"^^xsd:boolean ;
                           dcterms:created "2020-08-24"^^xsd:date ;
@@ -8480,9 +8554,9 @@ era:nationalValuesBrakeModel rdf:type owl:DatatypeProperty ;
                                          ] ;
                              rdfs:range xsd:string ;
                              era:XMLName "CPE_NVBRAKEMOD" ;
-                             era:appendixD3Index "1.5.13" ;
                              era:rinfIndex "1.1.1.3.2.16.13" ,
                                            "1.2.1.1.1.16.13" ;
+                             era:tsiOPEappendixD3Index "1.5.13" ;
                              dcterms:created "2023-03-14"^^xsd:date ;
                              dcterms:modified "2024-01-08"^^xsd:date ;
                              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -8587,8 +8661,8 @@ era:opName rdf:type owl:DatatypeProperty ,
            rdfs:domain era:OperationalPoint ;
            rdfs:range xsd:string ;
            era:XMLName "OPName" ;
-           era:appendixD2Index "2.3.1" ;
            era:rinfIndex "1.2.0.0.0.1" ;
+           era:tsiOPEappendixD2Index "2.3.1" ;
            dcterms:created "2021-09-13"^^xsd:date ;
            dcterms:modified "2021-09-13"^^xsd:date ;
            dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -8626,7 +8700,6 @@ era:organisationCode rdf:type owl:DatatypeProperty ;
                                  "OPTrackTunnelIMCode" ,
                                  "SOLIMCode" ,
                                  "SOLTunnelIMCode" ;
-                     era:appendixD2Index 1.1 ;
                      era:rinfIndex "1.1.0.0.0.1" ,
                                    "1.1.1.1.8.1" ,
                                    "1.2.1.0.0.1" ,
@@ -8634,6 +8707,7 @@ era:organisationCode rdf:type owl:DatatypeProperty ;
                                    "1.2.1.0.6.1" ,
                                    "1.2.2.0.0.1" ,
                                    "1.2.2.0.5.1" ;
+                     era:tsiOPEappendixD2Index 1.1 ;
                      dcterms:created "2024-06-03"^^xsd:date ;
                      dcterms:description """The Code is a unique identifier for the Infrastructure Manager and it shall be verified on national level. 
 - If the IM is subject to TAF/TAP TSIs, it corresponds to the code used in TAF/TAP TSIs. 
@@ -8764,7 +8838,8 @@ era:permissiblePayload rdf:type owl:DatatypeProperty ;
 
 
 ###  http://data.europa.eu/949/permissionChargingElectricEnergyTractionStandstill
-era:permissionChargingElectricEnergyTractionStandstill rdf:type owl:DatatypeProperty ;
+era:permissionChargingElectricEnergyTractionStandstill rdf:type owl:DatatypeProperty ,
+                                                                owl:FunctionalProperty ;
                                                        rdfs:domain era:ContactLineSystem ;
                                                        rdfs:range xsd:boolean ;
                                                        era:rinfIndex "1.2.1.0.7.1" ;
@@ -8937,8 +9012,8 @@ era:platformId rdf:type owl:DatatypeProperty ,
                rdfs:domain era:PlatformEdge ;
                rdfs:range xsd:string ;
                era:XMLName "OPTrackPlatformIdentification" ;
-               era:appendixD2Index "2.3.5" ;
                era:rinfIndex "1.2.1.0.6.2" ;
+               era:tsiOPEappendixD2Index "2.3.5" ;
                dcterms:created "2021-09-13"^^xsd:date ;
                dcterms:modified "2023-03-14"^^xsd:date ;
                dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -8982,8 +9057,8 @@ era:primaryLocationCode rdf:type owl:DatatypeProperty ;
                         rdfs:domain era:PrimaryLocation ;
                         rdfs:range xsd:string ;
                         era:XMLName "OPTafTapCode" ;
-                        era:appendixD2Index "2.2.2" ;
                         era:rinfIndex "1.2.0.0.0.3" ;
+                        era:tsiOPEappendixD2Index "2.2.2" ;
                         dcterms:created "2024-06-03"^^xsd:date ;
                         dcterms:replaces era:tafTAPCode ;
                         rdfs:comment "Primary location code developed for information exchange in accordance with the TSIs relating to the telematics applications subsystem."@en ;
@@ -9090,9 +9165,9 @@ era:qNvsbtsmperm rdf:type owl:DatatypeProperty ;
                              ] ;
                  rdfs:range xsd:boolean ;
                  era:XMLName "CPE_QNVSBTSMPERM" ;
-                 era:appendixD3Index "1.5.12" ;
                  era:rinfIndex "1.1.1.3.2.16.12" ,
                                "1.2.1.1.1.16.12" ;
+                 era:tsiOPEappendixD3Index "1.5.12" ;
                  dcterms:created "2023-03-14"^^xsd:date ;
                  dcterms:modified "2024-04-18"^^xsd:date ;
                  dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -9130,9 +9205,9 @@ era:radioNetworkId rdf:type owl:DatatypeProperty ;
                                ] ;
                    rdfs:range xsd:string ;
                    era:XMLName "CRG_RadioNID" ;
-                   era:appendixD2Index "3.4.4" ;
                    era:rinfIndex "1.1.1.3.3.12" ,
                                  "1.2.1.1.2.13" ;
+                   era:tsiOPEappendixD2Index "3.4.4" ;
                    dcterms:created "2023-03-14"^^xsd:date ;
                    dcterms:modified "2024-04-18"^^xsd:date ;
                    dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
@@ -9179,8 +9254,8 @@ era:raisedPantographsDistance rdf:type owl:DatatypeProperty ;
                               rdfs:domain era:RaisedPantographsDistanceAndSpeed ;
                               rdfs:range xsd:integer ;
                               era:XMLName "EPA_NumRaisedSpeed" ;
-                              era:appendixD2Index "3.3.4" ;
                               era:rinfIndex "1.1.1.2.3.3" ;
+                              era:tsiOPEappendixD2Index "3.3.4" ;
                               era:unitOfMeasure unit:M ;
                               era:usedInRCCCalculations "true"^^xsd:boolean ;
                               dcterms:created "2023-04-05"^^xsd:date ;
@@ -9199,8 +9274,8 @@ spacing centre line to centre line of adjacent pantograph heads, expressed in me
 era:raisedPantographsDistanceAndSpeed rdf:type owl:DatatypeProperty ;
                                       rdfs:range xsd:string ;
                                       era:XMLName "EPA_NumRaisedSpeed" ;
-                                      era:appendixD2Index "3.3.4" ;
                                       era:rinfIndex "1.1.1.2.3.3" ;
+                                      era:tsiOPEappendixD2Index "3.3.4" ;
                                       dcterms:created "2020-08-25"^^xsd:date ;
                                       dcterms:modified "2023-04-05"^^xsd:date ;
                                       dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -9219,8 +9294,8 @@ era:raisedPantographsNumber rdf:type owl:DatatypeProperty ;
                             rdfs:domain era:RaisedPantographsDistanceAndSpeed ;
                             rdfs:range xsd:integer ;
                             era:XMLName "EPA_NumRaisedSpeed" ;
-                            era:appendixD2Index "3.3.4" ;
                             era:rinfIndex "1.1.1.2.3.3" ;
+                            era:tsiOPEappendixD2Index "3.3.4" ;
                             era:usedInRCCCalculations "true"^^xsd:boolean ;
                             dcterms:created "2023-04-05"^^xsd:date ;
                             dcterms:modified "2024-09-19"^^xsd:date ;
@@ -9241,8 +9316,8 @@ era:raisedPantographsSpeed rdf:type owl:DatatypeProperty ;
                            rdfs:domain era:RaisedPantographsDistanceAndSpeed ;
                            rdfs:range xsd:integer ;
                            era:XMLName "EPA_NumRaisedSpeed" ;
-                           era:appendixD2Index "3.3.4" ;
                            era:rinfIndex "1.1.1.2.3.3" ;
+                           era:tsiOPEappendixD2Index "3.3.4" ;
                            era:unitOfMeasure <https://qudt.org/vocab/unit/KiloM-PER-HR> ;
                            era:usedInRCCCalculations "true"^^xsd:boolean ;
                            dcterms:created "2023-04-05"^^xsd:date ;
@@ -9265,9 +9340,9 @@ era:rbcID rdf:type owl:DatatypeProperty ;
           rdfs:domain era:RadioBlockCenter ;
           rdfs:range xsd:string ;
           era:XMLName "CPE_IDRBC" ;
-          era:appendixD2Index "3.4.7" ;
           era:rinfIndex "1.1.1.3.2.17" ,
                         "1.2.1.1.1.17" ;
+          era:tsiOPEappendixD2Index "3.4.7" ;
           dcterms:created "2024-04-18"^^xsd:date ;
           dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
           rdfs:comment """Unique RBC identification (NID_C+NID_RBC) as defined in the specification referenced in TSI CCS.
@@ -9286,9 +9361,9 @@ era:rbcPhone rdf:type owl:DatatypeProperty ;
              rdfs:domain era:RadioBlockCenter ;
              rdfs:range xsd:string ;
              era:XMLName "CPE_PHONERBC" ;
-             era:appendixD2Index "3.4.7" ;
              era:rinfIndex "1.1.1.3.2.17" ,
                            "1.2.1.1.1.17" ;
+             era:tsiOPEappendixD2Index "3.4.7" ;
              dcterms:created "2024-04-18"^^xsd:date ;
              dcterms:source <http://data.europa.eu/eli/reg_impl/2023/1695/oj> ;
              rdfs:comment """Unique RBC calling number (NID_RADIO) as defined in the specification referenced in TSI CCS.
@@ -9349,10 +9424,10 @@ era:relativeDistanceDangerPoint rdf:type owl:DatatypeProperty ;
                                 rdfs:subPropertyOf era:signalDataParameter ;
                                 rdfs:domain era:Signal ;
                                 rdfs:range xsd:integer ;
-                                era:appendixD2Index "2.2.3" ,
-                                                    "2.3.3" ;
                                 era:rinfIndex "1.1.1.3.14.4" ,
                                               "1.2.1.0.8.4" ;
+                                era:tsiOPEappendixD2Index "2.2.3" ,
+                                                          "2.3.3" ;
                                 era:unitOfMeasure <https://qudt.org/vocab/unit/M> ;
                                 dcterms:created "2023-03-14"^^xsd:date ;
                                 dcterms:modified "2024-04-18"^^xsd:date ;
@@ -9380,8 +9455,8 @@ era:requiredSandingOverride rdf:type owl:DatatypeProperty ;
                             rdfs:domain era:TrainDetectionSystem ;
                             rdfs:range xsd:boolean ;
                             era:XMLName "CTD_SandDriverOverride" ;
-                            era:appendixD2Index "3.2.6" ;
                             era:rinfIndex "1.1.1.3.7.18" ;
+                            era:tsiOPEappendixD2Index "3.2.6" ;
                             dcterms:created "2021-08-08"^^xsd:date ;
                             dcterms:modified "2023-03-14"^^xsd:date ;
                             dcterms:source <https://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -9434,9 +9509,9 @@ era:sidingId rdf:type owl:DatatypeProperty ;
              rdfs:domain era:Siding ;
              rdfs:range xsd:string ;
              era:XMLName "OPSidingIdentification" ;
-             era:appendixD2Index "2.2.1" ,
-                                 "2.2.1.4" ;
              era:rinfIndex "1.2.2.0.0.2" ;
+             era:tsiOPEappendixD2Index "2.2.1" ,
+                                       "2.2.1.4" ;
              dcterms:created "2021-09-13"^^xsd:date ;
              dcterms:modified "2023-03-14"^^xsd:date ;
              dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -9462,10 +9537,10 @@ era:signalId rdf:type owl:DatatypeProperty ;
              rdf:type owl:FunctionalProperty ;
              rdfs:domain era:Signal ;
              rdfs:range xsd:string ;
-             era:appendixD2Index "2.2.3" ,
-                                 "2.3.3" ;
              era:rinfIndex "1.1.1.3.14.1" ,
                            "1.2.1.0.8.1" ;
+             era:tsiOPEappendixD2Index "2.2.3" ,
+                                       "2.3.3" ;
              dcterms:created "2023-03-14"^^xsd:date ;
              dcterms:modified "2024-04-18"^^xsd:date ;
              rdfs:comment "Operational identifier of the signal (on the track or in OP), as in the operational and maintenance provisions."@en ;
@@ -9675,8 +9750,8 @@ era:switchProtectControlWarning rdf:type owl:DatatypeProperty ;
                                             ] ;
                                 rdfs:range xsd:boolean ;
                                 era:XMLName "CTS_SwitchProtectControlWarn" ;
-                                era:appendixD2Index "3.4.2" ;
                                 era:rinfIndex "1.1.1.3.8.1" ;
+                                era:tsiOPEappendixD2Index "3.4.2" ;
                                 dcterms:created "2021-08-09"^^xsd:date ;
                                 rdfs:comment "Indication whether a switch over between different systems whilst running exists."@en ;
                                 rdfs:isDefinedBy <http://data.europa.eu/949/> ;
@@ -9696,8 +9771,8 @@ era:switchRadioSystem rdf:type owl:DatatypeProperty ;
                                   ] ;
                       rdfs:range xsd:boolean ;
                       era:XMLName "CTS_SwitchRadioSystem" ;
-                      era:appendixD2Index "3.4.4" ;
                       era:rinfIndex "1.1.1.3.8.2" ;
+                      era:tsiOPEappendixD2Index "3.4.4" ;
                       dcterms:created "2021-08-09"^^xsd:date ;
                       dcterms:modified "2021-09-12"^^xsd:date ;
                       rdfs:comment "Indication whether a switch over between different radio systems and no communication system whilst running exists."@en ;
@@ -9827,9 +9902,9 @@ era:tNvcontact rdf:type owl:DatatypeProperty ;
                            ] ;
                rdfs:range xsd:integer ;
                era:XMLName "CPE_TNVCONTACT" ;
-               era:appendixD3Index "1.5.8" ;
                era:rinfIndex "1.1.1.3.2.16.8" ,
                              "1.2.1.1.1.16.8" ;
+               era:tsiOPEappendixD3Index "1.5.8" ;
                era:unitOfMeasure unit:SEC ;
                dcterms:created "2022-11-07"^^xsd:date ;
                dcterms:modified "2023-03-14"^^xsd:date ,
@@ -9858,9 +9933,9 @@ era:tNvovtrp rdf:type owl:DatatypeProperty ;
                          ] ;
              rdfs:range xsd:integer ;
              era:XMLName "CPE_TNVOVTRP" ;
-             era:appendixD3Index "1.5.6" ;
              era:rinfIndex "1.1.1.3.2.16.6" ,
                            "1.2.1.1.1.16.6" ;
+             era:tsiOPEappendixD3Index "1.5.6" ;
              era:unitOfMeasure unit:SEC ;
              dcterms:created "2022-11-07"^^xsd:date ;
              dcterms:modified "2023-03-14"^^xsd:date ,
@@ -9884,8 +9959,8 @@ era:tafTAPCode rdf:type owl:DatatypeProperty ;
                rdfs:domain era:OperationalPoint ;
                rdfs:range xsd:string ;
                era:XMLName "OPTafTapCode" ;
-               era:appendixD2Index "2.2.2" ;
                era:rinfIndex "1.2.0.0.0.3" ;
+               era:tsiOPEappendixD2Index "2.2.2" ;
                dcterms:created "2020-07-29"^^xsd:date ;
                dcterms:isReplacedBy era:primaryLocationCode ;
                dcterms:modified "2024-01-08"^^xsd:date ,
@@ -10026,9 +10101,9 @@ era:trackId rdf:type owl:DatatypeProperty ;
             rdfs:range xsd:string ;
             era:XMLName "OPTrackIdentification" ,
                         "SOLTrackIdentification" ;
-            era:appendixD2Index "2.2.1.1" ;
             era:rinfIndex "1.1.1.0.0.1" ,
                           "1.2.1.0.0.2" ;
+            era:tsiOPEappendixD2Index "2.2.1.1" ;
             dcterms:created "2021-09-09"^^xsd:date ;
             dcterms:description "Each track shall have unique identification or number within the SoL. This number cannot be used for naming any other track in the same SoL."@en ;
             dcterms:modified "2024-01-08"^^xsd:date ,
@@ -10096,9 +10171,9 @@ era:trainIntegrityOnBoardRequired rdf:type owl:DatatypeProperty ;
                                                          ]
                                              ] ;
                                   era:XMLName "CPE_IntegrityConfirmation" ;
-                                  era:appendixD2Index "3.4.11" ;
                                   era:rinfIndex "1.1.1.3.2.8" ,
                                                 "1.2.1.1.1.8" ;
+                                  era:tsiOPEappendixD2Index "3.4.11" ;
                                   era:usedInRCCCalculations "true"^^xsd:boolean ;
                                   dcterms:created "2020-08-31"^^xsd:date ;
                                   dcterms:modified "2021-09-12"^^xsd:date ,
@@ -10261,10 +10336,10 @@ era:tunnelIdentification rdf:type owl:DatatypeProperty ;
                          era:XMLName "OPSidingTunnelIdentification" ,
                                      "OPTrackTunnelIdentification" ,
                                      "SOLTunnelIdentification" ;
-                         era:appendixD2Index "3.2.3" ;
                          era:rinfIndex "1.1.1.1.8.2" ,
                                        "1.2.1.0.5.2" ,
                                        "1.2.2.0.5.2" ;
+                         era:tsiOPEappendixD2Index "3.2.3" ;
                          dcterms:created "2021-08-03"^^xsd:date ;
                          dcterms:modified "2021-09-13"^^xsd:date ,
                                           "2024-09-19"^^xsd:date ;
@@ -10328,6 +10403,7 @@ era:typeVersionNumber rdf:type owl:DatatypeProperty ;
 ###  http://data.europa.eu/949/umax2
 era:umax2 rdf:type owl:DatatypeProperty ;
           rdfs:subPropertyOf era:contactLineSystemDataParameter ;
+          rdf:type owl:FunctionalProperty ;
           rdfs:domain era:ContactLineSystem ;
           rdfs:range xsd:integer ;
           era:XMLName "ECS_Umax2" ;
@@ -10349,8 +10425,8 @@ era:uopid rdf:type owl:DatatypeProperty ;
           rdfs:domain era:OperationalPoint ;
           rdfs:range xsd:string ;
           era:XMLName "UniqueOPID" ;
-          era:appendixD2Index "2.2.2" ;
           era:rinfIndex "1.2.0.0.0.2" ;
+          era:tsiOPEappendixD2Index "2.2.2" ;
           dcterms:created "2020-07-29"^^xsd:date ;
           dcterms:modified "2024-01-08"^^xsd:date ,
                            "2024-09-19"^^xsd:date ;
@@ -10398,9 +10474,9 @@ era:vNvallowovtrp rdf:type owl:DatatypeProperty ;
                               ] ;
                   rdfs:range xsd:integer ;
                   era:XMLName "CPE_VNVALLOWOVTRP" ;
-                  era:appendixD3Index "1.5.3" ;
                   era:rinfIndex "1.1.1.3.2.16.3" ,
                                 "1.2.1.1.1.16.3" ;
+                  era:tsiOPEappendixD3Index "1.5.3" ;
                   era:unitOfMeasure unit:KiloM-PER-HR ;
                   dcterms:created "2022-11-07"^^xsd:date ;
                   dcterms:modified "2023-03-14"^^xsd:date ,
@@ -10429,9 +10505,9 @@ era:vNvsupovtrp rdf:type owl:DatatypeProperty ;
                             ] ;
                 rdfs:range xsd:integer ;
                 era:XMLName "CPE_VNVSUPOVTRP" ;
-                era:appendixD3Index "1.5.4" ;
                 era:rinfIndex "1.1.1.3.2.16.4" ,
                               "1.2.1.1.1.16.4" ;
+                era:tsiOPEappendixD3Index "1.5.4" ;
                 era:unitOfMeasure unit:KiloM-PER-HR ;
                 dcterms:created "2022-11-07"^^xsd:date ;
                 dcterms:modified "2023-03-14"^^xsd:date ,
@@ -10779,15 +10855,15 @@ geo:asWKT rdf:type owl:DatatypeProperty ;
           rdfs:domain geo:Geometry ;
           rdfs:range geo:wktLiteral ;
           era:XMLName "OPGeographicLocation" ;
-          era:appendixD2Index "2.1.1" ,
-                              "2.1.2" ,
-                              "2.2.2" ,
-                              "3.2.5" ;
           era:rinfIndex "1.1.0.0.1.1" ,
                         "1.1.1.0.1.1" ,
-                        "1.1.1.3.14.5" ,
+                        "1.1.1.3.14.6" ,
                         "1.2.0.0.0.5" ,
                         "1.2.1.0.8.5" ;
+          era:tsiOPEappendixD2Index "2.1.1" ,
+                                    "2.1.2" ,
+                                    "2.2.2" ,
+                                    "3.2.5" ;
           dcterms:contributor "Matthew Perry" ;
           dcterms:creator "OGC GeoSPARQL 1.0 Standard Working Group" ;
           dcterms:date "2011-06-16"^^xsd:date ;
@@ -11218,8 +11294,8 @@ A line is a sequence of one or mores sections of line, which connects operationa
 ###  http://data.europa.eu/949/OperationalPoint
 era:OperationalPoint rdf:type owl:Class ;
                      rdfs:subClassOf era:AggregatedElement ;
-                     era:appendixD2Index "2.1.2" ;
                      era:rinfIndex 1.2 ;
+                     era:tsiOPEappendixD2Index "2.1.2" ;
                      dcterms:created "2020-07-29"^^xsd:date ;
                      dcterms:modified "2022-07-07"^^xsd:date ;
                      rdfs:comment "An operational point (OP) means any location for train service operations, where train services may begin and end or change route, and where passenger or freight services may be provided; operational point also means any location at boundaries between Member States or infrastructure managers."@en ;
@@ -11366,8 +11442,8 @@ era:SectionOfLine rdf:type owl:Class ;
                                     owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                     owl:onClass era:OperationalPoint
                                   ] ;
-                  era:appendixD2Index "2.1.1" ;
                   era:rinfIndex "1.1" ;
+                  era:tsiOPEappendixD2Index "2.1.1" ;
                   dcterms:created "2021-04-02"^^xsd:date ;
                   dcterms:description "Each network shall be described using as many SoLs as necessary. Each SoL   is generated and identified by OP IDs at start and at end. A SoL only belongs to one Line."@en ;
                   dcterms:modified "2022-07-07"^^xsd:date ,
@@ -11432,8 +11508,8 @@ The switches' position in a SignalsGrid are controlled together by the interlock
 ###  http://data.europa.eu/949/SpecialArea
 era:SpecialArea rdf:type owl:Class ;
                 rdfs:subClassOf era:InfrastructureElement ;
-                era:appendixD2Index "3.2.4" ,
-                                    "3.2.5" ;
+                era:tsiOPEappendixD2Index "3.2.4" ,
+                                          "3.2.5" ;
                 dcterms:created "2022-10-27"^^xsd:date ,
                                 "2024-04-18"^^xsd:date ;
                 dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
@@ -11453,7 +11529,7 @@ Industrial Risk Area: locations where it is dangerous for the driver to step out
 ###  http://data.europa.eu/949/SpecialTunnelArea
 era:SpecialTunnelArea rdf:type owl:Class ;
                       rdfs:subClassOf era:SpecialArea ;
-                      era:appendixD2Index "3.2.3" ;
+                      era:tsiOPEappendixD2Index "3.2.3" ;
                       dcterms:created "2022-10-27"^^xsd:date ;
                       dcterms:source <http://data.europa.eu/eli/reg_impl/2019/773/oj> ;
                       rdfs:comment """TODO review: Area or location within a tunnel where there are 
@@ -11530,6 +11606,7 @@ era:TopologicalObject rdf:type owl:Class ;
 era:Track rdf:type owl:Class ;
           rdfs:subClassOf era:BasicElement ;
           dcterms:created "2024-11-20"^^xsd:date ;
+          rdfs:comment "In Railway, it is a pair of rails over which rail borne vehicles can run."@en ;
           rdfs:isDefinedBy <http://data.europa.eu/949/> ;
           rdfs:label "Track" .
 
@@ -11946,9 +12023,54 @@ foaf:Person rdf:type owl:Class ;
             vs:term_status "stable" .
 
 
-[ foaf:name "Maarten Duhoux" ;
+[ foaf:name "Ghislain Atemezing" ;
+  dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
 ] .
+
+[ foaf:name "Designated RINF Topical Working Groups"@en
+ ] .
+
+[ foaf:name "Edna Ruckhaus" ;
+   org:memberOf <https://www.upm.es/>
+ ] .
+
+[ foaf:name "Polymnia Vasilopoulou" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Oscar Corcho" ;
+   org:memberOf <https://www.upm.es/>
+ ] .
+
+[ foaf:name "Dragos Patru" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Marina Aguado" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Maarten Duhoux" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Dragos Patru" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Ghislain Atemezing" ;
+   dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Dragos Patru" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Maarten Duhoux" ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
 
 [ foaf:name "Marina Aguado" ;
    org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
@@ -11970,21 +12092,17 @@ foaf:Person rdf:type owl:Class ;
    org:memberOf <https://www.upm.es/>
  ] .
 
+[ foaf:name "Ghislain Atemezing" ;
+   dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
+[ foaf:name "Ghislain Atemezing" ;
+   dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
+   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
+ ] .
+
 [ foaf:name "Designated RINF Topical Working Groups"@en
- ] .
-
-[ foaf:name "Ghislain Atemezing" ;
-   dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Ghislain Atemezing" ;
-   dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Dragos Patru" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
  ] .
 
 #################################################################
@@ -11992,17 +12110,17 @@ foaf:Person rdf:type owl:Class ;
 #################################################################
 
 era:endLocation skos:scopeNote "Parameters of this group (from 1.1.1.1.8.1 to 1.1.1.1.8.13) are only applicable if tunnels exist on the SoL"@en ;
-                 dcterms:modified "2024-09-19"^^xsd:date ;
                  vs:term_status "stable" ;
+                 dcterms:modified "2024-09-19"^^xsd:date ;
                  rdfs:isDefinedBy <http://data.europa.eu/949/> ;
                  rdfs:comment "Geographical coordinates in decimal degrees and km of the line at the end of a tunnel"@en ;
                  dcterms:modified "2024-02-05"^^xsd:date ;
                  skos:example "Latitude=`51.5479123` Longitude=`-0.076732`" ;
-                 era:rinfIndex "1.1.1.1.8.4" ;
                  dcterms:description """Part of the End of tunnel that indicates the Geographical coordinates according to the standard World Geodetic System (WGS). 
 Precision for both geographical latitude and geographical longitude is assumed as [NN.NNNNNNN] in degrees with decimals what gives discretion of 10 m cm in the network.
 
 The End of tunnel is the Geographical coordinates in decimal degrees and km of the line at the end of a tunnel."""@en ;
+                 era:rinfIndex "1.1.1.1.8.4" ;
                  era:XMLName "SOLTunnelEnd" ;
                  rdfs:label "End of tunnel location"@en ;
                  dcterms:created "2020-07-29"^^xsd:date .
@@ -12010,8 +12128,8 @@ The End of tunnel is the Geographical coordinates in decimal degrees and km of t
 
 era:startLocation era:rinfIndex "1.1.1.1.8.3" ;
                   dcterms:created "2020-07-29"^^xsd:date ;
-                  vs:term_status "stable" ;
                   rdfs:isDefinedBy <http://data.europa.eu/949/> ;
+                  vs:term_status "stable" ;
                   rdfs:label "Start of tunnel location"@en ;
                   era:XMLName "SOLTunnelStart" ;
                   rdfs:comment """Part of the Start of tunnel that indicates the Geographical coordinates according to the standard World Geodetic System (WGS). Precision for both geographical latitude and geographical longitude is assumed as [NN.NNNNNNN] in degrees with decimals what gives discretion of 10 cm in the network.


### PR DESCRIPTION
- Added definitions to object properties that denote relationships among classes
- Fixes in hierarchies of CCS, Energy and Infra subsystems
- Added CommonCharacteristicsSubset to domain of parameterApplicability
- Added functional property axiom to some properties with domain TrainDetectionSystem and ContactLineSystem
- Added porperty borderPointId to the class ReferenceBorderPoint
- Fix RINF index 1.1.1.3.14.5 to 1.1.1.3.14.6 for location
- Added definition to class Track
- Renamed the annotation properties era:appendixD2Index and era:appendixD3Index to the corresponding era:tsiOPEappendixD2Index and era:tsiOPEappendixD3Index. Created  annotation properties era:tsiOPEappendixD1Index