### PR TITLE
Updated era-skos-NominalTrackGauges.ttl

### DIFF
--- a/era-skos/era-skos-NominalTrackGauges.ttl
+++ b/era-skos/era-skos-NominalTrackGauges.ttl
@@ -23,11 +23,19 @@
 
 era-ntg:NominalTrackGauges a skos:ConceptScheme ; 
     dct:issued "2020-09-01"^^xsd:date ;
-    dct:modified "2022-09-09"^^xsd:date ;
+    dct:modified "2022-09-09"^^xsd:date , "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     rdfs:label "Nominal Track Gauges"@en ;
+    era:unitOfMeasure <http://qudt.org/vocab/unit/MilliM> ;
+    era:rinfIndex "1.1.1.1.4.1"; 
     skos:prefLabel "Nominal Track Gauges"@en ;
+    skos:changeNote """ 
+    Revision 10-12-2024: 
+ - removed "other" from the list of SKOS
+ - removed eratv concepts and merged with altLabels in RINF concepts
+ - added unit of measure annotations
+  """@en ;
     dct:title "Concept scheme grouping nominal track gauges"@en .
 
 
@@ -43,64 +51,44 @@ era-ntg:NominalTrackGauges a skos:ConceptScheme ;
 ########## Nominal track gauges ##########
 # RINF values #
 era-ntg-rinf:20 a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the RINF database";
-  skos:prefLabel "1000" .
+  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
+  skos:prefLabel "1000"@en  ;
+  skos:altLabel "1000mm"@en ;
+  skos:notation "1000"^^xsd:string .
 
 era-ntg-rinf:30 a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the RINF database";
-  skos:prefLabel "1435" .
+  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
+  skos:prefLabel "1435"@en ;
+  skos:notation "1435"^^xsd:string ;
+  skos:altLabel "1435mm"@en .
 
 era-ntg-rinf:40 a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the RINF database";
-  skos:prefLabel "1520" .
+  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges;
+  skos:prefLabel "1520"@en ;
+  skos:altLabel "1520mm"@en ;
+  skos:notation  "1520"^^xsd:string.
 
 era-ntg-rinf:50 a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the RINF database";
-  skos:prefLabel "1524" .
+  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
+  skos:prefLabel "1524"@en ;
+  skos:altLabel "1524mm"@en ;
+  skos:notation "1524"^^xsd:string .
 
 era-ntg-rinf:60 a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the RINF database";
-  skos:prefLabel "1600" .
+  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
+  skos:prefLabel "1600"@en ;
+  skos:altLabel "1600mm"@en ;
+  skos:notation "1600"^^xsd:string .
 
 era-ntg-rinf:70 a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the RINF database";
-  skos:prefLabel "1668" .
+  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges;
+  skos:prefLabel "1668"@en ;
+  skos:altLabel "1668mm"@en ;
+  skos:notation "1668"^^xsd:string .
 
 era-ntg-rinf:10 a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the RINF database";
-  skos:prefLabel "750" .
+  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
+  skos:prefLabel "750"@en ;
+  skos:altLabel "750"@en ;
+  skos:notation "750"^^xsd:string .
 
-era-ntg-rinf:80 a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the RINF database";
-  skos:prefLabel "other" .
-
-# ERATV values #
-era-ntg-eratv:1000mm a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the ERATV database";
-  skos:exactMatch era-ntg-rinf:20;
-  skos:prefLabel "1000mm" .
-
-era-ntg-eratv:1435mm a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the ERATV database";
-  skos:exactMatch era-ntg-rinf:30;
-  skos:prefLabel "1435mm" .
-
-era-ntg-eratv:1520mm a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the ERATV database";
-  skos:exactMatch era-ntg-rinf:40;
-  skos:prefLabel "1520mm" .
-
-era-ntg-eratv:1524mm a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the ERATV database";
-  skos:exactMatch era-ntg-rinf:50;
-  skos:prefLabel "1524mm" .
-
-era-ntg-eratv:1600mm a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the ERATV database";
-  skos:exactMatch era-ntg-rinf:60;
-  skos:prefLabel "1600mm" .
-
-era-ntg-eratv:1668mm a skos:Concept;
-  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; skos:note "Value retrieved from the ERATV database";
-  skos:exactMatch era-ntg-rinf:70;
-  skos:prefLabel "1668mm" .


### PR DESCRIPTION
 Revision 10-12-2024: 
 - removed "other" from the list of SKOS
 - removed eratv concepts and merged with altLabels in RINF concepts
 - added unit of measure annotations