### PR TITLE
updates metadata and removed duplicate authors

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -68,7 +68,8 @@
                                                "2024-11-26"^^xsd:date ,
                                                "2024-11-27"^^xsd:date ,
                                                "2024-12-02"^^xsd:date ,
-                                               "2024-12-03"^^xsd:date ;
+                                               "2024-12-03"^^xsd:date ,
+                                               "2024-12-05"^^xsd:date ;
                               dcterms:publisher "European Union Agency for Railways" ;
                               dcterms:title "ERA Ontology"@en ;
                               rdfs:comment """This is the human and machine readable Ontology governed by the European Union Agency for Railways (https://www.era.europa.eu/). It represents the concepts and relationships linked to the sectorial legal framework and the use cases under the AgencyÂ´s remit, as described in the Commission Implementing Regulation (EU) [to be updated after publication] on the common specifications for the register of railway infrastructure [to be updated after publication].
@@ -83,7 +84,12 @@ The Ontology also includes the routebook concepts described in appendix D2 \"Ele
                               owl:priorVersion "https://github.com/Interoperable-data/ERA_vocabulary/releases/v3.0.0"^^xsd:anyURI ;
                               owl:versionInfo "v3.1.0" ;
                               owl:versionURI <https://github.com/Interoperable-data/ERA_vocabulary/releases/releases/v3.1.0> ;
-                              skos:changeNote """Revision 03-12-2024
+                              skos:changeNote """
+Revision 05-12-2024:
+ - Added restricted ranges for the dataproperties era:dNvovtrp, era:dNvpotrp, era:dNvroll, era:tNvcontact, era:tNvovtrp, 
+era:vNvallowovtrp and era:vNvsupovtrp. This partially solves issue #135 for our needs. 
+
+Revision 03-12-2024:
 - Fixed domain kmPostName to KilometricPost or LinearPositioningSystem
 - Deleted RINF index for \"parts\" of compund properties: PhaseInfo, RaisedPantographsDistanceAndSpeed, SystemSeparationInfo, MinVehicleImpedance, frenchTrainDetectionSystemLimitationApplicable, LoadCapability, MaximumMagneticField.
 - Completed some missing property and classes definitions.
@@ -13779,65 +13785,7 @@ foaf:Person rdf:type owl:Class ;
             vs:term_status "stable" .
 
 
-[ foaf:name "Marina Aguado" ;
-  org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
-] .
 
-[ foaf:name "Polymnia Vasilopoulou" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Polymnia Vasilopoulou" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Maarten Duhoux" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Maarten Duhoux" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Dragos Patru" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Ghislain Atemezing" ;
-   dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Dragos Patru" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Ghislain Atemezing" ;
-   dcterms:source <https://orcid.org/0000-0003-1562-6922> ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Marina Aguado" ;
-   org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/ERA>
- ] .
-
-[ foaf:name "Edna Ruckhaus"
- ] .
-
-[ foaf:name "Designated RINF Topical Working Groups"@en
- ] .
-
-[ foaf:name "Designated RINF Topical Working Groups"@en
- ] .
-
-[ foaf:name "Oscar Corcho"
- ] .
-
-[ foaf:name "Edna Ruckhaus"
- ] .
-
-[ foaf:name "Oscar Corcho"
- ] .
 
 #################################################################
 #    Annotations


### PR DESCRIPTION
Revision 05-12-2024:
 - Added restricted ranges for the dataproperties era:dNvovtrp, era:dNvpotrp, era:dNvroll, era:tNvcontact, era:tNvovtrp, 
era:vNvallowovtrp and era:vNvsupovtrp. This partially solves issue #135 for our needs. 
