### PR TITLE
updated skos values & added altLabel tag for CCSTMS 

### DIFF
--- a/era-skos/era-skos-ATOGradesAutomation.ttl
+++ b/era-skos/era-skos-ATOGradesAutomation.ttl
@@ -26,13 +26,20 @@
 
 era-ato-grades:ATOGradeOfAutomation a skos:ConceptScheme ; 
     dct:issued "2024-04-18"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2024-09-04"^^xsd:date ,
+				 "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.3.13.1"; 
     era:rinfIndex "1.2.1.1.10.1"; 
     rdfs:label "ATO Grade of Automation"@en ;
     skos:prefLabel "ATO Grade of Automation"@en ;
+	skos:altLabel "CCSTMS_GradeOfAutomation" ;
+	skos:changeNote """ 
+    Revision 12-12-2024: 
+	- add values for GradeOfAutomation (GoA3 and GoA4)
+	- add GoAunknown and CCSTMS altLabel tags
+  """@en ;
     skos:title "Concept scheme for ATO Grade of Automation"@en .
 
 
@@ -56,11 +63,30 @@ era-ato-grades:1 a skos:Concept;
   skos:inScheme era-ato-grades:ATOGradeOfAutomation; skos:note "Value introduced in TWG RINF 2024"@en;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
   skos:notation "1"^^xsd:string ;
-  skos:prefLabel "1"@en .
+  skos:prefLabel "1"@en ;
+  skos:altLabel "CCSTMS_GoA1_1" .
 
 era-ato-grades:2 a skos:Concept;
   skos:inScheme era-ato-grades:ATOGradeOfAutomation; skos:note "Value introduced in TWG RINF 2024"@en;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
   skos:notation "2"^^xsd:string ;
-  skos:prefLabel "2"@en .
+  skos:prefLabel "2"@en ;
+  skos:altLabel "CCSTMS_GoA2_2" .
+  
+era-ato-grades:3 a skos:Concept; 
+  skos:inScheme era-ato-grades:ATOGradeOfAutomation;
+  skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
+  skos:prefLabel "3"@en ;
+  skos:altLabel "CCSTMS_GoA3_3" .
 
+era-ato-grades:4 a skos:Concept; 
+  skos:inScheme era-ato-grades:ATOGradeOfAutomation;
+  skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
+  skos:prefLabel "4"@en ;
+  skos:altLabel "CCSTMS_GoA4_4" .
+  
+era-ato-grades:unknown a skos:Concept; 
+  skos:inScheme era-ato-grades:ATOGradeOfAutomation;
+  skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
+  skos:prefLabel "Unknown"@en ;
+  skos:altLabel "CCSTMS_GoAUnknown_0" .

--- a/era-skos/era-skos-ATOGradesAutomation.ttl
+++ b/era-skos/era-skos-ATOGradesAutomation.ttl
@@ -76,17 +76,20 @@ era-ato-grades:2 a skos:Concept;
 era-ato-grades:3 a skos:Concept; 
   skos:inScheme era-ato-grades:ATOGradeOfAutomation;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
+  skos:notation "3"^^xsd:string
   skos:prefLabel "3"@en ;
   skos:hiddenLabel "CCSTMS_GoA3_3" .
 
 era-ato-grades:4 a skos:Concept; 
   skos:inScheme era-ato-grades:ATOGradeOfAutomation;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
+  skos:notation "4"^^xsd:string
   skos:prefLabel "4"@en ;
   skos:hiddenLabel "CCSTMS_GoA4_4" .
   
 era-ato-grades:unknown a skos:Concept; 
   skos:inScheme era-ato-grades:ATOGradeOfAutomation;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
+  skos:notation "Unknown"^^xsd:string
   skos:prefLabel "Unknown"@en ;
   skos:hiddenLabel "CCSTMS_GoAUnknown_0" .

--- a/era-skos/era-skos-ATOGradesAutomation.ttl
+++ b/era-skos/era-skos-ATOGradesAutomation.ttl
@@ -34,7 +34,7 @@ era-ato-grades:ATOGradeOfAutomation a skos:ConceptScheme ;
     era:rinfIndex "1.2.1.1.10.1"; 
     rdfs:label "ATO Grade of Automation"@en ;
     skos:prefLabel "ATO Grade of Automation"@en ;
-	skos:altLabel "CCSTMS_GradeOfAutomation" ;
+	skos:hiddenLabel "CCSTMS_GradeOfAutomation" ;
 	skos:changeNote """ 
     Revision 12-12-2024: 
 	- add values for GradeOfAutomation (GoA3 and GoA4)
@@ -64,29 +64,29 @@ era-ato-grades:1 a skos:Concept;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
   skos:notation "1"^^xsd:string ;
   skos:prefLabel "1"@en ;
-  skos:altLabel "CCSTMS_GoA1_1" .
+  skos:hiddenLabel "CCSTMS_GoA1_1" .
 
 era-ato-grades:2 a skos:Concept;
   skos:inScheme era-ato-grades:ATOGradeOfAutomation; skos:note "Value introduced in TWG RINF 2024"@en;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
   skos:notation "2"^^xsd:string ;
   skos:prefLabel "2"@en ;
-  skos:altLabel "CCSTMS_GoA2_2" .
+  skos:hiddenLabel "CCSTMS_GoA2_2" .
   
 era-ato-grades:3 a skos:Concept; 
   skos:inScheme era-ato-grades:ATOGradeOfAutomation;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
   skos:prefLabel "3"@en ;
-  skos:altLabel "CCSTMS_GoA3_3" .
+  skos:hiddenLabel "CCSTMS_GoA3_3" .
 
 era-ato-grades:4 a skos:Concept; 
   skos:inScheme era-ato-grades:ATOGradeOfAutomation;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
   skos:prefLabel "4"@en ;
-  skos:altLabel "CCSTMS_GoA4_4" .
+  skos:hiddenLabel "CCSTMS_GoA4_4" .
   
 era-ato-grades:unknown a skos:Concept; 
   skos:inScheme era-ato-grades:ATOGradeOfAutomation;
   skos:topConceptOf era-ato-grades:ATOGradeOfAutomation ;
   skos:prefLabel "Unknown"@en ;
-  skos:altLabel "CCSTMS_GoAUnknown_0" .
+  skos:hiddenLabel "CCSTMS_GoAUnknown_0" .

--- a/era-skos/era-skos-CantDeficiencies.ttl
+++ b/era-skos/era-skos-CantDeficiencies.ttl
@@ -19,12 +19,14 @@
 
 era-cantdefs:CantDeficiencies a skos:ConceptScheme ; 
     dct:issued "2024-04-18"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2024-09-04"^^xsd:date ,
+				 "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.3.2.14"; 
     era:rinfIndex "1.2.1.1.1.14"; 
     era:unitOfMeasure <http://qudt.org/vocab/unit/MilliM> ;
+	skos:altLabel "CCSTMS_CantDeficiencyCategory" ;
     rdfs:label "Cant Deficiencies - Static Speed Profile Categories (Basic and Specific, type 1)"@en ;
     skos:prefLabel "Cant Deficiencies - Static Speed Profile Categories (Basic and Specific, type 1)"@en ;
     dct:title "Concept scheme grouping the “Cant Deficiency” SSP categories, defining the maximum speed, determined by suspension design, at which a particular train can traverse a curve and thus can be used to set a specific speed limit in a curve with regards to this category."@en .
@@ -45,54 +47,71 @@ era-cantdefs:80 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ;
 skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "80"^^xsd:string ;
+  skos:altLabel "CCSTMS_CD_80mm_1" ;
   skos:prefLabel "80"@en .
 
 era-cantdefs:100 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
   skos:notation "100"^^xsd:string  ;
+  skos:altLabel "CCSTMS_CD_100mm_2" ;
   skos:prefLabel "100"@en .
 
 era-cantdefs:130 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
   skos:notation "130"^^xsd:string  ;
+  skos:altLabel "CCSTMS_CD_130mm_3" ;
   skos:prefLabel "130"@en .
 
 era-cantdefs:150 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "150"^^xsd:string ;
+  skos:altLabel "CCSTMS_CD_150mm_4" ;
   skos:prefLabel "150"@en .
 
 era-cantdefs:165 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "165"^^xsd:string ;
+  skos:altLabel "CCSTMS_CD_165mm_5" ;
   skos:prefLabel "165"@en .
 
 era-cantdefs:180 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "180"^^xsd:string ;
+  skos:altLabel "CCSTMS_CD_180mm_6" ;
   skos:prefLabel "180"@en .
 
 era-cantdefs:210 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "210"^^xsd:string ;
+  skos:altLabel "CCSTMS_CD_210mm_7" ;
   skos:prefLabel "210"@en .
 
 era-cantdefs:225 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
   skos:notation "225"^^xsd:string ;
+  skos:altLabel "CCSTMS_CD_225mm_8" ;
   skos:prefLabel "225"@en .
 
 era-cantdefs:245 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "245"^^xsd:string ;  
+  skos:altLabel "CCSTMS_CD_245mm_9" ;
   skos:prefLabel "245"@en .
 
 era-cantdefs:275 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "275"^^xsd:string ;
+  skos:altLabel "CCSTMS_CD_275mm_10" ;
   skos:prefLabel "275"@en .
 
 era-cantdefs:300 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
   skos:notation "300"^^xsd:string ;
+  skos:altLabel "CCSTMS_CD_300mm_11" ;
   skos:prefLabel "300"@en .
+  
+era-cantdefs:undefined a skos:Concept;
+  skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
+  skos:notation "Undefined"^^xsd:string ;
+  skos:altLabel "CCSTMS_CD_Undefined_0" ;
+  skos:prefLabel "Undefined"@en .

--- a/era-skos/era-skos-CantDeficiencies.ttl
+++ b/era-skos/era-skos-CantDeficiencies.ttl
@@ -26,7 +26,7 @@ era-cantdefs:CantDeficiencies a skos:ConceptScheme ;
     era:rinfIndex "1.1.1.3.2.14"; 
     era:rinfIndex "1.2.1.1.1.14"; 
     era:unitOfMeasure <http://qudt.org/vocab/unit/MilliM> ;
-	skos:altLabel "CCSTMS_CantDeficiencyCategory" ;
+	skos:hiddenLabel "CCSTMS_CantDeficiencyCategory" ;
     rdfs:label "Cant Deficiencies - Static Speed Profile Categories (Basic and Specific, type 1)"@en ;
     skos:prefLabel "Cant Deficiencies - Static Speed Profile Categories (Basic and Specific, type 1)"@en ;
     dct:title "Concept scheme grouping the “Cant Deficiency” SSP categories, defining the maximum speed, determined by suspension design, at which a particular train can traverse a curve and thus can be used to set a specific speed limit in a curve with regards to this category."@en .
@@ -47,71 +47,71 @@ era-cantdefs:80 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ;
 skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "80"^^xsd:string ;
-  skos:altLabel "CCSTMS_CD_80mm_1" ;
+  skos:hiddenLabel "CCSTMS_CD_80mm_1" ;
   skos:prefLabel "80"@en .
 
 era-cantdefs:100 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
   skos:notation "100"^^xsd:string  ;
-  skos:altLabel "CCSTMS_CD_100mm_2" ;
+  skos:hiddenLabel "CCSTMS_CD_100mm_2" ;
   skos:prefLabel "100"@en .
 
 era-cantdefs:130 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
   skos:notation "130"^^xsd:string  ;
-  skos:altLabel "CCSTMS_CD_130mm_3" ;
+  skos:hiddenLabel "CCSTMS_CD_130mm_3" ;
   skos:prefLabel "130"@en .
 
 era-cantdefs:150 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "150"^^xsd:string ;
-  skos:altLabel "CCSTMS_CD_150mm_4" ;
+  skos:hiddenLabel "CCSTMS_CD_150mm_4" ;
   skos:prefLabel "150"@en .
 
 era-cantdefs:165 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "165"^^xsd:string ;
-  skos:altLabel "CCSTMS_CD_165mm_5" ;
+  skos:hiddenLabel "CCSTMS_CD_165mm_5" ;
   skos:prefLabel "165"@en .
 
 era-cantdefs:180 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "180"^^xsd:string ;
-  skos:altLabel "CCSTMS_CD_180mm_6" ;
+  skos:hiddenLabel "CCSTMS_CD_180mm_6" ;
   skos:prefLabel "180"@en .
 
 era-cantdefs:210 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "210"^^xsd:string ;
-  skos:altLabel "CCSTMS_CD_210mm_7" ;
+  skos:hiddenLabel "CCSTMS_CD_210mm_7" ;
   skos:prefLabel "210"@en .
 
 era-cantdefs:225 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
   skos:notation "225"^^xsd:string ;
-  skos:altLabel "CCSTMS_CD_225mm_8" ;
+  skos:hiddenLabel "CCSTMS_CD_225mm_8" ;
   skos:prefLabel "225"@en .
 
 era-cantdefs:245 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "245"^^xsd:string ;  
-  skos:altLabel "CCSTMS_CD_245mm_9" ;
+  skos:hiddenLabel "CCSTMS_CD_245mm_9" ;
   skos:prefLabel "245"@en .
 
 era-cantdefs:275 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;
   skos:notation "275"^^xsd:string ;
-  skos:altLabel "CCSTMS_CD_275mm_10" ;
+  skos:hiddenLabel "CCSTMS_CD_275mm_10" ;
   skos:prefLabel "275"@en .
 
 era-cantdefs:300 a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
   skos:notation "300"^^xsd:string ;
-  skos:altLabel "CCSTMS_CD_300mm_11" ;
+  skos:hiddenLabel "CCSTMS_CD_300mm_11" ;
   skos:prefLabel "300"@en .
   
 era-cantdefs:undefined a skos:Concept;
   skos:inScheme era-cantdefs:CantDeficiencies; skos:topConceptOf era-cantdefs:CantDeficiencies ; skos:note "Value (in mm) proposed by the CCS ERTMS WG"@en;  
   skos:notation "Undefined"^^xsd:string ;
-  skos:altLabel "CCSTMS_CD_Undefined_0" ;
+  skos:hiddenLabel "CCSTMS_CD_Undefined_0" ;
   skos:prefLabel "Undefined"@en .

--- a/era-skos/era-skos-ETCSLevels.ttl
+++ b/era-skos/era-skos-ETCSLevels.ttl
@@ -38,7 +38,7 @@ era-etcslevel:ETCSLevels a skos:ConceptScheme ;
     era:rinfIndex "1.2.1.1.1.1";
     rdfs:label "ETCS Levels"@en ;
     skos:prefLabel "ETCS Levels"@en ;
-	skos:altLabel "CCSTMS_EtcsLevel" ;
+	skos:hiddenLabel "CCSTMS_EtcsLevel" ;
     skos:title "Concept scheme grouping ETCS levels"@en .
 
 
@@ -55,26 +55,26 @@ era-etcslevel:ETCSLevels a skos:ConceptScheme ;
 era-etcslevel:50 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ;
   skos:notation "0"^^xsd:string ;
-  skos:altLabel "CCSTMS_Level0_0" ;
+  skos:hiddenLabel "CCSTMS_Level0_0" ;
   skos:prefLabel "0"@en .
 
 era-etcslevel:20 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ; 
   skos:notation "1"^^xsd:string ;
-  skos:altLabel "CCSTMS_Level1_2" ;
+  skos:hiddenLabel "CCSTMS_Level1_2" ;
   skos:prefLabel "1"@en .
 
 era-etcslevel:30 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ; 
   skos:notation "2"^^xsd:string ;
-  skos:altLabel "CCSTMS_Level2_3" ;
+  skos:hiddenLabel "CCSTMS_Level2_3" ;
   skos:prefLabel "2"@en .
 
 era-etcslevel:40 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ; 
   owl:deprecated "true"^^xsd:boolean ;
   skos:notation "3"^^xsd:string ;
-  skos:altLabel "CCSTMS_Level3_4" ;
+  skos:hiddenLabel "CCSTMS_Level3_4" ;
   skos:prefLabel "3"@en .
 
 era-etcslevel:10 a skos:Concept;
@@ -86,5 +86,5 @@ era-etcslevel:10 a skos:Concept;
 era-etcslevel:60 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ; 
   skos:notation "NTC"^^xsd:string ;
-  skos:altLabel "CCSTMS_LevelNTC_1" ;
+  skos:hiddenLabel "CCSTMS_LevelNTC_1" ;
   skos:prefLabel "NTC"@en .

--- a/era-skos/era-skos-ETCSLevels.ttl
+++ b/era-skos/era-skos-ETCSLevels.ttl
@@ -28,15 +28,17 @@
 
 era-etcslevel:ETCSLevels a skos:ConceptScheme ; 
     dct:issued "2020-09-01"^^xsd:date ;
-    dct:modified "2022-09-09"^^xsd:date ;
-    dct:modified "2024-04-18"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2022-09-09"^^xsd:date ,
+				 "2024-04-18"^^xsd:date ,
+				 "2024-09-04"^^xsd:date ,
+				 "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.3.2.1"; 
     era:rinfIndex "1.2.1.1.1.1";
     rdfs:label "ETCS Levels"@en ;
     skos:prefLabel "ETCS Levels"@en ;
+	skos:altLabel "CCSTMS_EtcsLevel" ;
     skos:title "Concept scheme grouping ETCS levels"@en .
 
 
@@ -53,22 +55,26 @@ era-etcslevel:ETCSLevels a skos:ConceptScheme ;
 era-etcslevel:50 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ;
   skos:notation "0"^^xsd:string ;
+  skos:altLabel "CCSTMS_Level0_0" ;
   skos:prefLabel "0"@en .
 
 era-etcslevel:20 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ; 
   skos:notation "1"^^xsd:string ;
+  skos:altLabel "CCSTMS_Level1_2" ;
   skos:prefLabel "1"@en .
 
 era-etcslevel:30 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ; 
   skos:notation "2"^^xsd:string ;
+  skos:altLabel "CCSTMS_Level2_3" ;
   skos:prefLabel "2"@en .
 
 era-etcslevel:40 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ; 
   owl:deprecated "true"^^xsd:boolean ;
   skos:notation "3"^^xsd:string ;
+  skos:altLabel "CCSTMS_Level3_4" ;
   skos:prefLabel "3"@en .
 
 era-etcslevel:10 a skos:Concept;
@@ -80,5 +86,5 @@ era-etcslevel:10 a skos:Concept;
 era-etcslevel:60 a skos:Concept;
   skos:inScheme era-etcslevel:ETCSLevels; skos:topConceptOf era-etcslevel:ETCSLevels ; 
   skos:notation "NTC"^^xsd:string ;
+  skos:altLabel "CCSTMS_LevelNTC_1" ;
   skos:prefLabel "NTC"@en .
-

--- a/era-skos/era-skos-ETCSMVersions.ttl
+++ b/era-skos/era-skos-ETCSMVersions.ttl
@@ -34,7 +34,7 @@ era-etcsmvers:ETCSMVersions a skos:ConceptScheme ;
     era:rinfIndex "1.1.1.3.2.10"; 
     era:rinfIndex "1.2.1.1.1.10"; 
     rdfs:label "ETCS M Versions"@en ;
-	skos:altLabel "CCSTMS_ETCSVersion" ;
+	skos:hiddenLabel "CCSTMS_ETCSVersion" ;
     skos:prefLabel "ETCS M Versions"@en ;
     dct:title "Concept scheme grouping ETCS M versions"@en .
 
@@ -52,25 +52,25 @@ era-etcsmvers:ETCSMVersions a skos:ConceptScheme ;
 era-etcsmvers:10 a skos:Concept;
   skos:inScheme era-etcsmvers:ETCSMVersions;  skos:topConceptOf era-etcsmvers:ETCSMVersions; 
   skos:notation "1.0"^^xsd:string ;
-  skos:altLabel "CCSTMS_v1_0_0" ;
+  skos:hiddenLabel "CCSTMS_v1_0_0" ;
   skos:prefLabel "1.0"@en .
 
 era-etcsmvers:11 a skos:Concept;
   skos:inScheme era-etcsmvers:ETCSMVersions;  skos:topConceptOf era-etcsmvers:ETCSMVersions; 
   skos:notation "1.1"^^xsd:string ;
-  skos:altLabel "CCSTMS_v1_1_1" ;
+  skos:hiddenLabel "CCSTMS_v1_1_1" ;
   skos:prefLabel "1.1"@en .
 
 era-etcsmvers:20 a skos:Concept;
   skos:inScheme era-etcsmvers:ETCSMVersions;  skos:topConceptOf era-etcsmvers:ETCSMVersions; 
   skos:notation "2.0"^^xsd:string ;
-  skos:altLabel "CCSTMS_v2_0_2" ;
+  skos:hiddenLabel "CCSTMS_v2_0_2" ;
   skos:prefLabel "2.0"@en .
 
 era-etcsmvers:21 a skos:Concept;
   skos:inScheme era-etcsmvers:ETCSMVersions;  skos:topConceptOf era-etcsmvers:ETCSMVersions; 
   skos:notation "2.1"^^xsd:string ;
-  skos:altLabel "CCSTMS_v2_1_3" ;
+  skos:hiddenLabel "CCSTMS_v2_1_3" ;
   skos:prefLabel "2.1"@en .
 
 era-etcsmvers:22 a skos:Concept;

--- a/era-skos/era-skos-ETCSMVersions.ttl
+++ b/era-skos/era-skos-ETCSMVersions.ttl
@@ -25,14 +25,16 @@
 
 era-etcsmvers:ETCSMVersions a skos:ConceptScheme ; 
     dct:issued "2020-09-01"^^xsd:date ;
-    dct:modified "2022-09-09"^^xsd:date ;
-    dct:modified "2024-04-18"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2022-09-09"^^xsd:date ,
+				 "2024-04-18"^^xsd:date ,
+				 "2024-09-04"^^xsd:date ,
+				 "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.3.2.10"; 
     era:rinfIndex "1.2.1.1.1.10"; 
     rdfs:label "ETCS M Versions"@en ;
+	skos:altLabel "CCSTMS_ETCSVersion" ;
     skos:prefLabel "ETCS M Versions"@en ;
     dct:title "Concept scheme grouping ETCS M versions"@en .
 
@@ -50,21 +52,25 @@ era-etcsmvers:ETCSMVersions a skos:ConceptScheme ;
 era-etcsmvers:10 a skos:Concept;
   skos:inScheme era-etcsmvers:ETCSMVersions;  skos:topConceptOf era-etcsmvers:ETCSMVersions; 
   skos:notation "1.0"^^xsd:string ;
+  skos:altLabel "CCSTMS_v1_0_0" ;
   skos:prefLabel "1.0"@en .
 
 era-etcsmvers:11 a skos:Concept;
   skos:inScheme era-etcsmvers:ETCSMVersions;  skos:topConceptOf era-etcsmvers:ETCSMVersions; 
   skos:notation "1.1"^^xsd:string ;
+  skos:altLabel "CCSTMS_v1_1_1" ;
   skos:prefLabel "1.1"@en .
 
 era-etcsmvers:20 a skos:Concept;
   skos:inScheme era-etcsmvers:ETCSMVersions;  skos:topConceptOf era-etcsmvers:ETCSMVersions; 
   skos:notation "2.0"^^xsd:string ;
+  skos:altLabel "CCSTMS_v2_0_2" ;
   skos:prefLabel "2.0"@en .
 
 era-etcsmvers:21 a skos:Concept;
   skos:inScheme era-etcsmvers:ETCSMVersions;  skos:topConceptOf era-etcsmvers:ETCSMVersions; 
   skos:notation "2.1"^^xsd:string ;
+  skos:altLabel "CCSTMS_v2_1_3" ;
   skos:prefLabel "2.1"@en .
 
 era-etcsmvers:22 a skos:Concept;

--- a/era-skos/era-skos-ETCSReactionsNVContact.ttl
+++ b/era-skos/era-skos-ETCSReactionsNVContact.ttl
@@ -32,7 +32,7 @@ era-contact-react:ETCSReactionsNVContact a skos:ConceptScheme ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.3.2.16.9";
     era:rinfIndex "1.2.1.1.1.16.9"; 
-	skos:altLabel "CCSTMS_LinkReaction" ;
+	skos:hiddenLabel "CCSTMS_LinkReaction" ;
     rdfs:label "ETCS Reactions after expired T_NVCONTACT"@en ;
     skos:prefLabel "ETCS Reactions after expired T_NVCONTACT"@en ;
     dct:title "Concept scheme grouping ETCS Reactions (T_NVCONTACT)"@en .
@@ -52,21 +52,21 @@ era-contact-react:00 a skos:Concept;
   skos:topConceptOf era-contact-react:ETCSReactionsNVContact;
   skos:inScheme era-contact-react:ETCSReactionsNVContact;  skos:note "Value added by TWG RINF CCS"@en;
   skos:notation "00"^^xsd:string ;
-  skos:altLabel "CCSTMS_trainTrip_0" ;
+  skos:hiddenLabel "CCSTMS_trainTrip_0" ;
   skos:prefLabel "Train Trip"@en .
 
 era-contact-react:01 a skos:Concept;
   skos:topConceptOf era-contact-react:ETCSReactionsNVContact;
   skos:inScheme era-contact-react:ETCSReactionsNVContact;  skos:note "Value added by TWG RINF CCS"@en;
   skos:notation "01"^^xsd:string ;
-  skos:altLabel "CCSTMS_applyServiceBrake_1" ;
+  skos:hiddenLabel "CCSTMS_applyServiceBrake_1" ;
   skos:prefLabel "Apply Service Brake"@en .
 
 era-contact-react:10 a skos:Concept;
   skos:topConceptOf era-contact-react:ETCSReactionsNVContact;
   skos:inScheme era-contact-react:ETCSReactionsNVContact;  skos:note "Value added by TWG RINF CCS"@en;
   skos:notation "10"^^xsd:string ;
-  skos:altLabel "CCSTMS_noReaction_2" ;
+  skos:hiddenLabel "CCSTMS_noReaction_2" ;
   skos:prefLabel "No reaction"@en .
 
 era-contact-react:11 a skos:Concept;

--- a/era-skos/era-skos-ETCSReactionsNVContact.ttl
+++ b/era-skos/era-skos-ETCSReactionsNVContact.ttl
@@ -26,11 +26,13 @@
 
 era-contact-react:ETCSReactionsNVContact a skos:ConceptScheme ; 
     dct:issued "2024-04-18"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2024-09-04"^^xsd:date ,
+				 "2024-12-11"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.3.2.16.9";
     era:rinfIndex "1.2.1.1.1.16.9"; 
+	skos:altLabel "CCSTMS_LinkReaction" ;
     rdfs:label "ETCS Reactions after expired T_NVCONTACT"@en ;
     skos:prefLabel "ETCS Reactions after expired T_NVCONTACT"@en ;
     dct:title "Concept scheme grouping ETCS Reactions (T_NVCONTACT)"@en .
@@ -50,18 +52,21 @@ era-contact-react:00 a skos:Concept;
   skos:topConceptOf era-contact-react:ETCSReactionsNVContact;
   skos:inScheme era-contact-react:ETCSReactionsNVContact;  skos:note "Value added by TWG RINF CCS"@en;
   skos:notation "00"^^xsd:string ;
+  skos:altLabel "CCSTMS_trainTrip_0" ;
   skos:prefLabel "Train Trip"@en .
 
 era-contact-react:01 a skos:Concept;
   skos:topConceptOf era-contact-react:ETCSReactionsNVContact;
   skos:inScheme era-contact-react:ETCSReactionsNVContact;  skos:note "Value added by TWG RINF CCS"@en;
   skos:notation "01"^^xsd:string ;
+  skos:altLabel "CCSTMS_applyServiceBrake_1" ;
   skos:prefLabel "Apply Service Brake"@en .
 
 era-contact-react:10 a skos:Concept;
   skos:topConceptOf era-contact-react:ETCSReactionsNVContact;
   skos:inScheme era-contact-react:ETCSReactionsNVContact;  skos:note "Value added by TWG RINF CCS"@en;
   skos:notation "10"^^xsd:string ;
+  skos:altLabel "CCSTMS_noReaction_2" ;
   skos:prefLabel "No reaction"@en .
 
 era-contact-react:11 a skos:Concept;

--- a/era-skos/era-skos-EnergySupplySystems.ttl
+++ b/era-skos/era-skos-EnergySupplySystems.ttl
@@ -33,7 +33,7 @@ era-ess:EnergySupplySystems a skos:ConceptScheme ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     rdfs:label "Energy Supply Systems"@en ;
     skos:prefLabel "Energy Supply Systems"@en ;
-	skos:altLabel "CCSTMS_VoltageType" ;
+	skos:hiddenLabel "CCSTMS_VoltageType" ;
     dct:title "Concept scheme grouping energy supply systems"@en .
 
 
@@ -214,32 +214,32 @@ era-ess-eratv:dc-3kv a skos:Concept;
 era-ess-rinf:DC80 a skos:Concept ; 
     skos:inScheme era-ess:EnergySupplySystems ; skos:topConceptOf era-ess:EnergySupplySystems ;
     skos:note "Value retrieved from the RINF database";
-	skos:altLabel "CCSTMS_vtDC600v_5" ;
+	skos:hiddenLabel "CCSTMS_vtDC600v_5" ;
     skos:prefLabel "DC 600 V" .
 
 era-ess-rinf:AC20 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
-  skos:altLabel "CCSTMS_vtAC15kv16_7Hz_2" ;
+  skos:hiddenLabel "CCSTMS_vtAC15kv16_7Hz_2" ;
   skos:prefLabel "AC 15kV-16.7Hz" .
 
 era-ess-rinf:AC10 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
-  skos:altLabel "CCSTMS_vtAC25kv50Hz_1" ;
+  skos:hiddenLabel "CCSTMS_vtAC25kv50Hz_1" ;
   skos:prefLabel "AC 25kV-50Hz" .
 
 era-ess-rinf:DC60 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
   skos:altLabel "DC750V";
-  skos:altLabel "CCSTMS_vtDC750v_7" ;
+  skos:hiddenLabel "CCSTMS_vtDC750v_7" ;
   skos:prefLabel "DC 750V" .
 
 era-ess-rinf:DC40 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
-  skos:altLabel "CCSTMS_vtDC1_5kv_4" ;
+  skos:hiddenLabel "CCSTMS_vtDC1_5kv_4" ;
   skos:prefLabel "DC 1.5kV" .
 
 #added from value in RINF lookup table
@@ -258,22 +258,22 @@ era-ess-rinf:90 a skos:Concept;
 era-ess-rinf:DC90 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems;
   skos:note "Value retrieved from the RINF database";
-  skos:altLabel "CCSTMS_vtDC850v_8" ;
+  skos:hiddenLabel "CCSTMS_vtDC850v_8" ;
   skos:prefLabel "DC 850V" .
 
 era-ess-rinf:DC30 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems;
-  skos:altLabel "CCSTMS_vtDC3kv_3" ;
+  skos:hiddenLabel "CCSTMS_vtDC3kv_3" ;
   skos:prefLabel "DC 3kV" .
 
 era-ess-rinf:DC70 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
-  skos:altLabel "CCSTMS_vtDC650v_6" ;
+  skos:hiddenLabel "CCSTMS_vtDC650v_6" ;
   skos:prefLabel "DC 650V" .
   
 era-ess:notFitted a skos:Concept ; 
     skos:inScheme era-ess:EnergySupplySystems ; skos:topConceptOf era-ess:EnergySupplySystems ;
 	rdfs:comment "Line not fitted (not electrified) with any traction system" ;
-	skos:altLabel "CCSTMS_vtNotFitted_0" ;
+	skos:hiddenLabel "CCSTMS_vtNotFitted_0" ;
     skos:prefLabel "Not Fitted" .

--- a/era-skos/era-skos-EnergySupplySystems.ttl
+++ b/era-skos/era-skos-EnergySupplySystems.ttl
@@ -27,11 +27,13 @@
 
 era-ess:EnergySupplySystems a skos:ConceptScheme ;
     dct:issued "2020-09-01"^^xsd:date ;
-    dct:modified "2022-09-09"^^xsd:date ;
+    dct:modified "2022-09-09"^^xsd:date ,
+				 "2024-12-11"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     rdfs:label "Energy Supply Systems"@en ;
     skos:prefLabel "Energy Supply Systems"@en ;
+	skos:altLabel "CCSTMS_VoltageType" ;
     dct:title "Concept scheme grouping energy supply systems"@en .
 
 
@@ -52,7 +54,7 @@ era-ess-eratv:others
     skos:altLabel "Others (The User must also specify nominal voltage, frequency, ranges and current type AC or DC)" ;
     skos:altLabel "others";
     skos:prefLabel "Others".
-     
+    
 era-ess-eratv:1-2kv a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems;
   skos:note "Value retrieved from the ERATV database";
@@ -212,27 +214,32 @@ era-ess-eratv:dc-3kv a skos:Concept;
 era-ess-rinf:DC80 a skos:Concept ; 
     skos:inScheme era-ess:EnergySupplySystems ; skos:topConceptOf era-ess:EnergySupplySystems ;
     skos:note "Value retrieved from the RINF database";
+	skos:altLabel "CCSTMS_vtDC600v_5" ;
     skos:prefLabel "DC 600 V" .
 
 era-ess-rinf:AC20 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
+  skos:altLabel "CCSTMS_vtAC15kv16_7Hz_2" ;
   skos:prefLabel "AC 15kV-16.7Hz" .
 
 era-ess-rinf:AC10 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
+  skos:altLabel "CCSTMS_vtAC25kv50Hz_1" ;
   skos:prefLabel "AC 25kV-50Hz" .
 
 era-ess-rinf:DC60 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
   skos:altLabel "DC750V";
+  skos:altLabel "CCSTMS_vtDC750v_7" ;
   skos:prefLabel "DC 750V" .
 
 era-ess-rinf:DC40 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
+  skos:altLabel "CCSTMS_vtDC1_5kv_4" ;
   skos:prefLabel "DC 1.5kV" .
 
 #added from value in RINF lookup table
@@ -251,18 +258,22 @@ era-ess-rinf:90 a skos:Concept;
 era-ess-rinf:DC90 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems;
   skos:note "Value retrieved from the RINF database";
+  skos:altLabel "CCSTMS_vtDC850v_8" ;
   skos:prefLabel "DC 850V" .
 
 era-ess-rinf:DC30 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems;
+  skos:altLabel "CCSTMS_vtDC3kv_3" ;
   skos:prefLabel "DC 3kV" .
 
 era-ess-rinf:DC70 a skos:Concept;
   skos:inScheme era-ess:EnergySupplySystems; 
   skos:note "Value retrieved from the RINF database";
+  skos:altLabel "CCSTMS_vtDC650v_6" ;
   skos:prefLabel "DC 650V" .
-
-
-
-
-
+  
+era-ess:notFitted a skos:Concept ; 
+    skos:inScheme era-ess:EnergySupplySystems ; skos:topConceptOf era-ess:EnergySupplySystems ;
+	rdfs:comment "Line not fitted (not electrified) with any traction system" ;
+	skos:altLabel "CCSTMS_vtNotFitted_0" ;
+    skos:prefLabel "Not Fitted" .

--- a/era-skos/era-skos-EnergySupplySystems.ttl
+++ b/era-skos/era-skos-EnergySupplySystems.ttl
@@ -274,6 +274,6 @@ era-ess-rinf:DC70 a skos:Concept;
   
 era-ess:notFitted a skos:Concept ; 
     skos:inScheme era-ess:EnergySupplySystems ; skos:topConceptOf era-ess:EnergySupplySystems ;
-    skos:definition "Line not fitted (not electrified) with any traction system" ;
+    skos:definition "Line not fitted (not electrified) with any traction system"@en ;
     skos:hiddenLabel "CCSTMS_vtNotFitted_0" ;
-    skos:prefLabel "Not Fitted" .
+    skos:prefLabel "Not Fitted"@en .

--- a/era-skos/era-skos-EnergySupplySystems.ttl
+++ b/era-skos/era-skos-EnergySupplySystems.ttl
@@ -33,7 +33,7 @@ era-ess:EnergySupplySystems a skos:ConceptScheme ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     rdfs:label "Energy Supply Systems"@en ;
     skos:prefLabel "Energy Supply Systems"@en ;
-	skos:hiddenLabel "CCSTMS_VoltageType" ;
+    skos:hiddenLabel "CCSTMS_VoltageType" ;
     dct:title "Concept scheme grouping energy supply systems"@en .
 
 
@@ -274,6 +274,6 @@ era-ess-rinf:DC70 a skos:Concept;
   
 era-ess:notFitted a skos:Concept ; 
     skos:inScheme era-ess:EnergySupplySystems ; skos:topConceptOf era-ess:EnergySupplySystems ;
-	rdfs:comment "Line not fitted (not electrified) with any traction system" ;
-	skos:hiddenLabel "CCSTMS_vtNotFitted_0" ;
+    skos:definition "Line not fitted (not electrified) with any traction system" ;
+    skos:hiddenLabel "CCSTMS_vtNotFitted_0" ;
     skos:prefLabel "Not Fitted" .

--- a/era-skos/era-skos-LoadCapabilityLineCategories.ttl
+++ b/era-skos/era-skos-LoadCapabilityLineCategories.ttl
@@ -149,5 +149,5 @@ era-lclc:220 a skos:Concept;
 era-lclc:230 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "HS17"^^xsd:string ;
   skos:hiddenLabel "CCSTMS_AL_HS17_1" ;
-  rdfs:comment "Applicable for trains falling under axle load category HS17" ;
+  skos:definition "Applicable for trains falling under axle load category HS17"@en ;
   skos:prefLabel "HS17"@en .

--- a/era-skos/era-skos-LoadCapabilityLineCategories.ttl
+++ b/era-skos/era-skos-LoadCapabilityLineCategories.ttl
@@ -23,12 +23,14 @@
 
 era-lclc:LoadCapabilityLineCategories a skos:ConceptScheme ; 
     dct:issued "2020-09-01"^^xsd:date ;
-    dct:modified "2023-01-20"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2023-01-20"^^xsd:date ,
+				 "2024-09-04"^^xsd:date ,
+				 "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.1.2.4"; 
     rdfs:label "Load capability line categories"@en ;
+	skos:altLabel "CCSTMS_AxleLoadCategory" ;
     skos:prefLabel "Load capability line categories"@en ;
     dct:title "Concept scheme grouping load capability line categories"@en .
 
@@ -46,50 +48,62 @@ era-lclc:LoadCapabilityLineCategories a skos:ConceptScheme ;
 
 era-lclc:10 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "A"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_A_0" ;
   skos:prefLabel "A"@en .
 
 era-lclc:20 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "B1"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_B1_2" ;
   skos:prefLabel "B1"@en .
 
 era-lclc:30 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "B2"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_B2_3" ;
   skos:prefLabel "B2"@en .
 
 era-lclc:40 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "C2"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_C2_4" ;
   skos:prefLabel "C2"@en .
 
 era-lclc:50 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "C3"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_C3_5" ;
   skos:prefLabel "C3"@en .
 
 era-lclc:60 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "C4"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_C4_6" ;
   skos:prefLabel "C4"@en .
 
 era-lclc:70 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "D2"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_D2_7" ;
   skos:prefLabel "D2"@en .
 
 era-lclc:80 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "D3"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_D3_8" ;
   skos:prefLabel "D3"@en .
 
 era-lclc:90 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "D4"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_D4_9" ;
   skos:prefLabel "D4"@en .
 
 era-lclc:100 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "D4xL"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_D4XL_10" ;
   skos:prefLabel "D4xL"@en .
 
 era-lclc:110 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "E4"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_E4_11" ;
   skos:prefLabel "E4"@en .
 
 era-lclc:120 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "E5"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_E5_12" ;
   skos:prefLabel "E5"@en .
 
 era-lclc:130 a skos:Concept;
@@ -131,3 +145,9 @@ era-lclc:210 a skos:Concept;
 era-lclc:220 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "RA10"^^xsd:string ;
   skos:prefLabel "RA10"@en .
+
+era-lclc:230 a skos:Concept;
+  skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "HS17"^^xsd:string ;
+  skos:altLabel "CCSTMS_AL_HS17_1" ;
+  rdfs:comment "Applicable for trains falling under axle load category HS17" ;
+  skos:prefLabel "HS17"@en .

--- a/era-skos/era-skos-LoadCapabilityLineCategories.ttl
+++ b/era-skos/era-skos-LoadCapabilityLineCategories.ttl
@@ -30,7 +30,7 @@ era-lclc:LoadCapabilityLineCategories a skos:ConceptScheme ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.1.2.4"; 
     rdfs:label "Load capability line categories"@en ;
-	skos:altLabel "CCSTMS_AxleLoadCategory" ;
+	skos:hiddenLabel "CCSTMS_AxleLoadCategory" ;
     skos:prefLabel "Load capability line categories"@en ;
     dct:title "Concept scheme grouping load capability line categories"@en .
 
@@ -48,62 +48,62 @@ era-lclc:LoadCapabilityLineCategories a skos:ConceptScheme ;
 
 era-lclc:10 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "A"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_A_0" ;
+  skos:hiddenLabel "CCSTMS_AL_A_0" ;
   skos:prefLabel "A"@en .
 
 era-lclc:20 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "B1"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_B1_2" ;
+  skos:hiddenLabel "CCSTMS_AL_B1_2" ;
   skos:prefLabel "B1"@en .
 
 era-lclc:30 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "B2"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_B2_3" ;
+  skos:hiddenLabel "CCSTMS_AL_B2_3" ;
   skos:prefLabel "B2"@en .
 
 era-lclc:40 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "C2"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_C2_4" ;
+  skos:hiddenLabel "CCSTMS_AL_C2_4" ;
   skos:prefLabel "C2"@en .
 
 era-lclc:50 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "C3"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_C3_5" ;
+  skos:hiddenLabel "CCSTMS_AL_C3_5" ;
   skos:prefLabel "C3"@en .
 
 era-lclc:60 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "C4"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_C4_6" ;
+  skos:hiddenLabel "CCSTMS_AL_C4_6" ;
   skos:prefLabel "C4"@en .
 
 era-lclc:70 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "D2"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_D2_7" ;
+  skos:hiddenLabel "CCSTMS_AL_D2_7" ;
   skos:prefLabel "D2"@en .
 
 era-lclc:80 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "D3"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_D3_8" ;
+  skos:hiddenLabel "CCSTMS_AL_D3_8" ;
   skos:prefLabel "D3"@en .
 
 era-lclc:90 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "D4"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_D4_9" ;
+  skos:hiddenLabel "CCSTMS_AL_D4_9" ;
   skos:prefLabel "D4"@en .
 
 era-lclc:100 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "D4xL"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_D4XL_10" ;
+  skos:hiddenLabel "CCSTMS_AL_D4XL_10" ;
   skos:prefLabel "D4xL"@en .
 
 era-lclc:110 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "E4"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_E4_11" ;
+  skos:hiddenLabel "CCSTMS_AL_E4_11" ;
   skos:prefLabel "E4"@en .
 
 era-lclc:120 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "E5"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_E5_12" ;
+  skos:hiddenLabel "CCSTMS_AL_E5_12" ;
   skos:prefLabel "E5"@en .
 
 era-lclc:130 a skos:Concept;
@@ -148,6 +148,6 @@ era-lclc:220 a skos:Concept;
 
 era-lclc:230 a skos:Concept;
   skos:inScheme era-lclc:LoadCapabilityLineCategories;  skos:topConceptOf era-lclc:LoadCapabilityLineCategories;  skos:notation "HS17"^^xsd:string ;
-  skos:altLabel "CCSTMS_AL_HS17_1" ;
+  skos:hiddenLabel "CCSTMS_AL_HS17_1" ;
   rdfs:comment "Applicable for trains falling under axle load category HS17" ;
   skos:prefLabel "HS17"@en .

--- a/era-skos/era-skos-NominalTrackGauges.ttl
+++ b/era-skos/era-skos-NominalTrackGauges.ttl
@@ -19,8 +19,8 @@
 #
 #################################################################
 
-
-
+	
+	
 era-ntg:NominalTrackGauges a skos:ConceptScheme ; 
     dct:issued "2020-09-01"^^xsd:date ;
     dct:modified "2022-09-09"^^xsd:date , "2024-12-12"^^xsd:date ;
@@ -29,12 +29,16 @@ era-ntg:NominalTrackGauges a skos:ConceptScheme ;
     rdfs:label "Nominal Track Gauges"@en ;
     era:unitOfMeasure <http://qudt.org/vocab/unit/MilliM> ;
     era:rinfIndex "1.1.1.1.4.1"; 
+	skos:altLabel "CCSTMS_TrackGaugeType" ;
     skos:prefLabel "Nominal Track Gauges"@en ;
     skos:changeNote """ 
     Revision 10-12-2024: 
- - removed "other" from the list of SKOS
- - removed eratv concepts and merged with altLabels in RINF concepts
- - added unit of measure annotations
+	- removed "other" from the list of SKOS
+	- removed eratv concepts and merged with altLabels in RINF concepts
+	- added unit of measure annotations
+	Revision 12-12-2024:
+	- add altLabel for CCSTMS 
+	- add value for the unknown Track Gauge type
   """@en ;
     dct:title "Concept scheme grouping nominal track gauges"@en .
 
@@ -54,41 +58,53 @@ era-ntg-rinf:20 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "1000"@en  ;
   skos:altLabel "1000mm"@en ;
+  skos:altLabel "CCSTMS_tg1000mm_2" ;
   skos:notation "1000"^^xsd:string .
 
 era-ntg-rinf:30 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "1435"@en ;
   skos:notation "1435"^^xsd:string ;
+  skos:altLabel "CCSTMS_tg1435mm_3" ;
   skos:altLabel "1435mm"@en .
 
 era-ntg-rinf:40 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges;
   skos:prefLabel "1520"@en ;
   skos:altLabel "1520mm"@en ;
+  skos:altLabel "CCSTMS_tg1520mm_4" ;
   skos:notation  "1520"^^xsd:string.
 
 era-ntg-rinf:50 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "1524"@en ;
   skos:altLabel "1524mm"@en ;
+  skos:altLabel "CCSTMS_tg1524mm_5" ;
   skos:notation "1524"^^xsd:string .
 
 era-ntg-rinf:60 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "1600"@en ;
   skos:altLabel "1600mm"@en ;
+  skos:altLabel "CCSTMS_tgtg1600mm_6" ;
   skos:notation "1600"^^xsd:string .
 
 era-ntg-rinf:70 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges;
   skos:prefLabel "1668"@en ;
   skos:altLabel "1668mm"@en ;
+  skos:altLabel "CCSTMS_tgtg1668mm_6" ;
   skos:notation "1668"^^xsd:string .
 
 era-ntg-rinf:10 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "750"@en ;
   skos:altLabel "750"@en ;
+  skos:altLabel "CCSTMS_tg750_1" ;
   skos:notation "750"^^xsd:string .
 
+era-ntg:unknown a skos:Concept;
+  skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
+  rdfs:comment "Track gauge type not known" ;
+  skos:altLabel "CCSTMS_tgUnknown_0" ;
+  skos:prefLabel "Unknown"@en .

--- a/era-skos/era-skos-NominalTrackGauges.ttl
+++ b/era-skos/era-skos-NominalTrackGauges.ttl
@@ -105,6 +105,6 @@ era-ntg-rinf:10 a skos:Concept;
 
 era-ntg:unknown a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
-  skos:definition "Track gauge type not known" ;
+  skos:definition "Track gauge type not known"@en ;
   skos:hiddenLabel "CCSTMS_tgUnknown_0" ;
   skos:prefLabel "Unknown"@en .

--- a/era-skos/era-skos-NominalTrackGauges.ttl
+++ b/era-skos/era-skos-NominalTrackGauges.ttl
@@ -108,4 +108,4 @@ era-ntg:unknown a skos:Concept;
   skos:definition "Track gauge type not known"@en ;
   skos:hiddenLabel "CCSTMS_tgUnknown_0" ;
   skos:prefLabel "Unknown"@en ;
-  skos:notation "unknown"^^xsd:string
+  skos:notation "Unknown"^^xsd:string .

--- a/era-skos/era-skos-NominalTrackGauges.ttl
+++ b/era-skos/era-skos-NominalTrackGauges.ttl
@@ -107,4 +107,5 @@ era-ntg:unknown a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:definition "Track gauge type not known"@en ;
   skos:hiddenLabel "CCSTMS_tgUnknown_0" ;
-  skos:prefLabel "Unknown"@en .
+  skos:prefLabel "Unknown"@en ;
+  skos:notation "unknown"^^xsd:string

--- a/era-skos/era-skos-NominalTrackGauges.ttl
+++ b/era-skos/era-skos-NominalTrackGauges.ttl
@@ -29,7 +29,7 @@ era-ntg:NominalTrackGauges a skos:ConceptScheme ;
     rdfs:label "Nominal Track Gauges"@en ;
     era:unitOfMeasure <http://qudt.org/vocab/unit/MilliM> ;
     era:rinfIndex "1.1.1.1.4.1"; 
-	skos:altLabel "CCSTMS_TrackGaugeType" ;
+    skos:hiddenLabel "CCSTMS_TrackGaugeType" ;
     skos:prefLabel "Nominal Track Gauges"@en ;
     skos:changeNote """ 
     Revision 10-12-2024: 
@@ -58,53 +58,53 @@ era-ntg-rinf:20 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "1000"@en  ;
   skos:altLabel "1000mm"@en ;
-  skos:altLabel "CCSTMS_tg1000mm_2" ;
+  skos:hiddenLabel "CCSTMS_tg1000mm_2" ;
   skos:notation "1000"^^xsd:string .
 
 era-ntg-rinf:30 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "1435"@en ;
   skos:notation "1435"^^xsd:string ;
-  skos:altLabel "CCSTMS_tg1435mm_3" ;
+  skos:hiddenLabel "CCSTMS_tg1435mm_3" ;
   skos:altLabel "1435mm"@en .
 
 era-ntg-rinf:40 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges;
   skos:prefLabel "1520"@en ;
   skos:altLabel "1520mm"@en ;
-  skos:altLabel "CCSTMS_tg1520mm_4" ;
+  skos:hiddenLabel "CCSTMS_tg1520mm_4" ;
   skos:notation  "1520"^^xsd:string.
 
 era-ntg-rinf:50 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "1524"@en ;
   skos:altLabel "1524mm"@en ;
-  skos:altLabel "CCSTMS_tg1524mm_5" ;
+  skos:hiddenLabel "CCSTMS_tg1524mm_5" ;
   skos:notation "1524"^^xsd:string .
 
 era-ntg-rinf:60 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "1600"@en ;
   skos:altLabel "1600mm"@en ;
-  skos:altLabel "CCSTMS_tgtg1600mm_6" ;
+  skos:hiddenLabel "CCSTMS_tg1600mm_6" ;
   skos:notation "1600"^^xsd:string .
 
 era-ntg-rinf:70 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges;
   skos:prefLabel "1668"@en ;
   skos:altLabel "1668mm"@en ;
-  skos:altLabel "CCSTMS_tgtg1668mm_6" ;
+  skos:hiddenLabel "CCSTMS_tg1668mm_6" ;
   skos:notation "1668"^^xsd:string .
 
 era-ntg-rinf:10 a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:prefLabel "750"@en ;
   skos:altLabel "750"@en ;
-  skos:altLabel "CCSTMS_tg750_1" ;
+  skos:hiddenLabel "CCSTMS_tg750_1" ;
   skos:notation "750"^^xsd:string .
 
 era-ntg:unknown a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   rdfs:comment "Track gauge type not known" ;
-  skos:altLabel "CCSTMS_tgUnknown_0" ;
+  skos:hiddenLabel "CCSTMS_tgUnknown_0" ;
   skos:prefLabel "Unknown"@en .

--- a/era-skos/era-skos-NominalTrackGauges.ttl
+++ b/era-skos/era-skos-NominalTrackGauges.ttl
@@ -103,7 +103,7 @@ era-ntg-rinf:10 a skos:Concept;
   skos:hiddenLabel "CCSTMS_tg750_1" ;
   skos:notation "750"^^xsd:string .
 
-era-ntg-rinf:unknown a skos:Concept;
+era-ntg:unknown a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
   skos:definition "Track gauge type not known" ;
   skos:hiddenLabel "CCSTMS_tgUnknown_0" ;

--- a/era-skos/era-skos-NominalTrackGauges.ttl
+++ b/era-skos/era-skos-NominalTrackGauges.ttl
@@ -103,8 +103,8 @@ era-ntg-rinf:10 a skos:Concept;
   skos:hiddenLabel "CCSTMS_tg750_1" ;
   skos:notation "750"^^xsd:string .
 
-era-ntg:unknown a skos:Concept;
+era-ntg-rinf:unknown a skos:Concept;
   skos:inScheme era-ntg:NominalTrackGauges; skos:topConceptOf era-ntg:NominalTrackGauges; 
-  rdfs:comment "Track gauge type not known" ;
+  skos:definition "Track gauge type not known" ;
   skos:hiddenLabel "CCSTMS_tgUnknown_0" ;
   skos:prefLabel "Unknown"@en .

--- a/era-skos/era-skos-OperationalPointTypes.ttl
+++ b/era-skos/era-skos-OperationalPointTypes.ttl
@@ -19,11 +19,13 @@
 
 era-op-types:OperationalPointTypes a skos:ConceptScheme ;
     dct:issued "2020-09-01"^^xsd:date ;
-    dct:modified "2022-09-09"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2022-09-09"^^xsd:date ,
+				 "2024-09-04"^^xsd:date ,
+				 "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.2.0.0.0.4"; 
+	skos:altLabel "CCSTMS_OPType" ;
     rdfs:label "Operational Point Types"@en ;
     skos:prefLabel "Operational Point Types"@en ;
     dct:title "Concept scheme grouping the different existing types of Operational Points"@en .
@@ -41,11 +43,13 @@ era-op-types:OperationalPointTypes a skos:ConceptScheme ;
 era-op-types:90 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "90"^^xsd:string ;
   skos:definition "Located exactly in the point where a border between Member States meets a railway line."@en;
+  skos:altLabel "CCSTMS_OPT_borderPoint_5" ;
   skos:prefLabel "border point"@en, "punto de frontera"@es .
 
 era-op-types:50 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "50"^^xsd:string ;  
   skos:definition "Operational Point which is a group of tracks used by depot or workshop for rolling stock maintenance"@en;
+  skos:altLabel "CCSTMS_OPT_depot_1" ;
   skos:prefLabel "depot or workshop"@en, "depósito o taller"@es .
 
 era-op-types:140 a skos:Concept ;
@@ -76,11 +80,13 @@ era-op-types:30 a skos:Concept ;
 era-op-types:130 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "130"^^xsd:string ;  
   skos:definition "Operational Point allowing to provide more information on the private siding and on the way its is linked to the main network. Its use is left to the discretion of each Member State."@en;
+  skos:altLabel "CCSTMS_OPT_siding_2" ;
   skos:prefLabel "private siding"@en, "vía lateral privada"@es .
 
 era-op-types:100 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "100"^^xsd:string ;  
   skos:definition "Group of tracks used for shunting trains, mostly related to freight trains"@en;
+  skos:altLabel "CCSTMS_OPT_shuntingYard_4" ;
   skos:prefLabel "shunting yard"@en, "patio de maniobras"@es .
 
 era-op-types:20 a skos:Concept ;
@@ -91,6 +97,7 @@ era-op-types:20 a skos:Concept ;
 era-op-types:10 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "10"^^xsd:string ;  
   skos:definition "Big or huge station with several functions, important for international traffic, basic for national railway system"@en;
+  skos:altLabel "CCSTMS_OPT_station_0" ;
   skos:prefLabel "station"@en, "estación"@es .
 
 era-op-types:120 a skos:Concept ;
@@ -101,11 +108,13 @@ era-op-types:120 a skos:Concept ;
 era-op-types:110 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "110"^^xsd:string ; 
   skos:definition "To describe a change on CCS or a type of contact line or gauge changeover facility – fixed installation allowing a train to travel across a break of gauge where two railway networks with different track gauges meet."@en;
+  skos:altLabel "CCSTMS_OPT_technicalChange_6" ;
   skos:prefLabel "technical change"@en, "cambio técnico"@es .
 
 era-op-types:60 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "60"^^xsd:string ; 
   skos:definition "Operational Point which is a group of tracks for servicing trains (parking, cleaning, washing, current revisions, etc.)"@en;
+  skos:altLabel "CCSTMS_OPT_trainTechnicalServices_3" ;
   skos:prefLabel "train technical services"@en, "servicios técnicos para trenes"@es .
 
 era-op-types:150 a skos:Concept ;

--- a/era-skos/era-skos-OperationalPointTypes.ttl
+++ b/era-skos/era-skos-OperationalPointTypes.ttl
@@ -25,7 +25,7 @@ era-op-types:OperationalPointTypes a skos:ConceptScheme ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.2.0.0.0.4"; 
-	skos:altLabel "CCSTMS_OPType" ;
+    skos:hiddenLabel "CCSTMS_OPType" ;
     rdfs:label "Operational Point Types"@en ;
     skos:prefLabel "Operational Point Types"@en ;
     dct:title "Concept scheme grouping the different existing types of Operational Points"@en .
@@ -43,13 +43,13 @@ era-op-types:OperationalPointTypes a skos:ConceptScheme ;
 era-op-types:90 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "90"^^xsd:string ;
   skos:definition "Located exactly in the point where a border between Member States meets a railway line."@en;
-  skos:altLabel "CCSTMS_OPT_borderPoint_5" ;
+  skos:hiddenLabel "CCSTMS_OPT_borderPoint_5" ;
   skos:prefLabel "border point"@en, "punto de frontera"@es .
 
 era-op-types:50 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "50"^^xsd:string ;  
   skos:definition "Operational Point which is a group of tracks used by depot or workshop for rolling stock maintenance"@en;
-  skos:altLabel "CCSTMS_OPT_depot_1" ;
+  skos:hiddenLabel "CCSTMS_OPT_depot_1" ;
   skos:prefLabel "depot or workshop"@en, "depósito o taller"@es .
 
 era-op-types:140 a skos:Concept ;
@@ -80,13 +80,13 @@ era-op-types:30 a skos:Concept ;
 era-op-types:130 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "130"^^xsd:string ;  
   skos:definition "Operational Point allowing to provide more information on the private siding and on the way its is linked to the main network. Its use is left to the discretion of each Member State."@en;
-  skos:altLabel "CCSTMS_OPT_siding_2" ;
+  skos:hiddenLabel "CCSTMS_OPT_siding_2" ;
   skos:prefLabel "private siding"@en, "vía lateral privada"@es .
 
 era-op-types:100 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "100"^^xsd:string ;  
   skos:definition "Group of tracks used for shunting trains, mostly related to freight trains"@en;
-  skos:altLabel "CCSTMS_OPT_shuntingYard_4" ;
+  skos:hiddenLabel "CCSTMS_OPT_shuntingYard_4" ;
   skos:prefLabel "shunting yard"@en, "patio de maniobras"@es .
 
 era-op-types:20 a skos:Concept ;
@@ -97,7 +97,7 @@ era-op-types:20 a skos:Concept ;
 era-op-types:10 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "10"^^xsd:string ;  
   skos:definition "Big or huge station with several functions, important for international traffic, basic for national railway system"@en;
-  skos:altLabel "CCSTMS_OPT_station_0" ;
+  skos:hiddenLabel "CCSTMS_OPT_station_0" ;
   skos:prefLabel "station"@en, "estación"@es .
 
 era-op-types:120 a skos:Concept ;
@@ -108,13 +108,13 @@ era-op-types:120 a skos:Concept ;
 era-op-types:110 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "110"^^xsd:string ; 
   skos:definition "To describe a change on CCS or a type of contact line or gauge changeover facility – fixed installation allowing a train to travel across a break of gauge where two railway networks with different track gauges meet."@en;
-  skos:altLabel "CCSTMS_OPT_technicalChange_6" ;
+  skos:hiddenLabel "CCSTMS_OPT_technicalChange_6" ;
   skos:prefLabel "technical change"@en, "cambio técnico"@es .
 
 era-op-types:60 a skos:Concept ;
   skos:inScheme era-op-types:OperationalPointTypes; skos:topConceptOf era-op-types:OperationalPointTypes; skos:notation "60"^^xsd:string ; 
   skos:definition "Operational Point which is a group of tracks for servicing trains (parking, cleaning, washing, current revisions, etc.)"@en;
-  skos:altLabel "CCSTMS_OPT_trainTechnicalServices_3" ;
+  skos:hiddenLabel "CCSTMS_OPT_trainTechnicalServices_3" ;
   skos:prefLabel "train technical services"@en, "servicios técnicos para trenes"@es .
 
 era-op-types:150 a skos:Concept ;

--- a/era-skos/era-skos-PlatformHeights.ttl
+++ b/era-skos/era-skos-PlatformHeights.ttl
@@ -126,7 +126,7 @@ era-ph-rinf:140 a skos:Concept;
 era-ph-rinf:130 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "915"@en ;
-  skos:aaltLabel "915mm (UK specific case)"@en ;
+  skos:altLabel "915mm (UK specific case)"@en ;
   skos:altLabel "CCSTMS_PH_915mm_10" ;
   skos:notation "915"^^xsd:string .
 

--- a/era-skos/era-skos-PlatformHeights.ttl
+++ b/era-skos/era-skos-PlatformHeights.ttl
@@ -22,7 +22,9 @@
 
 era-ph:PlatformHeights a skos:ConceptScheme ; 
     dct:issued "2020-09-01"^^xsd:date ;
-    dct:modified "2022-09-09"^^xsd:date, "2024-09-07"^^xsd:date;
+    dct:modified "2022-09-09"^^xsd:date, 
+				 "2024-09-07"^^xsd:date, 
+				 "2024-12-12"^^xsd:date ;
     era:rinfIndex "1.2.1.0.6.5"; 
 	era:eratvIndex "4.12.3.1 ";  
 	era:unitOfMeasure <http://qudt.org/vocab/unit/MilliM> ; 
@@ -30,6 +32,7 @@ era-ph:PlatformHeights a skos:ConceptScheme ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     rdfs:label "Platform Heights"@en ;
     skos:prefLabel "Platform Heights"@en ;
+	skos:altLabel "CCSTMS_PlatformHeight" ;
     skos:changeNote """
             Revision 
             - harmonized values in RINF and ERATV
@@ -55,6 +58,7 @@ era-ph:PlatformHeights a skos:ConceptScheme ;
 era-ph-rinf:160 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights; 
   skos:notation "1100"^^xsd:string;
+  skos:altLabel "CCSTMS_PH_1100mm_13" ;
   skos:prefLabel "1100"@en .
 
 era-ph-rinf:60 a skos:Concept;
@@ -62,6 +66,7 @@ era-ph-rinf:60 a skos:Concept;
   era-ph:PlatformHeights;  
   skos:prefLabel "200"@en ;
   skos:altLabel "200 mm"@en ;
+  skos:altLabel "CCSTMS_PH_200mm_0" ;
   skos:notation "200"^^xsd:string .
 
 era-ph-rinf:10 a skos:Concept;
@@ -80,6 +85,7 @@ era-ph-rinf:20 a skos:Concept;
 era-ph-rinf:70 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "580"@en;
+  skos:altLabel "CCSTMS_PH_580mm_3" ;
   skos:notation "580"^^xsd:string .
 
 
@@ -87,61 +93,72 @@ era-ph-rinf:50 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "300-380"@en;
   skos:altLabel "380 mm (with dual movable step)"@en ;
+  skos:altLabel "CCSTMS_PH_300_380mm_1" ;
   skos:notation "300-380"^^xsd:string .
 
 era-ph-rinf:40 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "760"@en ;
+  skos:altLabel "CCSTMS_PH_760mm_7" ;
   skos:altLabel "760 mm"@en ;
   skos:notation "760"^^xsd:string .
 
 era-ph-rinf:30 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "550"@en;
+  skos:altLabel "CCSTMS_PH_550mm_2" ;
   skos:notation "550"^^xsd:string .
 
 era-ph-rinf:150 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "960"@en ;
   skos:altLabel "960 mm"@en ;
+  skos:altLabel "CCSTMS_PH_960mm_12" ;
   skos:notation "960"^^xsd:string .
 
 era-ph-rinf:140 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "920"@en ;
   skos:altLabel "920 mm"@en ;
+  skos:altLabel "CCSTMS_PH_920mm_11" ;
   skos:notation "920"^^xsd:string .
 
 era-ph-rinf:130 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "915"@en ;
   skos:aaltLabel "915mm (UK specific case)"@en ;
+  skos:altLabel "CCSTMS_PH_915mm_10" ;
   skos:notation "915"^^xsd:string .
 
 era-ph-rinf:120 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "900"@en;
+  skos:altLabel "CCSTMS_PH_900mm_9" ;
   skos:notation "900"^^xsd:string .
 
 era-ph-rinf:110 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "840"@en;
+  skos:altLabel "CCSTMS_PH_840mm_8" ;
   skos:altLabel "840 mm"@en;
   skos:notation "840"^^xsd:string .
 
 era-ph-rinf:100 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
+  skos:altLabel "CCSTMS_PH_730mm_6" ;
   skos:prefLabel "730"@en ;
   skos:notation "730"^^xsd:string .
 
 era-ph-rinf:90 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
+  skos:altLabel "CCSTMS_PH_685mm_5" ;
   skos:prefLabel "685"@en ;
   skos:notation "685"^^xsd:string .
 
 era-ph-rinf:80 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "680"@en ;
+  skos:altLabel "CCSTMS_PH_680mm_4" ;
   skos:altLabel "680 mm"@en ;
   skos:notation "680"^^xsd:string .
 
@@ -437,4 +454,3 @@ era-ph-eratv:585 a skos:Concept;
   skos:altLabel "remorque : 585 mm"@en ;
   skos:prefLabel "585"@en ;
   skos:notation "585"^^xsd:string .
-

--- a/era-skos/era-skos-PlatformHeights.ttl
+++ b/era-skos/era-skos-PlatformHeights.ttl
@@ -32,7 +32,7 @@ era-ph:PlatformHeights a skos:ConceptScheme ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     rdfs:label "Platform Heights"@en ;
     skos:prefLabel "Platform Heights"@en ;
-	skos:altLabel "CCSTMS_PlatformHeight" ;
+    skos:hiddenLabel "CCSTMS_PlatformHeight" ;
     skos:changeNote """
             Revision 
             - harmonized values in RINF and ERATV
@@ -58,7 +58,7 @@ era-ph:PlatformHeights a skos:ConceptScheme ;
 era-ph-rinf:160 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights; 
   skos:notation "1100"^^xsd:string;
-  skos:altLabel "CCSTMS_PH_1100mm_13" ;
+  skos:hiddenLabel "CCSTMS_PH_1100mm_13" ;
   skos:prefLabel "1100"@en .
 
 era-ph-rinf:60 a skos:Concept;
@@ -66,7 +66,7 @@ era-ph-rinf:60 a skos:Concept;
   era-ph:PlatformHeights;  
   skos:prefLabel "200"@en ;
   skos:altLabel "200 mm"@en ;
-  skos:altLabel "CCSTMS_PH_200mm_0" ;
+  skos:hiddenLabel "CCSTMS_PH_200mm_0" ;
   skos:notation "200"^^xsd:string .
 
 era-ph-rinf:10 a skos:Concept;
@@ -85,7 +85,7 @@ era-ph-rinf:20 a skos:Concept;
 era-ph-rinf:70 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "580"@en;
-  skos:altLabel "CCSTMS_PH_580mm_3" ;
+  skos:hiddenLabel "CCSTMS_PH_580mm_3" ;
   skos:notation "580"^^xsd:string .
 
 
@@ -93,72 +93,72 @@ era-ph-rinf:50 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "300-380"@en;
   skos:altLabel "380 mm (with dual movable step)"@en ;
-  skos:altLabel "CCSTMS_PH_300_380mm_1" ;
+  skos:hiddenLabel "CCSTMS_PH_300_380mm_1" ;
   skos:notation "300-380"^^xsd:string .
 
 era-ph-rinf:40 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "760"@en ;
-  skos:altLabel "CCSTMS_PH_760mm_7" ;
+  skos:hiddenLabel "CCSTMS_PH_760mm_7" ;
   skos:altLabel "760 mm"@en ;
   skos:notation "760"^^xsd:string .
 
 era-ph-rinf:30 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "550"@en;
-  skos:altLabel "CCSTMS_PH_550mm_2" ;
+  skos:hiddenLabel "CCSTMS_PH_550mm_2" ;
   skos:notation "550"^^xsd:string .
 
 era-ph-rinf:150 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "960"@en ;
   skos:altLabel "960 mm"@en ;
-  skos:altLabel "CCSTMS_PH_960mm_12" ;
+  skos:hiddenLabel "CCSTMS_PH_960mm_12" ;
   skos:notation "960"^^xsd:string .
 
 era-ph-rinf:140 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "920"@en ;
   skos:altLabel "920 mm"@en ;
-  skos:altLabel "CCSTMS_PH_920mm_11" ;
+  skos:hiddenLabel "CCSTMS_PH_920mm_11" ;
   skos:notation "920"^^xsd:string .
 
 era-ph-rinf:130 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "915"@en ;
   skos:altLabel "915mm (UK specific case)"@en ;
-  skos:altLabel "CCSTMS_PH_915mm_10" ;
+  skos:hiddenLabel "CCSTMS_PH_915mm_10" ;
   skos:notation "915"^^xsd:string .
 
 era-ph-rinf:120 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "900"@en;
-  skos:altLabel "CCSTMS_PH_900mm_9" ;
+  skos:hiddenLabel "CCSTMS_PH_900mm_9" ;
   skos:notation "900"^^xsd:string .
 
 era-ph-rinf:110 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "840"@en;
-  skos:altLabel "CCSTMS_PH_840mm_8" ;
+  skos:hiddenLabel "CCSTMS_PH_840mm_8" ;
   skos:altLabel "840 mm"@en;
   skos:notation "840"^^xsd:string .
 
 era-ph-rinf:100 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
-  skos:altLabel "CCSTMS_PH_730mm_6" ;
+  skos:hiddenLabel "CCSTMS_PH_730mm_6" ;
   skos:prefLabel "730"@en ;
   skos:notation "730"^^xsd:string .
 
 era-ph-rinf:90 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
-  skos:altLabel "CCSTMS_PH_685mm_5" ;
+  skos:hiddenLabel "CCSTMS_PH_685mm_5" ;
   skos:prefLabel "685"@en ;
   skos:notation "685"^^xsd:string .
 
 era-ph-rinf:80 a skos:Concept;
   skos:inScheme era-ph:PlatformHeights;  skos:topConceptOf  era-ph:PlatformHeights;  
   skos:prefLabel "680"@en ;
-  skos:altLabel "CCSTMS_PH_680mm_4" ;
+  skos:hiddenLabel "CCSTMS_PH_680mm_4" ;
   skos:altLabel "680 mm"@en ;
   skos:notation "680"^^xsd:string .
 

--- a/era-skos/era-skos-TrackRunningDirections.ttl
+++ b/era-skos/era-skos-TrackRunningDirections.ttl
@@ -22,14 +22,17 @@
 
 era-trd:TrackRunningDirections a skos:ConceptScheme ;
     dct:issued "2020-09-01"^^xsd:date ;
-    dct:modified "2022-09-09"^^xsd:date ;
-    dct:modified "2024-04-18"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date, "2024-09-09"^^xsd:date ;
+    dct:modified "2022-09-09"^^xsd:date ,
+				 "2024-04-18"^^xsd:date ,
+				 "2024-09-04"^^xsd:date , 
+				 "2024-09-09"^^xsd:date ,
+				 "2024-12-11"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.0.0.2"; 
     rdfs:label "Track Running Directions"@en ;
     skos:prefLabel "Track Running Directions"@en ;
+	skos:altLabel "CCSTMS_GradeOfAutomation" ;
     dct:title "Concept scheme grouping track running directions"@en .
 
 #################################################################
@@ -46,6 +49,7 @@ era-trd:10 a skos:Concept;
   skos:topConceptOf era-trd:TrackRunningDirections ;
   skos:notation "N"^^xsd:string ;
   skos:prefLabel "N"@en ; 
+  skos:altLabel "CCSTMS_dirSame_1" ;
   skos:definition "The normal running direction is the same as the direction defined by the start and end of the Section of Line."@en .
 
 era-trd:20 a skos:Concept;
@@ -53,6 +57,7 @@ era-trd:20 a skos:Concept;
   skos:topConceptOf era-trd:TrackRunningDirections ;
   skos:notation "O"^^xsd:string ;
   skos:prefLabel "O"@en ; 
+  skos:altLabel "CCSTMS_dirReverse_2" ;
   skos:definition "The normal running direction is the opposite/reverse as the direction defined by the start and end of the Section of Line."@en .
 
 era-trd:30 a skos:Concept;
@@ -60,4 +65,5 @@ era-trd:30 a skos:Concept;
   skos:topConceptOf era-trd:TrackRunningDirections ;
   skos:notation "B"^^xsd:string ;
   skos:prefLabel "B"@en ; 
+  skos:altLabel "CCSTMS_dirBoth_0" ;
   skos:definition "The normal running direction is both directions defined by the Section of Line."@en .

--- a/era-skos/era-skos-TrackRunningDirections.ttl
+++ b/era-skos/era-skos-TrackRunningDirections.ttl
@@ -32,7 +32,7 @@ era-trd:TrackRunningDirections a skos:ConceptScheme ;
     era:rinfIndex "1.1.1.0.0.2"; 
     rdfs:label "Track Running Directions"@en ;
     skos:prefLabel "Track Running Directions"@en ;
-	skos:altLabel "CCSTMS_GradeOfAutomation" ;
+	skos:hiddenLabel "CCSTMS_GradeOfAutomation" ;
     dct:title "Concept scheme grouping track running directions"@en .
 
 #################################################################
@@ -49,7 +49,7 @@ era-trd:10 a skos:Concept;
   skos:topConceptOf era-trd:TrackRunningDirections ;
   skos:notation "N"^^xsd:string ;
   skos:prefLabel "N"@en ; 
-  skos:altLabel "CCSTMS_dirSame_1" ;
+  skos:hiddenLabel "CCSTMS_dirSame_1" ;
   skos:definition "The normal running direction is the same as the direction defined by the start and end of the Section of Line."@en .
 
 era-trd:20 a skos:Concept;
@@ -57,7 +57,7 @@ era-trd:20 a skos:Concept;
   skos:topConceptOf era-trd:TrackRunningDirections ;
   skos:notation "O"^^xsd:string ;
   skos:prefLabel "O"@en ; 
-  skos:altLabel "CCSTMS_dirReverse_2" ;
+  skos:hiddenLabel "CCSTMS_dirReverse_2" ;
   skos:definition "The normal running direction is the opposite/reverse as the direction defined by the start and end of the Section of Line."@en .
 
 era-trd:30 a skos:Concept;
@@ -65,5 +65,5 @@ era-trd:30 a skos:Concept;
   skos:topConceptOf era-trd:TrackRunningDirections ;
   skos:notation "B"^^xsd:string ;
   skos:prefLabel "B"@en ; 
-  skos:altLabel "CCSTMS_dirBoth_0" ;
+  skos:hiddenLabel "CCSTMS_dirBoth_0" ;
   skos:definition "The normal running direction is both directions defined by the Section of Line."@en .

--- a/era-skos/era-skos-TrainDetectionSystems.ttl
+++ b/era-skos/era-skos-TrainDetectionSystems.ttl
@@ -24,10 +24,12 @@
 
 era-tds:TrainDetectionSystems a skos:ConceptScheme ; #
     dct:issued "2020-09-01"^^xsd:date ;
-    dct:modified "2022-09-09"^^xsd:date ;
+    dct:modified "2022-09-09"^^xsd:date ,
+				 "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     rdfs:label "Train Detection Systems"@en ;
+	skos:altLabel "CCSTMS_TrainDetectorType" ;
     skos:prefLabel "Train Detection Systems"@en ;
     dct:title "Concept scheme grouping train detection systems"@en .
 
@@ -50,11 +52,13 @@ era-tds-rinf:30 a skos:Concept;
 era-tds-rinf:10 a skos:Concept;
   skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
   skos:note "Value retrieved from the RINF database";
+  skos:altLabel "CCSTMS_trackCircuitBorder_1" ;
   skos:prefLabel "track circuit" .
 
 era-tds-rinf:20 a skos:Concept;
   skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
   skos:note "Value retrieved from the RINF database";
+  skos:altLabel "CCSTMS_axleCounter_0" ;
   skos:prefLabel "wheel detector" .
 
 era-tds-eratv:track-circuits a skos:Concept;
@@ -80,9 +84,3 @@ era-tds-eratv:axle-counters a skos:Concept;
   skos:note "Value retrieved from the ERATV database";
   skos:closeMatch era-tds-rinf:20;
   skos:prefLabel "axle counters" .
-
-
-
-
-
-

--- a/era-skos/era-skos-TrainDetectionSystems.ttl
+++ b/era-skos/era-skos-TrainDetectionSystems.ttl
@@ -29,7 +29,7 @@ era-tds:TrainDetectionSystems a skos:ConceptScheme ; #
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     rdfs:label "Train Detection Systems"@en ;
-	skos:altLabel "CCSTMS_TrainDetectorType" ;
+	skos:hiddenLabel "CCSTMS_TrainDetectorType" ;
     skos:prefLabel "Train Detection Systems"@en ;
     dct:title "Concept scheme grouping train detection systems"@en .
 
@@ -52,13 +52,13 @@ era-tds-rinf:30 a skos:Concept;
 era-tds-rinf:10 a skos:Concept;
   skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
   skos:note "Value retrieved from the RINF database";
-  skos:altLabel "CCSTMS_trackCircuitBorder_1" ;
+  skos:hiddenLabel "CCSTMS_trackCircuitBorder_1" ;
   skos:prefLabel "track circuit" .
 
 era-tds-rinf:20 a skos:Concept;
   skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
   skos:note "Value retrieved from the RINF database";
-  skos:altLabel "CCSTMS_axleCounter_0" ;
+  skos:hiddenLabel "CCSTMS_axleCounter_0" ;
   skos:prefLabel "wheel detector" .
 
 era-tds-eratv:track-circuits a skos:Concept;

--- a/era-skos/era-skos-TransmittedTrackConditions.ttl
+++ b/era-skos/era-skos-TransmittedTrackConditions.ttl
@@ -103,6 +103,7 @@ era-transmittedtcs:5-8-12-f a skos:Concept;
 era-transmittedtcs:bigMetalMasses a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "Big metal masses";
+  skos:notation "Big Metal Masses"^^xsd:string ;
   skos:definition "Big metal masses, ignore on-board integrity check alarm of balise transmission"@en ;
   skos:hiddenLabel "CCSTMS_bigMetalMasses_6" ;
   skos:prefLabel "big Metal Masses"@en .
@@ -110,6 +111,7 @@ era-transmittedtcs:bigMetalMasses a skos:Concept;
 era-transmittedtcs:switchOffRegenerativeBrake a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "Switch-Off Regenerative Brake";
+  skos:notation "Switch Off Regenerative Brake"^^xsd:string ;
   skos:definition "defines a switch Off Regenerative Brake sections"@en ;
   skos:hiddenLabel "CCSTMS_switchOffRegenerativeBrake_8" ;
   skos:prefLabel "switch Off Regenerative Brake"@en .
@@ -117,6 +119,7 @@ era-transmittedtcs:switchOffRegenerativeBrake a skos:Concept;
 era-transmittedtcs:switchOffEddyCurrentBrakeForServiceBrake a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "Switch-Off Eddy Current Brake for Service Brake";
+  skos:notation "Switch Off Eddy Current Brake for Service Brake"^^xsd:string ;
   skos:definition "defines a switch Off Eddy Current Brake sections"@en ;
   skos:hiddenLabel "CCSTMS_switchOffEddyCurrentBrakeForServiceBrake_9" ;
   skos:prefLabel "switch Off Eddy Current Brake For Service Brake"@en .
@@ -124,6 +127,7 @@ era-transmittedtcs:switchOffEddyCurrentBrakeForServiceBrake a skos:Concept;
 era-transmittedtcs:switchOffEddyCurrentBrakeForEmergencyBrake a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "switch-Off Eddy Current Brake for Emergency Brake";
+  skos:notation "Switch Off Eddy Current Brake for Emergency Brake"^^xsd:string ;
   skos:definition "defines a switch Off Eddy Current Emergency Brake sections"@en ;
   skos:hiddenLabel "CCSTMS_switchOffEddyCurrentBrakeForEmergencyBrake_10" ;
   skos:prefLabel "switch Off Eddy Current Brake For Emergency Brake"@en .
@@ -131,6 +135,7 @@ era-transmittedtcs:switchOffEddyCurrentBrakeForEmergencyBrake a skos:Concept;
 era-transmittedtcs:switchOffMagneticShoeBrake a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "switch-Off Magnetic Shoe Brake";
+  skos:notation "Switch Off Magnetic Shoe Brake"^^xsd:string ;
   skos:definition "defines a switch Off Magnetic Shoe Brake sections"@en ;
   skos:hiddenLabel "CCSTMS_switchOffMagneticShoeBrake_11" ;
   skos:prefLabel "switch Off Magnetic Shoe Brake"@en .

--- a/era-skos/era-skos-TransmittedTrackConditions.ttl
+++ b/era-skos/era-skos-TransmittedTrackConditions.ttl
@@ -20,12 +20,14 @@
 
 era-transmittedtcs:TransmittedTrackConditions a skos:ConceptScheme ; 
     dct:issued "2024-04-18"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2024-09-04"^^xsd:date ,
+				 "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.3.2.12.1"; 
     era:rinfIndex "1.2.1.1.1.12.1"; 
     rdfs:label "Track Conditions transmitted to the Onboard (Subset-026, version 4.0 - 5.8.12)"@en ;
+	skos:altLabel "CCSTMS_ConditionType" ;
     dct:title "Concept scheme grouping the transmittable track conditions."@en .
 
 
@@ -44,30 +46,35 @@ era-transmittedtcs:5-8-12-a a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "a)"^^xsd:string ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 a)";
   rdfs:comment "Powerless section with pantograph to be lowered" ;
+  skos:altLabel "CCSTMS_powerlessLowPanthograph_0" ;
   skos:prefLabel "a)"@en .
 
 era-transmittedtcs:5-8-12-b a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "b)"^^xsd:string ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 b)";
   rdfs:comment "Powerless section with main power switch to be switched off" ;
+  skos:altLabel "CCSTMS_powerlessMainSwitch_1" ;
   skos:prefLabel "b)"@en .
 
 era-transmittedtcs:5-8-12-c a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "c)"^^xsd:string ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 c)"@en;
   rdfs:comment "Non-stopping area" ;
+  skos:altLabel "CCSTMS_nonStoppingArea_4" ;
   skos:prefLabel "c)"@en .
 
 era-transmittedtcs:5-8-12-d a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "d)"^^xsd:string ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 d)";
   rdfs:comment "Radio hole" ;
+  skos:altLabel "CCSTMS_radioHole_7" ;
   skos:prefLabel "d)"@en .
 
 era-transmittedtcs:5-8-12-e a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "e)"^^xsd:string ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 e)";
   rdfs:comment "Air tightness area" ;
+  skos:altLabel "CCSTMS_airTightness_2" ;
   skos:prefLabel "e)"@en .
 
 era-transmittedtcs:5-8-12-f a skos:Concept;
@@ -80,12 +87,14 @@ era-transmittedtcs:5-8-12-g a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "g)"^^xsd:string ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 g)";
   rdfs:comment "Tunnel stopping area" ;
+  skos:altLabel "CCSTMS_tunnelStoppingArea_5" ;
   skos:prefLabel "g)"@en .
 
 era-transmittedtcs:5-8-12-h a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "h)"^^xsd:string ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 h)";
   rdfs:comment "Sound horn" ;
+  skos:altLabel "CCSTMS_soundHorn_3" ;
   skos:prefLabel "h)"@en .
 
 era-transmittedtcs:5-8-12-i a skos:Concept;
@@ -93,3 +102,41 @@ era-transmittedtcs:5-8-12-i a skos:Concept;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 i)";
   rdfs:comment "Change of traction system" ;
   skos:prefLabel "i)"@en .
+  
+  
+  
+  
+era-transmittedtcs:bigMetalMasses a skos:Concept;
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "Big metal masses";
+  rdfs:comment "Big metal masses, ignore on-board integrity check alarm of balise transmission" ;
+  skos:altLabel "CCSTMS_bigMetalMasses_6" ;
+  skos:prefLabel "bigMetalMasses"@en .
+  
+era-transmittedtcs:switchOffRegenerativeBrake a skos:Concept;
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "Switch-Off Regenerative Brake";
+  rdfs:comment "defines a switch Off Regenerative Brake sections" ;
+  skos:altLabel "CCSTMS_switchOffRegenerativeBrake_8" ;
+  skos:prefLabel "switchOffRegenerativeBrake"@en .
+
+era-transmittedtcs:switchOffEddyCurrentBrakeForServiceBrake a skos:Concept;
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "Switch-Off Eddy Current Brake for Service Brake";
+  rdfs:comment "defines a switch Off Eddy Current Brake sections" ;
+  skos:altLabel "CCSTMS_switchOffEddyCurrentBrakeForServiceBrake_9" ;
+  skos:prefLabel "switchOffEddyCurrentBrakeForServiceBrake"@en .
+  
+era-transmittedtcs:switchOffEddyCurrentBrakeForEmergencyBrake a skos:Concept;
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "switch-Off Eddy Current Brake for Emergency Brake";
+  rdfs:comment "defines a switch Off Eddy Current Emergency Brake sections" ;
+  skos:altLabel "CCSTMS_switchOffEddyCurrentBrakeForEmergencyBrake_10" ;
+  skos:prefLabel "switchOffEddyCurrentBrakeForEmergencyBrake"@en .
+  
+era-transmittedtcs:switchOffMagneticShoeBrake a skos:Concept;
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "switch-Off Magnetic Shoe Brake";
+  rdfs:comment "defines a switch Off Magnetic Shoe Brake sections" ;
+  skos:altLabel "CCSTMS_switchOffMagneticShoeBrake_11" ;
+  skos:prefLabel "switchOffMagneticShoeBrake"@en .

--- a/era-skos/era-skos-TransmittedTrackConditions.ttl
+++ b/era-skos/era-skos-TransmittedTrackConditions.ttl
@@ -103,37 +103,37 @@ era-transmittedtcs:5-8-12-f a skos:Concept;
 era-transmittedtcs:bigMetalMasses a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "Big metal masses";
-  rdfs:comment "Big metal masses, ignore on-board integrity check alarm of balise transmission" ;
+  skos:definition "Big metal masses, ignore on-board integrity check alarm of balise transmission"@en ;
   skos:hiddenLabel "CCSTMS_bigMetalMasses_6" ;
-  skos:prefLabel "bigMetalMasses"@en .
+  skos:prefLabel "big Metal Masses"@en .
   
 era-transmittedtcs:switchOffRegenerativeBrake a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "Switch-Off Regenerative Brake";
-  rdfs:comment "defines a switch Off Regenerative Brake sections" ;
+  skos:definition "defines a switch Off Regenerative Brake sections"@en ;
   skos:hiddenLabel "CCSTMS_switchOffRegenerativeBrake_8" ;
-  skos:prefLabel "switchOffRegenerativeBrake"@en .
+  skos:prefLabel "switch Off Regenerative Brake"@en .
 
 era-transmittedtcs:switchOffEddyCurrentBrakeForServiceBrake a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "Switch-Off Eddy Current Brake for Service Brake";
-  rdfs:comment "defines a switch Off Eddy Current Brake sections" ;
+  skos:definition "defines a switch Off Eddy Current Brake sections"@en ;
   skos:hiddenLabel "CCSTMS_switchOffEddyCurrentBrakeForServiceBrake_9" ;
-  skos:prefLabel "switchOffEddyCurrentBrakeForServiceBrake"@en .
+  skos:prefLabel "switch Off Eddy Current Brake For Service Brake"@en .
   
 era-transmittedtcs:switchOffEddyCurrentBrakeForEmergencyBrake a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "switch-Off Eddy Current Brake for Emergency Brake";
-  rdfs:comment "defines a switch Off Eddy Current Emergency Brake sections" ;
+  skos:definition "defines a switch Off Eddy Current Emergency Brake sections"@en ;
   skos:hiddenLabel "CCSTMS_switchOffEddyCurrentBrakeForEmergencyBrake_10" ;
-  skos:prefLabel "switchOffEddyCurrentBrakeForEmergencyBrake"@en .
+  skos:prefLabel "switch Off Eddy Current Brake For Emergency Brake"@en .
   
 era-transmittedtcs:switchOffMagneticShoeBrake a skos:Concept;
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
   skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "switch-Off Magnetic Shoe Brake";
-  rdfs:comment "defines a switch Off Magnetic Shoe Brake sections" ;
+  skos:definition "defines a switch Off Magnetic Shoe Brake sections"@en ;
   skos:hiddenLabel "CCSTMS_switchOffMagneticShoeBrake_11" ;
-  skos:prefLabel "switchOffMagneticShoeBrake"@en .
+  skos:prefLabel "switch Off Magnetic Shoe Brake"@en .
 
   skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; 
   skos:notation "5.8.12 g"^^xsd:string ;


### PR DESCRIPTION
[AtoGradesAutomation, LoadCapabilityLineCategories, PlatformHeight, NominalTrackGauge, OperationalPointType, ETCSMVersion, ETCSLevel, EnergySupplySystem, CantDeficiencies, ETCSReactionNVContact, TrainDetectionSystem, TransmittedTrackConditions, TrackRunningDirection ]

AtoGradesAutomation
	- GoA3 , GoA4, GoAUnknown <-- added
CantDeficiencies:
	- Undefined <-- missing (added)
LoadCapabilityLineCategories
	- HS17 <-- missing (added)
NominalTrackGauge:
	- Unknown <-- missing added)
EnergySupplySystem:
	- NotFitted <-- missing (added)
TransmittedTrackConditions
	- bigMetalMasses, switchOffRegenerativeBrake, switchOffEddyCurrentBrakeForServiceBrake, switchOffEddyCurrentBrakeForEmergencyBrake, switchOffMagneticShoeBrake