### PR TITLE
Update era-skos-TransmittedTrackConditions.ttl

### DIFF
--- a/era-skos/era-skos-TransmittedTrackConditions.ttl
+++ b/era-skos/era-skos-TransmittedTrackConditions.ttl
@@ -20,11 +20,17 @@
 
 era-transmittedtcs:TransmittedTrackConditions a skos:ConceptScheme ; 
     dct:issued "2024-04-18"^^xsd:date ;
-    dct:modified "2024-09-04"^^xsd:date ;
+    dct:modified "2024-09-04"^^xsd:date, "2024-12-12"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     era:rinfIndex "1.1.1.3.2.12.1"; 
     era:rinfIndex "1.2.1.1.1.12.1"; 
+   skos:changeNote """ 
+   Revision 2024-12-12: 
+     - renamed the rdfs:comment to skos:definition property
+     - added language  tag @en in the relevant properties
+     - changed the notation values and preflabel to be more human readable
+    """@en ; 
     rdfs:label "Track Conditions transmitted to the Onboard (Subset-026, version 4.0 - 5.8.12)"@en ;
     dct:title "Concept scheme grouping the transmittable track conditions."@en .
 
@@ -41,55 +47,73 @@ era-transmittedtcs:TransmittedTrackConditions a skos:ConceptScheme ;
 ########## Safe Consist Length + SIL ##########
 
 era-transmittedtcs:5-8-12-a a skos:Concept;
-  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "a)"^^xsd:string ;
-  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 a)";
-  rdfs:comment "Powerless section with pantograph to be lowered" ;
-  skos:prefLabel "a)"@en .
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; 
+  skos:notation "5.8.12 a"^^xsd:string ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; 
+  skos:note "See Subset-026, version 4.0 - 5.8.12 a)"@en ;
+  skos:definition "Powerless section with pantograph to be lowered"@en ;
+  skos:prefLabel "5.8.12 a"@en .
 
 era-transmittedtcs:5-8-12-b a skos:Concept;
-  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "b)"^^xsd:string ;
-  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 b)";
-  rdfs:comment "Powerless section with main power switch to be switched off" ;
-  skos:prefLabel "b)"@en .
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; 
+  skos:notation "5.8.12 b"^^xsd:string ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; 
+  skos:note "See Subset-026, version 4.0 - 5.8.12 b)"@en ;
+  skos:definition "Powerless section with main power switch to be switched off"@en ;
+  skos:prefLabel "5.8.12 b"@en .
 
 era-transmittedtcs:5-8-12-c a skos:Concept;
-  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "c)"^^xsd:string ;
-  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 c)"@en;
-  rdfs:comment "Non-stopping area" ;
-  skos:prefLabel "c)"@en .
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; 
+  skos:notation "5.8.12 c"^^xsd:string ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; 
+  skos:note "See Subset-026, version 4.0 - 5.8.12 c)"@en ;
+  skos:definition "Non-stopping area"@en ;
+  skos:prefLabel "5.8.12 c"@en .
 
 era-transmittedtcs:5-8-12-d a skos:Concept;
-  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "d)"^^xsd:string ;
-  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 d)";
-  rdfs:comment "Radio hole" ;
-  skos:prefLabel "d)"@en .
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
+  skos:notation "5.8.12 d"^^xsd:string ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; 
+  skos:note "See Subset-026, version 4.0 - 5.8.12 d)"@en ;
+  skos:definition "Radio hole"@en ;
+  skos:prefLabel "5.8.12 d"@en .
 
 era-transmittedtcs:5-8-12-e a skos:Concept;
-  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "e)"^^xsd:string ;
-  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 e)";
-  rdfs:comment "Air tightness area" ;
-  skos:prefLabel "e)"@en .
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ;
+  skos:notation "5.8.12 e "^^xsd:string ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; 
+  skos:note "See Subset-026, version 4.0 - 5.8.12 e)";
+  skos:definition "Air tightness area"@en ;
+  skos:prefLabel "5.8.12 e"@en .
 
 era-transmittedtcs:5-8-12-f a skos:Concept;
-  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "f)"^^xsd:string ;
-  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 f)";
-  rdfs:comment "Inhibition of a defined type of brake" ;
-  skos:prefLabel "f)"@en .
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; 
+  skos:notation "5.8.12 f"^^xsd:string ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; 
+  skos:note "See Subset-026, version 4.0 - 5.8.12 f)"@en ;
+  skos:definition "Inhibition of a defined type of brake"@en ;
+  skos:prefLabel "5.8.12 f"@en .
 
 era-transmittedtcs:5-8-12-g a skos:Concept;
-  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "g)"^^xsd:string ;
-  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 g)";
-  rdfs:comment "Tunnel stopping area" ;
-  skos:prefLabel "g)"@en .
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; 
+  skos:notation "5.8.12 g"^^xsd:string ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; 
+  skos:note "See Subset-026, version 4.0 - 5.8.12 g)"@en;
+  skos:definition "Tunnel stopping area"@en ;
+  skos:prefLabel "5.8.12 g"@en .
 
 era-transmittedtcs:5-8-12-h a skos:Concept;
-  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "h)"^^xsd:string ;
-  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 h)";
-  rdfs:comment "Sound horn" ;
-  skos:prefLabel "h)"@en .
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; 
+  skos:notation "5.8.12 h"^^xsd:string ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; 
+  skos:note "See Subset-026, version 4.0 - 5.8.12 h)"@en ;
+  skos:definition "Sound horn"@en ;
+  skos:prefLabel "5.8.12 h "@en .
 
 era-transmittedtcs:5-8-12-i a skos:Concept;
-  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; skos:notation "i)"^^xsd:string ;
-  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; skos:note "See Subset-026, version 4.0 - 5.8.12 i)";
-  rdfs:comment "Change of traction system" ;
-  skos:prefLabel "i)"@en .
+  skos:topConceptOf era-transmittedtcs:TransmittedTrackConditions ; 
+  skos:notation "5.8.12 i"^^xsd:string ;
+  skos:inScheme era-transmittedtcs:TransmittedTrackConditions; 
+  skos:note "See Subset-026, version 4.0 - 5.8.12 i)"@en ;
+  skos:definition "Change of traction system"@en ;
+  skos:prefLabel "5.8.12 i"@en .


### PR DESCRIPTION
Revision 2024-12-12: 
     - renamed the rdfs:comment to skos:definition property
     - added language  tag @en in the relevant properties
     - changed the notation values and preflabel to be more human readable