### PR TITLE
Update era-skos-TrainDetectionSystems.ttl

### DIFF
--- a/era-skos/era-skos-TrainDetectionSystems.ttl
+++ b/era-skos/era-skos-TrainDetectionSystems.ttl
@@ -25,12 +25,20 @@
 era-tds:TrainDetectionSystems a skos:ConceptScheme ; #
     dct:issued "2020-09-01"^^xsd:date ;
     dct:modified "2022-09-09"^^xsd:date ,
-				 "2024-12-12"^^xsd:date ;
+                 "2024-12-12"^^xsd:date ,
+		 "2024-12-19"^^xsd:date ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
     rdfs:comment "Controlled SKOS-based vocabularies defined by the European Union Agency for Railways to describe concepts related to the European railway infrastructure and the vehicles authorized to operate over it."@en ;
     rdfs:label "Train Detection Systems"@en ;
-	skos:hiddenLabel "CCSTMS_TrainDetectorType" ;
+    skos:hiddenLabel "CCSTMS_TrainDetectorType" ;
     skos:prefLabel "Train Detection Systems"@en ;
+    skos:changeNote """
+      Revision 19-12-2024:
+       - Harmonized values with ERATV, removed 'none'  
+       - Removed exactMatch with priorities to RINF URIs
+       - Removed note retrieved from the RINF database 
+       - Added skos:notation annotations when relevant
+       """@en ;
     dct:title "Concept scheme grouping train detection systems"@en .
 
 
@@ -46,41 +54,27 @@ era-tds:TrainDetectionSystems a skos:ConceptScheme ; #
 
 era-tds-rinf:30 a skos:Concept;
   skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
-  skos:note "Value retrieved from the RINF database";
-  skos:prefLabel "loop" .
+  skos:notation "loop"^^xsd:string;
+  skos:prefLabel "Loop"@en ;
+  skos:altLabel "Loops"@en .
 
 era-tds-rinf:10 a skos:Concept;
   skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
-  skos:note "Value retrieved from the RINF database";
+  skos:notation "track circuit"^^xsd:string ;
   skos:hiddenLabel "CCSTMS_trackCircuitBorder_1" ;
-  skos:prefLabel "track circuit" .
+  skos:prefLabel "track circuit"@en ;
+  skos:altLabel "track circuits"@en .
 
 era-tds-rinf:20 a skos:Concept;
   skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
-  skos:note "Value retrieved from the RINF database";
+  skos:notation "wheel detector"^^xsd:string ;
   skos:hiddenLabel "CCSTMS_axleCounter_0" ;
-  skos:prefLabel "wheel detector" .
+  skos:prefLabel "wheel detector"@en .
 
-era-tds-eratv:track-circuits a skos:Concept;
-  skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
-  skos:note "Value retrieved from the ERATV database";
-  skos:exactMatch era-tds-rinf:10;
-  skos:prefLabel "track circuits" .
 
-era-tds-eratv:none a skos:Concept;
-  skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
-  skos:note "Value retrieved from the ERATV database";
-  skos:prefLabel "none" .
-
-era-tds-eratv:loops a skos:Concept;
-  skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
-  skos:note "Value retrieved from the ERATV database";
-  skos:exactMatch era-tds-rinf:30;
-  skos:altLabel "Loops";
-  skos:prefLabel "loops" .
-
+### ERATV concepts
 era-tds-eratv:axle-counters a skos:Concept;
   skos:inScheme era-tds:TrainDetectionSystems; skos:topConceptOf era-tds:TrainDetectionSystems;
-  skos:note "Value retrieved from the ERATV database";
-  skos:closeMatch era-tds-rinf:20;
-  skos:prefLabel "axle counters" .
+  skos:notation "axle counters"^^xsd:string ;
+  skos:prefLabel "axle counters"@en ; 
+  .


### PR DESCRIPTION
 Revision 19-12-2024:

-  Harmonized values with ERATV, removed 'none'  

-  Removed exactMatch with priorities to RINF URIs

- Removed note retrieved from the RINF database 
- Added skos:notation annotations when relevant